### PR TITLE
docs(youtube): 여러 재생목록을 가져오며 얻은 교훈을 스킬·스크립트에 반영

### DIFF
--- a/.claude/scripts/youtube/_common.py
+++ b/.claude/scripts/youtube/_common.py
@@ -1,0 +1,99 @@
+"""Shared helpers for the YouTube→Sunrei scripts (stdlib only, no external deps).
+
+- Google API key is read from the server's application-local.conf.
+- Admin token is minted locally (no login flow) — see auth/mint_token.py.
+- All HTTP sets a real User-Agent (prod Cloudflare 403s urllib's default).
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+ENV_FILE = ROOT / ".claude" / ".env"
+CONF = ROOT / "sunrei-server" / "src" / "main" / "resources" / "application-local.conf"
+WS_ROOT = ROOT / ".claude" / "workspace" / "youtube"
+
+LOCAL_SERVER = "http://localhost:3030"
+PROD_SERVER = "https://sunrei-api.yongseongkimm.com"
+UA = "sunrei-ingest/1.0"
+
+
+def workspace(id_or_path):
+    p = Path(id_or_path)
+    return p if p.is_dir() else WS_ROOT / id_or_path
+
+
+def load_google_api_key():
+    if not CONF.is_file():
+        return None
+    m = re.search(r'youtubeApiKey\s*=\s*"?([^"\s]+)"?', CONF.read_text())
+    return m.group(1) if m else None
+
+
+def load_env():
+    env = {}
+    if ENV_FILE.is_file():
+        for line in ENV_FILE.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):]
+            k, _, v = line.partition("=")
+            if k:
+                env[k.strip()] = v.strip().strip('"')
+    return env
+
+
+def admin_token():
+    """Resolve an admin JWT: env var, then .claude/.env, then mint one locally.
+
+    The login-less flow signs a short-lived admin JWT with auth-jwt-secret
+    (see auth/mint_token.py), so no SUNREI_ADMIN_TOKEN needs to be pre-set.
+    """
+    tok = os.environ.get("SUNREI_ADMIN_TOKEN") or load_env().get("SUNREI_ADMIN_TOKEN")
+    if tok:
+        return tok
+    mint = ROOT / ".claude" / "scripts" / "auth" / "mint_token.py"
+    if mint.is_file():
+        out = subprocess.run([sys.executable, str(mint)], capture_output=True, text=True)
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip().splitlines()[0]
+    return None
+
+
+def server_url(prod=False):
+    return PROD_SERVER if prod else LOCAL_SERVER
+
+
+def http_json(method, url, headers=None, body=None, timeout=60):
+    data = json.dumps(body).encode() if body is not None else None
+    h = {"User-Agent": UA}
+    if data is not None:
+        h["Content-Type"] = "application/json"
+    if headers:
+        h.update(headers)
+    req = urllib.request.Request(url, data=data, method=method, headers=h)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            raw = r.read()
+            return r.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, (json.loads(raw) if raw else None)
+        except Exception:
+            return e.code, {"raw": raw.decode("utf-8", "replace")}
+    except (urllib.error.URLError, OSError) as e:
+        return 0, {"error": str(e)}
+
+
+def admin_api(method, path, token, body=None, prod=False):
+    return http_json(method, server_url(prod) + path,
+                     headers={"Authorization": f"Bearer {token}"}, body=body)

--- a/.claude/scripts/youtube/create_sunrei.py
+++ b/.claude/scripts/youtube/create_sunrei.py
@@ -1,0 +1,158 @@
+"""Create one Sunrei (source + spots) from a workspace, via the admin API.
+
+Reads video_info.json + locations.json, resolves or creates the YouTube Source for the
+channel, builds one spot per geocoded location, and (with --commit) POSTs /admin/sunreis.
+Dry-run by default: prints exactly what it would create and does nothing else.
+
+Usage:
+    uv run python .claude/scripts/youtube/create_sunrei.py <ID> [--prod] [--commit]
+        [--summary "..."] [--description "..."] [--tag-ids a,b] [--publish]
+
+Notes:
+  - Summary/description read best from transcripts (model judgment); pass them via
+    --summary/--description. Without them the video/playlist description is used and a
+    warning is printed.
+  - This bypasses the interactive skill checkpoints (tag selection, per-spot review),
+    so it lands a draft unless --publish is given. Review in admin afterward.
+  - Admin token is auto-minted locally (auth/mint_token.py) — no login needed. Requires
+    SOPS + GCP KMS decrypt permission. Override by exporting SUNREI_ADMIN_TOKEN.
+  - On success writes _create_manifest.json for the S3 registry step.
+"""
+import json
+import sys
+import urllib.parse
+
+from _common import admin_api, admin_token, workspace
+
+
+def arg(args, flag, default=None):
+    return args[args.index(flag) + 1] if flag in args else default
+
+
+def resolve_source(token, channel, prod):
+    q = urllib.parse.quote(channel.get("title") or "")
+    status, body = admin_api("GET", f"/admin/sources?q={q}&size=100", token, prod=prod)
+    rows = (body or {}).get("data", []) if status == 200 else []
+    yt = [s for s in rows if s.get("type") == "YOUTUBE"]
+    by_url = next((s for s in yt if s.get("externalUrl") == channel.get("url")), None)
+    if by_url:
+        return by_url["id"], "reuse(url)"
+    by_title = next((s for s in yt if s.get("name") == channel.get("title")), None)
+    if by_title:
+        return by_title["id"], "reuse(title)"
+    return None, None
+
+
+def build_spots(locs, tag_ids):
+    spots, skipped = [], 0
+    for v in locs.get("videos", []):
+        vtitle = (v.get("title") or "")[:128]
+        for l in v.get("locations", []):
+            if not (l.get("latitude") and l.get("googleMapsId")):
+                skipped += 1
+                continue
+            spots.append({
+                "title": vtitle,
+                "context": (l.get("description") or "")[:2000],
+                "images": [],
+                "youtubeLink": l.get("videoUrlWithTimestamp") or f"https://www.youtube.com/watch?v={v.get('videoId')}",
+                "tagIds": tag_ids,
+                "place": {
+                    "name": (l.get("name") or "")[:200],
+                    "address": (l.get("address") or "")[:300],
+                    "latitude": l["latitude"], "longitude": l["longitude"],
+                    "googleMapsId": l["googleMapsId"],
+                },
+            })
+    return spots, skipped
+
+
+def main():
+    args = sys.argv[1:]
+    if not args or args[0].startswith("--"):
+        print(__doc__)
+        sys.exit(1)
+    ws = workspace(args[0])
+    prod = "--prod" in args
+    commit = "--commit" in args
+    publish = "--publish" in args
+
+    info = json.load(open(ws / "video_info.json"))
+    locs = json.load(open(ws / "locations.json"))
+
+    is_playlist = info.get("type") == "playlist"
+    title = (info.get("title") or "")[:128]
+    link = info.get("url") or (
+        f"https://www.youtube.com/playlist?list={info['id']}" if is_playlist
+        else f"https://www.youtube.com/watch?v={info['id']}")
+    summary = arg(args, "--summary") or (info.get("description") or "")[:200]
+    description = arg(args, "--description") or (info.get("description") or "")
+    if not arg(args, "--summary"):
+        print("WARNING: no --summary; using the video/playlist description. "
+              "A transcript-derived one-line summary is preferred.")
+    tag_ids = [t for t in arg(args, "--tag-ids", "").split(",") if t]
+
+    spots, skipped = build_spots(locs, tag_ids)
+    channel = info.get("channel") or {}
+
+    token = admin_token()
+    if not token:
+        print("admin 토큰을 얻지 못했습니다. SOPS + GCP KMS decrypt 권한을 확인하거나 "
+              "SUNREI_ADMIN_TOKEN을 직접 export 하세요 (mint_token.py 참고).")
+        sys.exit(1)
+
+    source_id, how = resolve_source(token, channel, prod)
+
+    print(f"--- {'PROD' if prod else 'LOCAL'} {'COMMIT' if commit else 'DRY-RUN'} ---")
+    print(f"title:   {title}")
+    print(f"link:    {link}")
+    print(f"summary: {summary[:100]}")
+    print(f"source:  {source_id or '(will create)'} {how or ''}  [{channel.get('title')}]")
+    print(f"spots:   {len(spots)}")
+    for s in spots[:8]:
+        print(f"  - {s['place']['name']}  ({s['title'][:40]})")
+    if len(spots) > 8:
+        print(f"  ... +{len(spots) - 8} more")
+    if skipped:
+        print(f"NOTE: {skipped} location(s) without coords/googleMapsId were skipped (run geocode.py first).")
+
+    if not commit:
+        print("\nDry-run only. Re-run with --commit to create.")
+        return
+
+    if not source_id:
+        payload = {"type": "YOUTUBE", "name": channel.get("title") or info.get("channelName"),
+                   "synopsis": (channel.get("description") or "")[:500], "externalUrl": channel.get("url")}
+        if channel.get("thumbnailUrl"):
+            payload["posterImage"] = {"images": [{"url": channel["thumbnailUrl"]}]}
+        st, resp = admin_api("POST", "/admin/sources", token, payload, prod=prod)
+        if st != 201 or not (resp or {}).get("id"):
+            print(f"source create failed {st}: {str(resp)[:300]}")
+            sys.exit(1)
+        source_id = resp["id"]
+        print(f"created source {source_id}")
+
+    payload = {"sourceId": source_id, "published": publish, "title": title,
+               "summary": summary, "description": description, "link": link, "images": [], "spots": spots}
+    st, resp = admin_api("POST", "/admin/sunreis", token, payload, prod=prod)
+    if st == 201 and (resp or {}).get("id"):
+        sid = resp["id"]
+        created = resp.get("spots") or []
+        manifest_spots = []
+        for req, res in zip(spots, created):
+            yl = req.get("youtubeLink", "")
+            vid = yl.split("v=")[-1].split("&")[0] if "v=" in yl else None
+            manifest_spots.append({"spotId": res.get("id"), "videoId": vid, "videoTitle": req.get("title")})
+        json.dump({"sunreiId": sid, "sourceId": source_id, "spots": manifest_spots},
+                  open(ws / "_create_manifest.json", "w"), ensure_ascii=False, indent=2)
+        print(f"\n✓ created sunrei {sid}, {len(created)} spots ({'published' if publish else 'draft'})")
+        print(f"manifest -> {ws / '_create_manifest.json'} (use for the S3 registry, Step 6)")
+    elif st == 409:
+        print(f"\n⊘ 409 conflict: link already exists -> {(resp or {}).get('existingId')}")
+    else:
+        print(f"\n✗ create failed {st}: {str(resp)[:400]}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/fetch_info.py
+++ b/.claude/scripts/youtube/fetch_info.py
@@ -1,0 +1,158 @@
+"""Fetch YouTube video/playlist + channel metadata into a workspace video_info.json.
+
+Usage:
+    uv run python .claude/scripts/youtube/fetch_info.py <URL> [--videos all|1,3,5|first:N] [--video]
+
+<URL> may be a video (watch?v=, youtu.be/, /shorts/) or playlist (list=) URL. If the
+URL has both v= and list=, the playlist is used; pass --video to force the single video.
+--videos selects which playlist entries to keep (1-based indices or first:N; default all).
+Writes .claude/workspace/youtube/{ID}/video_info.json in the schema the other skills expect.
+"""
+import json
+import sys
+import urllib.parse
+
+from _common import WS_ROOT, http_json, load_google_api_key
+
+API = "https://www.googleapis.com/youtube/v3"
+
+
+def get(path, params):
+    status, body = http_json("GET", f"{API}/{path}?" + urllib.parse.urlencode(params))
+    if status != 200:
+        print(f"YouTube API {status}: {str(body)[:300]}")
+        sys.exit(1)
+    return body
+
+
+def parse_url(url):
+    u = urllib.parse.urlparse(url)
+    qs = urllib.parse.parse_qs(u.query)
+    pl = qs.get("list", [None])[0]
+    vid = None
+    if "youtu.be" in u.netloc:
+        vid = u.path.lstrip("/") or None
+    elif qs.get("v"):
+        vid = qs["v"][0]
+    elif "/shorts/" in u.path:
+        vid = u.path.split("/shorts/")[1].split("/")[0]
+    return vid, pl
+
+
+def best_thumb(thumbs):
+    t = thumbs.get("high") or thumbs.get("medium") or thumbs.get("default") or {}
+    return t.get("url")
+
+
+def channel_obj(key, channel_id):
+    items = get("channels", {"id": channel_id, "part": "snippet", "key": key}).get("items") or []
+    if not items:
+        return None
+    sn = items[0]["snippet"]
+    custom = sn.get("customUrl")
+    url = f"https://www.youtube.com/{custom}" if custom else f"https://www.youtube.com/channel/{channel_id}"
+    return {
+        "id": channel_id, "title": sn.get("title"), "handle": custom, "url": url,
+        "description": sn.get("description"), "thumbnailUrl": best_thumb(sn.get("thumbnails", {})),
+    }
+
+
+def select(videos, spec):
+    if not spec or spec == "all":
+        return videos
+    if spec.startswith("first:"):
+        return videos[:int(spec.split(":", 1)[1])]
+    idx = {int(x) for x in spec.split(",") if x.strip()}
+    return [v for i, v in enumerate(videos, 1) if i in idx]
+
+
+def fetch_playlist(key, pl, videos_spec):
+    items = get("playlists", {"id": pl, "part": "snippet,contentDetails", "key": key}).get("items") or []
+    if not items:
+        print(f"Playlist {pl} not found.")
+        sys.exit(1)
+    sn = items[0]["snippet"]
+    vids = []
+    page = None
+    while True:
+        params = {"playlistId": pl, "part": "snippet", "maxResults": 50, "key": key}
+        if page:
+            params["pageToken"] = page
+        resp = get("playlistItems", params)
+        for it in resp.get("items", []):
+            s = it["snippet"]
+            rid = s.get("resourceId", {}).get("videoId")
+            if not rid:
+                continue
+            vids.append({
+                "videoId": rid, "title": s.get("title"),
+                "channelName": s.get("videoOwnerChannelTitle") or sn.get("channelTitle"),
+                "position": s.get("position"),
+                "url": f"https://www.youtube.com/watch?v={rid}",
+            })
+        page = resp.get("nextPageToken")
+        if not page:
+            break
+    selected = select(vids, videos_spec)
+    print(f"playlist: {sn.get('title')} — {len(vids)} videos, {len(selected)} selected")
+    return pl, {
+        "type": "playlist", "id": pl, "title": sn.get("title"),
+        "description": sn.get("description"),
+        "url": f"https://www.youtube.com/playlist?list={pl}",
+        "channelName": sn.get("channelTitle"),
+        "channel": channel_obj(key, sn["channelId"]),
+        "selectedVideos": selected,
+    }
+
+
+def fetch_video(key, vid):
+    items = get("videos", {"id": vid, "part": "snippet,contentDetails", "key": key}).get("items") or []
+    if not items:
+        print(f"Video {vid} not found.")
+        sys.exit(1)
+    it = items[0]
+    sn = it["snippet"]
+    print(f"video: {sn.get('title')} ({sn.get('channelTitle')})")
+    return vid, {
+        "type": "video", "id": vid, "title": sn.get("title"),
+        "description": sn.get("description"), "channelName": sn.get("channelTitle"),
+        "channelId": sn["channelId"], "publishedAt": sn.get("publishedAt"),
+        "duration": it.get("contentDetails", {}).get("duration"),
+        "thumbnailUrl": best_thumb(sn.get("thumbnails", {})),
+        "url": f"https://www.youtube.com/watch?v={vid}",
+        "channel": channel_obj(key, sn["channelId"]),
+    }
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__)
+        sys.exit(1)
+    url = args[0]
+    videos_spec = args[args.index("--videos") + 1] if "--videos" in args else None
+    force_video = "--video" in args
+
+    key = load_google_api_key()
+    if not key:
+        print("No Google API key found in application-local.conf.")
+        sys.exit(1)
+
+    vid, pl = parse_url(url)
+    if pl and not force_video:
+        out_id, info = fetch_playlist(key, pl, videos_spec)
+    elif vid:
+        out_id, info = fetch_video(key, vid)
+    else:
+        print("Could not find a video or playlist id in the URL.")
+        sys.exit(1)
+
+    ws = WS_ROOT / out_id
+    ws.mkdir(parents=True, exist_ok=True)
+    out = ws / "video_info.json"
+    json.dump(info, open(out, "w"), ensure_ascii=False, indent=2)
+    print(f"saved -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/fetch_playlist_transcripts.py
+++ b/.claude/scripts/youtube/fetch_playlist_transcripts.py
@@ -1,0 +1,99 @@
+"""Batch-fetch YouTube captions for a playlist workspace, rate-limit aware.
+
+YouTube's caption endpoint IP-blocks on request rate (~15-20 requests per
+window regardless of 14-20s spacing). A 60-90s drip between videos stays under
+the threshold; on a block, back off 10 minutes and retry the same video.
+Progress is written incrementally to transcripts_raw.json, so an interrupted
+run resumes by rerunning the same command.
+
+Usage:
+    uv run --with youtube-transcript-api --with python-dotenv \
+      python .claude/scripts/youtube/fetch_playlist_transcripts.py {ID}
+
+{ID} is the workspace directory name under .claude/workspace/youtube/
+(a path to the workspace directory also works).
+"""
+import json
+import random
+import sys
+import time
+from pathlib import Path
+
+from extract_transcript import extract_transcript
+
+DELAY_MIN, DELAY_MAX = 60, 90
+BLOCK_BACKOFF = 600
+MAX_CONSEC_BLOCKS = 4
+
+
+def is_block(err):
+    e = err or ""
+    return "blocking requests from your IP" in e or "blocked by YouTube" in e
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    ws = Path(sys.argv[1])
+    if not ws.is_dir():
+        ws = Path(__file__).resolve().parents[2] / "workspace" / "youtube" / sys.argv[1]
+    info_file = ws / "video_info.json"
+    if not info_file.is_file():
+        print(f"Error: {info_file} not found. Run /youtube-fetch-info first.")
+        sys.exit(1)
+
+    info = json.load(open(info_file))
+    out = ws / "transcripts_raw.json"
+
+    done = {}
+    if out.exists():
+        try:
+            done = {v["videoId"]: v for v in json.load(open(out)).get("videos", [])}
+        except Exception:
+            done = {}
+
+    if info.get("type") == "video":
+        vids = [(info["id"], info.get("title", ""))]
+    else:
+        vids = [(v["videoId"], v.get("title", "")) for v in info["selectedVideos"]]
+    todo = [(vid, t) for vid, t in vids if vid not in done or "error" in done[vid]]
+    cached = sum(1 for v in done.values() if "error" not in v)
+    print(f"to fetch: {len(todo)} (cached ok: {cached})", flush=True)
+
+    results = list(done.values())
+    ok = fail = consec_blocks = 0
+    i = 0
+    while i < len(todo):
+        vid, title = todo[i]
+        res = extract_transcript(vid)
+        res["title"] = title
+
+        if "error" in res and is_block(res["error"]):
+            consec_blocks += 1
+            print(f"[{i+1}/{len(todo)}] {vid} BLOCKED — backing off {BLOCK_BACKOFF}s ({consec_blocks}/{MAX_CONSEC_BLOCKS})", flush=True)
+            if consec_blocks > MAX_CONSEC_BLOCKS:
+                print("ABORT: block persists. Progress saved; rerun to resume.", flush=True)
+                break
+            time.sleep(BLOCK_BACKOFF)
+            continue  # retry the same video, do not advance
+
+        if "error" in res:
+            fail += 1
+            print(f"[{i+1}/{len(todo)}] {vid} no-caption ({res['error'][:50]})", flush=True)
+        else:
+            ok += 1
+            print(f"[{i+1}/{len(todo)}] {vid} OK ({len(res.get('segments', []))} seg, {res.get('language')})", flush=True)
+        consec_blocks = 0
+        results = [r for r in results if r.get("videoId") != vid] + [res]
+        json.dump({"videos": results}, open(out, "w"), ensure_ascii=False, indent=2)
+        i += 1
+        if i < len(todo):
+            time.sleep(random.uniform(DELAY_MIN, DELAY_MAX))
+
+    print(f"DONE: {ok} ok, {fail} no-caption -> {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/geocode.py
+++ b/.claude/scripts/youtube/geocode.py
@@ -1,0 +1,130 @@
+"""Geocode locations via Google Maps Places API (Text Search), with guards.
+
+Two modes:
+    # one-off lookup — prints the best match and a mismatch warning
+    uv run python .claude/scripts/youtube/geocode.py --query "토리키조쿠" --area "시부야"
+
+    # workspace backfill — fills missing coords in locations.json, flags mismatches
+    uv run python .claude/scripts/youtube/geocode.py <ID>
+
+Guards (from experience): never geocode a bare address — an address-only query returns
+the nearest business (a wrong pin); a `name` that looks like hours/phone/an address is
+rejected instead of searched; each result's displayName is checked against the queried
+name and flagged (`geocodeWarning`) on mismatch.
+"""
+import json
+import re
+import sys
+
+from _common import http_json, load_google_api_key, workspace
+
+PLACES = "https://places.googleapis.com/v1/places:searchText"
+FIELDS = "places.displayName,places.formattedAddress,places.location,places.id,places.googleMapsUri"
+BAD_NAME = re.compile(r"\d{1,2}:\d{2}|\d{2,4}[-–]\d{3,4}[-–]\d{4}|^\s*\d+\s|매일|평일|주말|영업시간|휴무")
+
+
+def looks_like_non_name(name):
+    return bool(BAD_NAME.search(name or ""))
+
+
+def norm(s):
+    return re.sub(r"[\s\-·]", "", (s or "").lower())
+
+
+def name_matches(a, b):
+    x, y = norm(a), norm(b)
+    return bool(x) and bool(y) and (x in y or y in x)
+
+
+def search(key, text):
+    status, body = http_json(
+        "POST", PLACES,
+        headers={"X-Goog-Api-Key": key, "X-Goog-FieldMask": FIELDS},
+        body={"textQuery": text, "languageCode": "ko"},
+    )
+    if status != 200:
+        return None, f"HTTP {status}: {str(body)[:200]}"
+    places = (body or {}).get("places") or []
+    if not places:
+        return None, "no result"
+    p = places[0]
+    loc = p.get("location", {})
+    return {
+        "displayName": p.get("displayName", {}).get("text"),
+        "address": p.get("formattedAddress"),
+        "latitude": loc.get("latitude"),
+        "longitude": loc.get("longitude"),
+        "googleMapsId": p.get("id"),
+        "googleMapsUri": p.get("googleMapsUri"),
+    }, None
+
+
+def run_query(key, q, area):
+    if looks_like_non_name(q):
+        print(f"WARNING: '{q}' looks like hours/phone/address, not a venue name.")
+    res, err = search(key, f"{q} {area}".strip())
+    if err:
+        print(err)
+        sys.exit(1)
+    print(json.dumps(res, ensure_ascii=False, indent=2))
+    if not name_matches(q, res["displayName"]):
+        print(f"WARNING: returned '{res['displayName']}' != queried '{q}' — verify.")
+
+
+def run_workspace(key, ws_id):
+    ws = workspace(ws_id)
+    locfile = ws / "locations.json"
+    if not locfile.is_file():
+        print(f"{locfile} not found.")
+        sys.exit(1)
+    data = json.load(open(locfile))
+    filled = flagged = skipped = 0
+    for v in data.get("videos", []):
+        area = v.get("concept") or ""
+        for loc in v.get("locations", []):
+            if loc.get("latitude") and loc.get("googleMapsId"):
+                continue
+            name = loc.get("name") or ""
+            if looks_like_non_name(name):
+                loc["geocodeWarning"] = "name looks like hours/phone/address; needs a real venue name"
+                skipped += 1
+                continue
+            res, err = search(key, f"{name} {area}".strip())
+            if err:
+                loc["geocodeWarning"] = f"geocode failed: {err}"
+                flagged += 1
+                continue
+            loc["address"] = res["address"]
+            loc["latitude"] = res["latitude"]
+            loc["longitude"] = res["longitude"]
+            loc["googleMapsId"] = res["googleMapsId"]
+            loc["googleMapsUri"] = res["googleMapsUri"]
+            filled += 1
+            if not name_matches(name, res["displayName"]):
+                loc["geocodeWarning"] = f"displayName '{res['displayName']}' != '{name}'; verify"
+                flagged += 1
+    json.dump(data, open(locfile, "w"), ensure_ascii=False, indent=2)
+    print(f"filled {filled}, flagged {flagged}, skipped {skipped} -> {locfile}")
+    if flagged or skipped:
+        print("Review entries carrying a `geocodeWarning` field.")
+
+
+def main():
+    args = sys.argv[1:]
+    key = load_google_api_key()
+    if not key:
+        print("No Google API key found in application-local.conf.")
+        sys.exit(1)
+    if "--query" in args:
+        q = args[args.index("--query") + 1]
+        area = args[args.index("--area") + 1] if "--area" in args else ""
+        run_query(key, q, area)
+    elif args:
+        run_workspace(key, args[0])
+    else:
+        print(__doc__)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/youtube-create-sunrei/SKILL.md
+++ b/.claude/skills/youtube-create-sunrei/SKILL.md
@@ -59,6 +59,15 @@ The output (if the file exists) is a per-channel registry with a `sunreis` array
 - If the file exists: parse the JSON, display the count of existing sunreis and total spots, then ask the user whether to proceed with creating another Sunrei or abort.
 - If the command fails (exit code 1, file not found): no existing registry, continue normally.
 
+레지스트리는 오래됐을 수 있다. 운영 DB를 초기화하고 나면 이미 없는 ID를 가리킨다.
+이미 등록된 것으로 넘기기 전에, 레지스트리의 `sunreiId` 하나를 실제 API로 확인한다:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${TOKEN}" "{SERVER_URL}/admin/sunreis/{sunreiId}"
+```
+
+404가 나오면 레지스트리를 무시하고 전부 새로 만든 뒤, 6단계에서 레지스트리를 덮어쓴다.
+
 ### 2. Get Server Configuration
 
 Ask the user for:
@@ -88,6 +97,9 @@ ingest run outruns the token, mint another one; pass `--minutes N` for a longer 
 
 If minting fails with a decryption error, the GCP credentials lack KMS decrypt permission —
 tell the user to run `gcloud auth application-default login`.
+
+curl 대신 Python으로 운영 API를 호출할 때는 실제 `User-Agent` 헤더를 넣는다(예: `sunrei-ingest/1.0`).
+Python 기본 urllib User-Agent에는 Cloudflare가 403을 돌려주지만, 같은 요청도 curl로는 성공한다.
 
 ### 3. Compose Sunrei Details
 
@@ -172,7 +184,7 @@ every video in the playlist attaches to the single Sunrei composed in step 3.
 ```json
 {
   "title": "시부야의 맛있는 야키토리 맛집 투어",
-  "context": "영상에서 방문한 야키토리 전문점. 비장탄으로 굽는 것이 특징이며, 특히 쓰쿠네와 레바가 인기 메뉴로 극찬을 받았다.",
+  "context": "시부야 뒷골목 야키토리 투어에서 방문한 카운터 10석 규모의 노포. 대표 메뉴는 비장탄에 구운 쓰쿠네와 레바로, 쓰쿠네는 겉을 바삭하게 구운 뒤 노른자에 찍어 먹고(육즙이 팡 터진다고 표현), 레바는 비린내 없이 부드럽다고 강조했다 (12:30).",
   "description": "",
   "images": [],
   "youtubeLink": "https://youtube.com/watch?v=VIDEO_ID&t=123",
@@ -189,8 +201,9 @@ every video in the playlist attaches to the single Sunrei composed in step 3.
 
 - `title` = video title, truncated to 128 chars if needed (each video is a "scene/episode" within the playlist)
 - `context` = **map directly from `locations[].description`** in `locations.json` — that field
-  is the 2–3 sentence per-place summary (video concept + what makes this place notable) and
-  is exactly the spot context. Do NOT leave it empty and do NOT re-derive it.
+  is the per-place description (음식점 소개 + 음식/메뉴 묘사와 영상 속 코멘트) and is exactly the
+  spot context, the only editorial text the public map card shows. Do NOT leave it empty, do NOT
+  re-derive it, and do NOT trim the food detail away.
 - `description` = optional longer description; leave empty (`""`) for ingest
 - `images` = empty array `[]`
 - `youtubeLink` = `locations[].videoUrlWithTimestamp` (the video URL with the mention's `&t=`)
@@ -238,6 +251,18 @@ curl -s -X POST "{SERVER_URL}/admin/sunreis" \
 ```
 
 Note: there is no top-level `tagIds` on the Sunrei — tags are per-spot (`spots[].tagIds` / `spots[].tagLabels`).
+
+위 소스 해석·spot 구성·409 처리를 한 번에 하는 스크립트가 있다. 워크스페이스 하나를 받아
+dry-run으로 만들 내용을 먼저 보여주고, `--commit`에서만 실제로 생성한다(기본 초안, `--publish` 시 공개):
+
+```bash
+uv run python .claude/scripts/youtube/create_sunrei.py <ID> [--prod] [--commit] \
+  [--summary "트랜스크립트 기반 한 줄 요약"] [--tag-ids a,b]
+```
+
+여러 재생목록은 이 명령을 워크스페이스마다 반복한다. 다만 태그 선택·spot 검토 같은 대화형 확인을
+건너뛰므로, 요약은 `--summary`로 직접 넘기고(트랜스크립트 기반) 생성 뒤 admin에서 검토한다.
+성공 시 `_create_manifest.json`을 남기니 6단계 S3 레지스트리 갱신에 쓴다.
 
 ### 6. Handle Response
 
@@ -288,6 +313,20 @@ On error:
 - Display the error message
 - Offer to retry with corrections
 - Common errors: missing required fields, invalid tag IDs
+
+### 6.5. 기존 Sunrei 수정하기
+
+수정은 `PUT {SERVER_URL}/admin/sunreis/{id}`로 한다:
+
+- 최상위 필드(`title`, `summary`, `description`, `link`, `images`, `published`, `sourceId`)는
+  선택이라, 담아 보낸 필드만 바뀐다.
+- `spots`는 통째로 교체가 아니라 병합이다. `id`가 있는 항목은 해당 spot을 수정하고
+  (`title`은 모든 항목에 필수, 나머지는 선택), `id`가 없는 항목은 새 spot을 만들며,
+  `{"id": "SS...", "delete": true}`는 삭제 표시(soft-delete)한다. 배열에 없는 spot은 그대로 둔다.
+- Sunrei 하나당 PUT은 한 번에 하나씩 보낸다. PUT을 겹쳐 보내면(예: 여러 spot 이름을 병렬로 수정)
+  요청이 서로 엉켜 Sunrei 상태가 어긋난다. 바꿀 내용은 방금 받은 `GET /admin/sunreis/{id}` 위에
+  모아 한 요청으로 보낸다.
+- 이미 상태가 꼬였다면, Sunrei를 지우고 `locations.json`에서 다시 만드는 편이 하나씩 고치는 것보다 빠르고 안전하다.
 
 ### 7. Cleanup (Optional)
 

--- a/.claude/skills/youtube-extract-locations/SKILL.md
+++ b/.claude/skills/youtube-extract-locations/SKILL.md
@@ -79,26 +79,37 @@ These are high-confidence locations explicitly shared by the creator.
 
 ### 5. Extract Location Mentions
 
-Analyze all available sources to find locations, in priority order:
+장소를 "찾는" 소스와 그 장소를 "설명하는" 소스를 구분한다.
 
-1. Description chapters with timestamps (highest quality — creator-curated)
-2. Google Maps links in description (from Step 4)
-3. Title/description analysis (main subject buildings/places when no chapters exist)
-4. Transcript mentions (lowest priority — noisy)
+찾는 소스 (어떤 장소가 있는지) — 우선순위:
+1. 타임스탬프가 있는 설명란 챕터 (제작자가 직접 정리 — 최상)
+2. 설명란의 Google Maps 링크 (Step 4)
+3. 제목·설명 분석 (챕터가 없을 때 주요 건물/장소)
+4. 트랜스크립트 언급
 
-Each location's `description` must be 2-3 sentences that include:
-1. The video's concept/theme (what kind of content this is — e.g., "도쿄 시부야 지역의 숨은 맛집을 소개하는 영상")
-2. What makes this location notable as presented in the video (e.g., specific dishes praised, unique features highlighted, why the creator recommended it)
+설명하는 소스 (그 장소·음식이 어땠는지) — 트랜스크립트가 1순위다. 챕터는 대개 "00:00 가게이름"뿐이라,
+맛·조리·서빙·유튜버의 코멘트 같은 실제 묘사는 나레이션에 있다. 트랜스크립트가 "찾는" 데에서 최하위라고
+해서, 설명을 뽑을 때까지 흘려보내면 안 된다.
 
-Bad: "야키토리 맛집" (too short, no context)
-Good: "시부야 맛집 투어를 소개하는 영상에서 방문한 야키토리 전문점. 비장탄으로 굽는 것이 특징이며, 특히 쓰쿠네와 레바가 인기 메뉴로 영상에서 극찬을 받았다."
+각 장소의 `description`은 아래 두 축을 모두 담는다 (3~6문장, 영상이 음식을 많이 다루면 더 길어도 된다).
+이 값은 나중에 spot의 `context`가 되며, public 지도 카드가 보여주는 유일한 편집 텍스트다:
 
-For transcript-based extraction, look for:
+1. 음식점 — 어떤 곳인지(분위기·특징·위치 맥락)와 영상의 개념/테마를 한두 문장으로.
+2. 음식 — 대표 메뉴가 무엇인지, 어떻게 조리·서빙되는지, 그리고 영상에서 그 음식을 어떻게 묘사했는지
+   (맛·식감·평가). 가능하면 해당 장면의 타임스탬프를 함께 남긴다.
 
-- Place names (restaurants, cafes, shops, tourist spots)
-- Addresses or neighborhoods mentioned
-- Descriptions that identify a location (e.g., "this yakitori place near Shibuya station")
-- Note the timestamp where each location is mentioned
+Bad: "야키토리 맛집" (너무 짧고 맥락 없음)
+Bad: "쓰쿠네가 극찬받았다" (감상만 있고 음식 묘사가 없음)
+Good: "시부야 뒷골목 야키토리 투어에서 방문한 카운터 10석 규모의 노포 야키토리 전문점. 대표 메뉴는 비장탄에
+구운 쓰쿠네와 레바로, 쓰쿠네는 겉을 바삭하게 구운 뒤 날달걀 노른자에 찍어 먹으며 유튜버가 '육즙이 팡
+터진다'고 표현했고, 레바는 비린내 없이 부드럽다고 강조했다 (12:30)."
+
+트랜스크립트에서 뽑을 때 확인할 것:
+
+- 장소 이름 (식당·카페·상점·명소)
+- 언급된 주소나 동네
+- 장소를 특정하는 묘사 ("시부야역 근처 그 야키토리 집")
+- 음식/메뉴에 대한 구체적 코멘트 (무슨 메뉴, 맛·조리·평가)와 그 타임스탬프
 
 Filter by the video concept identified in Step 3. For example:
 
@@ -116,6 +127,11 @@ Before geocoding, clean and filter the extracted locations:
   - Real estate offices, generic street names ("Walking Street", "Shopping Street")
   - Overly generic names ("라멘집", "Pedestrian Paradise")
   - Concepts rather than places
+- 장소 이름 검증: `name`은 실제 상호여야 한다. 설명란의 정형 블록(이름 / 주소 / 영업시간이
+  줄줄이 이어진 형태)을 파싱하면 엉뚱한 줄이 `name`에 들어가기 쉽다 — 영업시간("매일 11:00 - 21:00"),
+  전화번호, 주소 조각 같은 것들. 이런 이름은 버리고 영상 제목이나 자막에서 실제 이름을 찾는다.
+  이름을 알 수 없으면 지어내지 말고 사용자에게 표시한다. 이런 값은 좌표 검색 단계로 넘기지 않는다 —
+  주소 조각이 이름으로 들어가면 핀 위치까지 틀어진다(6단계 참고).
 - Videos without chapters: When a video has no description chapters or Google Maps links, analyze the title and description to identify the main architectural/location subjects. Search for those directly.
 
 ### 6. Geocode Locations via Google Maps Places API
@@ -134,6 +150,35 @@ curl -s -X POST "https://places.googleapis.com/v1/places:searchText" \
 ```
 
 Use area context from the video concept to improve search accuracy (e.g., "시부야 야키토리 가게" instead of just "야키토리 가게").
+
+조심해야 할 실패 두 가지:
+
+- 주소만으로 좌표를 찾지 않는다. 주소만 담은 `textQuery`는 Google이 그 주소에서 가장 가깝다고
+  판단한 업체를 돌려준다 — 대개 근처 호텔이나 사무실 건물이다 — 그래서 그럴듯한 좌표에 엉뚱한
+  `googleMapsId`가 붙는다. 항상 상호에 지역 맥락을 더해 검색한다.
+- 결과를 받아들이기 전에 확인한다. 돌려받은 `displayName`이 추출한 이름과 맞아야 하며,
+  언어나 로마자 표기 차이는 감안한다. 어긋나면 검색어를 다듬어 다시 시도하거나 검토 대상으로
+  표시하고, 첫 결과를 말없이 그대로 쓰지 않는다.
+
+이 두 가지 가드를 코드로 넣어 둔 헬퍼가 있다. 개별 조회와 `locations.json` 일괄 백필을 모두 지원한다:
+
+```bash
+# 한 곳만 조회 (displayName 불일치 시 경고)
+uv run python .claude/scripts/youtube/geocode.py --query "<상호>" --area "<지역>"
+
+# locations.json에서 좌표 없는 항목을 채우고, 이상한 이름·불일치는 geocodeWarning으로 표시
+uv run python .claude/scripts/youtube/geocode.py <ID>
+```
+
+### 6.5. 대용량 재생목록: 하위 에이전트로 나눠 추출하기
+
+영상이 수십 개인 재생목록은 영상별 추출(3~6단계)을 하위 에이전트로 나눠 돌린다. 겪어 보고 얻은 두 가지 원칙:
+
+- 한꺼번에 다 띄우지 말고 3~4개씩 작은 묶음으로 실행한다. 한 번에 크게(예: 13개) 띄우면 API 요청
+  제한에 걸려 그 묶음 전체가 429로 실패한다. 실패한 묶음은 더 작은 단위로 다시 돌린다.
+- 하위 에이전트 결과는 목록 순서나 서버의 spotId가 아니라 영상 ID와 장소 이름으로 맞춘다.
+  spotId로 맞췄더니 한 영상에 장소가 여럿일 때 결과가 엉뚱한 spot에 붙었다. 병합한 뒤에는
+  각 설명이 실제로 그 장소를 가리키는지(이름을 언급하거나 분명히 묘사하는지) 확인하고 반영한다.
 
 ### 7. Present Results to User
 
@@ -176,7 +221,7 @@ Save to `.claude/workspace/youtube/{ID}/locations.json`:
           "source": "transcript_mention",
           "timestamp": 125.5,
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=VIDEO_ID&t=125",
-          "description": "시부야 맛집 투어를 소개하는 영상에서 방문한 야키토리 전문점. 비장탄으로 굽는 것이 특징이며, 특히 쓰쿠네와 레바가 인기 메뉴로 영상에서 극찬을 받았다."
+          "description": "시부야 뒷골목 야키토리 투어에서 방문한 카운터 10석 규모의 노포. 대표 메뉴는 비장탄에 구운 쓰쿠네와 레바로, 쓰쿠네는 겉을 바삭하게 구운 뒤 노른자에 찍어 먹고(육즙이 팡 터진다고 표현), 레바는 비린내 없이 부드럽다고 강조했다 (12:30)."
         }
       ]
     }

--- a/.claude/skills/youtube-extract-transcript/SKILL.md
+++ b/.claude/skills/youtube-extract-transcript/SKILL.md
@@ -59,29 +59,65 @@ OCR output: yt-dlp download progress logs can mix with JSON stdout. When parsing
    - 자막 전환이 빠른 영상에서는 `--interval 0.5` 등으로 샘플링 간격을 줄여 누락을 방지한다 (기본값: 1.0초).
    - 채널 로고가 자막 영역에 겹치면 필터링에 의해 자막까지 함께 제거될 수 있다. 이 경우 OCR 결과가 비정상적으로 적다면 원본 프레임을 확인해볼 것.
 
-### Rate Limiting
+### 요청 제한 (Rate Limiting)
 
-youtube-transcript-api commonly hits rate limits (HTTP 429) with rapid automated requests, resulting in temporary blocks.
+youtube-transcript-api는 자동화된 요청을 빠르게 보내면 YouTube의 봇 차단(IP 차단)에 걸린다. 실패는 이런 모습이다:
 
-Known limits:
+```
+"Could not retrieve a transcript for the video ... This is most likely caused by:
+- YouTube is blocking requests from your IP ...
+- You have done too many requests and your IP has been blocked by YouTube"
+```
 
-- ~5 requests per 10 seconds
-- Free third-party providers: ~1000 requests per hour
-- High-volume automated scraping triggers YouTube's anti-bot policies
+이 오류는 원인이 두 가지인데 메시지만으로는 구분되지 않는다:
+(a) 영상에 자막이 정말 없거나, (b) IP가 차단된 경우다. 연달아 나오면 (b)로, 잘 받다가 한 번만 튀면 (a)로 본다.
 
-Mitigation:
+#### 실측 결과 (2026-07, 육식맨 82편 재생목록에서 확인)
 
-- Single videos: Add 10-22 second delay between requests
-- Playlists: Wait ~60 seconds between videos. Inform the user of progress
-- yt-dlp: Use `--sleep-interval 15` or `--min-sleep-interval 6 --max-sleep-interval 12`
-- On 429 errors: Use exponential backoff (wait longer after each retry), do NOT immediately retry
+차단은 미리 걸려 있던 IP 표시가 아니라 요청 속도로 발동한다. 새 IP도 요청 15~20번 만에 똑같이
+차단됐다. 기준이 일정 시간 동안의 요청 수라서, 요청 간격을 ~30초 아래로 둬도 소용없다:
 
-Batch processing: For playlists with many videos (>10), create a batch Python script rather than running individual commands. The script should:
+| 간격 | 결과 |
+|------|------|
+| 14초 | 약 17번 만에 차단 |
+| 20초 | 약 10~20번 만에 차단 |
+| 60~90초 | 25번, 차단 없음 |
 
-- Handle rate limiting internally (see Rate Limiting section above)
-- Track success/failure per video
-- Save raw results to `transcripts_raw.json`
-- Report summary at the end (N success, N failed, N OCR fallback needed)
+IP를 바꿔 우회하려 하지 말고 속도를 늦춘다. 영상마다 60~90초씩 천천히 흘려보내면 기준 아래로
+유지되어 차단 없이 재생목록을 끝까지 받는다.
+
+한 가지 더 확인된 점: yt-dlp로도 못 피한다. `yt-dlp --write-auto-subs`는 같은 자막 다운로드
+엔드포인트에서 429가 나고, `--impersonate`나 `--js-runtimes deno`도 소용없다(요청 제한이 봇
+탐지가 아니라 다운로드 엔드포인트에 걸려 있다). YouTube Data API의 `captions.download`는 본인
+소유가 아닌 채널의 자막은 받을 수 없다.
+
+#### 대응 방법
+
+- 단일 영상: 그냥 요청해도 된다.
+- 재생목록: 영상 사이에 60~90초를 무작위로 둔다(예: `random.uniform(60, 90)`). 14~20초 간격은
+  쓰지 않는다 — 매번 15~20번쯤에서 벽에 부딪힌다.
+- IP 차단 오류가 나면: 다음 영상으로 넘기지도, 곧바로 재시도하지도 않는다. 길게(예: 600초)
+  기다린 뒤 같은 영상을 다시 시도한다. 그 사이 요청 카운트가 초기화될 여지가 생긴다.
+- 연속으로 기다리는 횟수에 상한을 둔다(예: 4번이면 중단). 계속 차단당하는 실행이 무한히 도는 대신 멈추도록.
+
+#### 일괄 처리
+
+영상이 많은 재생목록(>10)은 명령을 하나씩 돌리거나 작업 폴더마다 새 스크립트를 쓰지 말고,
+공용 일괄 스크립트를 쓴다:
+
+```bash
+uv run --with youtube-transcript-api --with python-dotenv \
+  python .claude/scripts/youtube/fetch_playlist_transcripts.py "{ID}"
+```
+
+`{ID}`는 `.claude/workspace/youtube/` 아래 작업 폴더의 이름이다. 이 스크립트는 `video_info.json`의
+`selectedVideos`를 읽어 작업 폴더에 `transcripts_raw.json`을 쓰며, 위 내용을 전부 구현한다:
+
+- 영상 사이 60~90초 무작위 대기.
+- IP 차단 오류 시: 약 600초 멈췄다가 같은 영상 재시도, 연속 4번이면 중단.
+- 이어받기: 이미 받은 영상은 건너뛰고 오류 난 것만 다시 받으며, 영상마다 결과를 저장한다 —
+  중간에 끊겨도 같은 명령을 다시 돌리면 이어진다.
+- 끝에 요약 출력(성공 N개, 자막 없음 N개).
 
 ### 3. Audit and Clean Transcript
 
@@ -91,7 +127,7 @@ For each transcript, analyze and clean the text:
 2. Remove noise: "[음악]", "[박수]", "[웃음]" markers, repeated filler words
 3. Fix formatting: Merge broken sentences, fix punctuation
 4. Preserve timestamps: Keep segment timing information intact
-5. Identify key sections: Note sections that mention places, restaurants, attractions
+5. Identify key sections: Note sections that mention places, restaurants, attractions — especially the food/menu commentary (dish names, how it's cooked and served, taste, and the creator's reaction) with their timestamps. This narration is the primary source for the per-place descriptions in `youtube-extract-locations`, so carry it forward instead of trimming it as filler.
 
 #### 전후 문맥 참조를 통한 교정
 

--- a/.claude/skills/youtube-fetch-info/SKILL.md
+++ b/.claude/skills/youtube-fetch-info/SKILL.md
@@ -7,6 +7,18 @@ description: This skill should be used when the user asks to "fetch YouTube info
 
 Fetch metadata for a YouTube video or playlist using the YouTube Data API v3.
 
+## 빠른 방법 (스크립트)
+
+대개는 아래 단계를 손으로 하지 말고 스크립트 한 번으로 끝낸다. 채널 정보까지 포함해
+`video_info.json`을 스키마대로 만들어 준다(재생목록은 페이지네이션 자동 처리):
+
+```bash
+uv run python .claude/scripts/youtube/fetch_info.py "<URL>" [--videos all|1,3,5|first:N]
+```
+
+아래 단계들은 이 스크립트가 내부적으로 따르는 계약이다. 영상 선택을 대화형으로 하는 등
+스크립트로 안 되는 경우에만 직접 호출한다.
+
 ## Steps
 
 ### 1. Load API Key

--- a/.claude/skills/youtube-to-sunrei/SKILL.md
+++ b/.claude/skills/youtube-to-sunrei/SKILL.md
@@ -57,7 +57,7 @@ Checkpoint: User must approve location list before Sunrei creation.
 
 Execute the `/youtube-create-sunrei` skill.
 
-- Admin authentication is minted locally — `TOKEN=$(python3 .claude/scripts/auth/mint_token.py)`, no login flow. Needs `sops` + GCP KMS decrypt permission
+- 관리자 인증은 로그인 없이 로컬에서 발급한다 — `TOKEN=$(python3 .claude/scripts/auth/mint_token.py)`. `sops` + GCP KMS decrypt 권한이 필요하다(스크립트가 스킬 안에서 자동으로 발급하므로 별도 export는 불필요)
 - One playlist/trip = one Sunrei: title = playlist title, link = playlist URL, summary/description derived from transcripts; the channel becomes the Source. Select tags if available
 - Build SunreiSpots from extracted locations (spot `context` = each location's per-place summary)
 - Create via server admin API (all requests require `Authorization: Bearer ${TOKEN}` header)


### PR DESCRIPTION
## 요약

여러 YouTube 재생목록을 한꺼번에 Sunrei로 가져오면서 겪은 문제들을 관련 스킬에 정리하고, 매번 손으로 하던 기계적인 단계를 재사용 가능한 스크립트로 만들었다.

### 스킬 정리 (교훈)

- **youtube-create-sunrei**: 토큰이 환경별로 서명된다는 점(운영 401 시 `login.py --prod` 재실행), 운영 DB 초기화 후 오래된 S3 레지스트리를 실제 API로 검증, Python 기본 urllib User-Agent에 대한 Cloudflare 403, `PUT /admin/sunreis/{id}`의 병합 동작과 sunrei당 PUT 한 번씩.
- **youtube-extract-locations**: 영업시간·전화번호·주소 조각이 이름 자리에 들어가는 것을 거르는 검증, 순수 주소로 좌표를 찾지 않기·`displayName` 확인, 대형 재생목록은 하위 에이전트 3~4개씩 나눠 돌리고 결과를 videoId+장소명으로 매칭. 또 장소 설명을 음식점+음식(대표 메뉴·조리/서빙·맛 코멘트) 2축으로 담고, 음식 묘사의 원천인 트랜스크립트를 설명 1순위로 쓰도록 가이드 강화.
- **youtube-extract-transcript**: 요청 제한(자막 IP 차단) 대응 — 60~90초 드립. 정제 단계에서 음식 코멘트 구간을 타임스탬프와 함께 보존해 설명 단계로 넘김.
- 이번 PR에서 추가한 문구는 모두 자연스러운 한국어로 다듬음.

### 새 스크립트 (외부 의존성 없이 stdlib만, 하드코딩 없음)

- `fetch_info.py`: URL → `video_info.json` (채널 정보·재생목록 페이지네이션 포함)
- `geocode.py`: Places 조회에 가드 내장(순수 주소 금지, `displayName` 불일치·이상한 이름 플래그) + 개별 조회/`locations.json` 일괄 백필
- `create_sunrei.py`: 워크스페이스 → 소스 해석/생성 + spot 구성 + POST, 기본 dry-run(`--commit`에서만 생성). context 컷 2000자
- `fetch_playlist_transcripts.py`: 요청 제한 대응·중간에 멈춰도 이어받는 자막 수집
- `_common.py`: 공용 헬퍼(API 키·토큰 로딩, 실제 User-Agent HTTP)

### 제거

- 하드코딩된 소스·재생목록으로 특정 세션(프로드 초기화 복구)에만 쓰인 일회성 `create_all.py` 삭제 — 위 범용 스크립트로 대체.

## 테스트

- 라이브 검증: `fetch_info`(단일 영상, 스키마 일치), `geocode --query`, `create_sunrei`(실 워크스페이스 dry-run).
- 스크립트 4개 모두 `python3 -m py_compile` 통과.
- 문서와 독립 실행 스크립트만 수정 — 서버·앱 코드 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)