### PR TITLE
refactor(server): SunreiSpot에서 미사용 description 컬럼 제거

### DIFF
--- a/sunrei-api/admin-api-spec.yaml
+++ b/sunrei-api/admin-api-spec.yaml
@@ -735,7 +735,6 @@ components:
         id: { type: string }
         sunreiId: { type: string }
         title: { type: string, maxLength: 128 }
-        description: { type: string, nullable: true }
         context: { type: string, nullable: true, description: What this source says here. }
         youtubeLink: { type: string, nullable: true }
         images:
@@ -820,7 +819,6 @@ components:
       required: [title]
       properties:
         title: { type: string, maxLength: 128 }
-        description: { type: string, nullable: true }
         context: { type: string, nullable: true }
         youtubeLink: { type: string, nullable: true }
         place:
@@ -846,7 +844,6 @@ components:
       properties:
         id: { type: string, description: ID for existing spot (omit for new spots) }
         title: { type: string, maxLength: 128 }
-        description: { type: string, nullable: true }
         context: { type: string, nullable: true }
         youtubeLink: { type: string, nullable: true }
         place:

--- a/sunrei-api/app-api-spec.yaml
+++ b/sunrei-api/app-api-spec.yaml
@@ -306,7 +306,6 @@ components:
         id: { type: string }
         sunreiId: { type: string }
         title: { type: string, maxLength: 128 }
-        description: { type: string, nullable: true }
         context:
           type: string
           nullable: true

--- a/sunrei-frontend/packages/sunrei-admin/src/api/admin/api.ts
+++ b/sunrei-frontend/packages/sunrei-admin/src/api/admin/api.ts
@@ -49,7 +49,6 @@ export interface CreateSunreiRequest {
 }
 export interface CreateSunreiSpotInline {
     'title': string;
-    'description'?: string | null;
     'context'?: string | null;
     'youtubeLink'?: string | null;
     'place'?: PlaceInput | null;
@@ -235,7 +234,6 @@ export interface SunreiSpotDTO {
     'id': string;
     'sunreiId': string;
     'title': string;
-    'description'?: string | null;
     /**
      * What this source says here.
      */
@@ -285,7 +283,6 @@ export interface UpdateSunreiSpotInline {
      */
     'id'?: string;
     'title': string;
-    'description'?: string | null;
     'context'?: string | null;
     'youtubeLink'?: string | null;
     'place'?: PlaceInput | null;

--- a/sunrei-frontend/packages/sunrei-admin/src/components/SunreiForm.tsx
+++ b/sunrei-frontend/packages/sunrei-admin/src/components/SunreiForm.tsx
@@ -107,7 +107,6 @@ export default function SunreiForm({
       const spots = (sunreiData.spots || []).map((s) => ({
         id: s.id,
         title: s.title,
-        description: s.description ?? '',
         context: s.context ?? '',
         youtubeLink: s.youtubeLink ?? '',
         place: s.place ?? null,

--- a/sunrei-frontend/packages/sunrei-admin/src/components/sunrei-form/SpotCard.tsx
+++ b/sunrei-frontend/packages/sunrei-admin/src/components/sunrei-form/SpotCard.tsx
@@ -93,12 +93,6 @@ export default function SpotCard({
               placeholder="Context — what this source says here (e.g. 7화에서 울며 식사한 식당)"
               className="text-xs resize-none"
             />
-            <Textarea
-              {...register(`spots.${index}.description` as const)}
-              rows={3}
-              placeholder="Spot description"
-              className="text-sm resize-none"
-            />
           </div>
         </div>
         <PlaceSection

--- a/sunrei-frontend/packages/sunrei-app/src/dto/api.ts
+++ b/sunrei-frontend/packages/sunrei-app/src/dto/api.ts
@@ -615,12 +615,6 @@ export interface SunreiSpotDTO {
      */
     'title': string;
     /**
-     * 
-     * @type {string}
-     * @memberof SunreiSpotDTO
-     */
-    'description'?: string | null;
-    /**
      * What this source says here (\"7화에서 주인공이 울며 식사한 식당\").
      * @type {string}
      * @memberof SunreiSpotDTO

--- a/sunrei-server/src/main/kotlin/com/sunrei/database/SunreiSpotTable.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/database/SunreiSpotTable.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 
 object SunreiSpots : ULIDTimestampedTable("sunrei_spot", "SS") {
     val title = varchar("title", 128)
-    val description = text("description").nullable()
     val context = text("context").nullable()
     val youtubeLink = varchar("youtube_link", 255).nullable()
     val images = json<List<MultiSizeImage>>("images", Json.Default).default(emptyList())

--- a/sunrei-server/src/main/kotlin/com/sunrei/model/SunreiSpot.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/model/SunreiSpot.kt
@@ -4,7 +4,6 @@ data class SunreiSpot(
     val id: String,
     val sunreiId: String,
     val title: String,
-    val description: String?,
     val context: String?,
     val youtubeLink: String?,
     val images: List<MultiSizeImage>,

--- a/sunrei-server/src/main/kotlin/com/sunrei/routes/admin/converter/SunreiConverter.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/routes/admin/converter/SunreiConverter.kt
@@ -61,7 +61,6 @@ fun SunreiSpot.toDTO(): SunreiSpotDTO = SunreiSpotDTO(
     id = id,
     sunreiId = sunreiId,
     title = title,
-    description = description,
     context = context,
     youtubeLink = youtubeLink,
     images = images.map { it.toDTO() },

--- a/sunrei-server/src/main/kotlin/com/sunrei/routes/app/converter/SunreiConverter.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/routes/app/converter/SunreiConverter.kt
@@ -51,7 +51,6 @@ fun SunreiSpot.toDTO(): SunreiSpotDTO = SunreiSpotDTO(
     id = id,
     sunreiId = sunreiId,
     title = title,
-    description = description,
     context = context,
     youtubeLink = youtubeLink,
     images = images.map { it.toDTO() },

--- a/sunrei-server/src/main/kotlin/com/sunrei/service/SunreiService.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/service/SunreiService.kt
@@ -213,13 +213,13 @@ class SunreiService(
 
     private fun createSunreiSpot(sunreiId: String, spot: CreateSunreiSpotInline): String =
         doCreateSpot(
-            sunreiId, spot.title, spot.description, spot.context, spot.youtubeLink,
+            sunreiId, spot.title, spot.context, spot.youtubeLink,
             spot.place, spot.images, spot.tagIds, spot.tagLabels
         )
 
     private fun createSunreiSpot(sunreiId: String, spot: UpdateSunreiSpotInline): String =
         doCreateSpot(
-            sunreiId, spot.title, spot.description, spot.context, spot.youtubeLink,
+            sunreiId, spot.title, spot.context, spot.youtubeLink,
             spot.place, spot.images, spot.tagIds, spot.tagLabels
         )
 
@@ -227,7 +227,6 @@ class SunreiService(
     private fun doCreateSpot(
         sunreiId: String,
         title: String,
-        description: String?,
         context: String?,
         youtubeLink: String?,
         place: PlaceInput?,
@@ -242,7 +241,6 @@ class SunreiService(
         val spotId = SunreiSpots.insertAndGetId { stmt ->
             stmt[SunreiSpots.sunreiId] = sunreiId
             stmt[SunreiSpots.title] = title
-            stmt[SunreiSpots.description] = description
             stmt[SunreiSpots.context] = context
             stmt[SunreiSpots.placeId] = placeId
             stmt[SunreiSpots.youtubeLink] = youtubeLink
@@ -261,7 +259,6 @@ class SunreiService(
     private fun updateSunreiSpot(spotId: String, spot: UpdateSunreiSpotInline) {
         SunreiSpots.update({ SunreiSpots.id eq spotId }) { stmt ->
             stmt[SunreiSpots.title] = spot.title
-            spot.description?.let { stmt[SunreiSpots.description] = it }
             spot.context?.let { stmt[SunreiSpots.context] = it }
             spot.youtubeLink?.let { stmt[SunreiSpots.youtubeLink] = it }
             spot.place?.let { placeInput ->
@@ -384,7 +381,6 @@ class SunreiService(
                     id = spotId,
                     sunreiId = row[SunreiSpots.sunreiId],
                     title = row[SunreiSpots.title],
-                    description = row[SunreiSpots.description],
                     context = row[SunreiSpots.context],
                     youtubeLink = row[SunreiSpots.youtubeLink],
                     images = row[SunreiSpots.images],

--- a/sunrei-server/src/main/kotlin/com/sunrei/service/SunreiSpotService.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/service/SunreiSpotService.kt
@@ -196,7 +196,6 @@ class SunreiSpotService {
                 id = spotId,
                 sunreiId = row[SunreiSpots.sunreiId],
                 title = row[SunreiSpots.title],
-                description = row[SunreiSpots.description],
                 context = row[SunreiSpots.context],
                 youtubeLink = row[SunreiSpots.youtubeLink],
                 images = row[SunreiSpots.images],

--- a/sunrei-server/src/main/resources/db/migration/V1__init.sql
+++ b/sunrei-server/src/main/resources/db/migration/V1__init.sql
@@ -80,7 +80,7 @@ CREATE INDEX idx_sunrei_deleted_at ON sunrei(deleted_at);
 -- SunreiSpot: one mention of a place under a Sunrei.
 CREATE TABLE sunrei_spot (
   id VARCHAR(32) PRIMARY KEY,
-  title VARCHAR(128) NOT NULL, description TEXT, context TEXT, youtube_link VARCHAR(255),
+  title VARCHAR(128) NOT NULL, context TEXT, youtube_link VARCHAR(255),
   images JSONB NOT NULL DEFAULT '[]'::jsonb,
   place_id VARCHAR(32) NOT NULL REFERENCES place(id),
   sunrei_id VARCHAR(32) NOT NULL REFERENCES sunrei(id) ON DELETE CASCADE,


### PR DESCRIPTION
## 요약

SunreiSpot의 `description` 컬럼을 제거한다. 이 필드는 인제스트가 항상 빈 값으로 채우고 프론트 어디에서도 렌더하지 않는 미사용 중복 컬럼이었다. 스팟의 편집 텍스트는 `context` 하나가 전담한다(맵 카드가 노출하고, 대표 스팟 선택도 `context` 기준).

같은 실제 장소가 여러 영상에 나오는 경우도 영상마다 SunreiSpot이 따로 생겨 각자의 `context`로 이미 구분되므로, "영상마다 다른 설명"을 위해 두 번째 필드가 필요하지 않다. `description`이 의미를 갖는 유일한 경우는 한 스팟을 카드(짧게)와 상세(길게)로 나눠 보여줄 때인데, 현재 그런 화면이 없어 순수 미사용 상태였다. (Sunrei·Tag의 `description`은 사용 중이라 유지한다.)

### 변경

- 마이그레이션: `V1__init.sql`의 `sunrei_spot`에서 `description` 컬럼 제거.
- 서버: Exposed 테이블·모델·서비스(create/update/조회)·app+admin converter에서 참조 제거.
- 스펙: admin·app OpenAPI의 spot 스키마에서 `description` 제거 → Kotlin DTO 재생성.
- 어드민 프론트: `SpotCard` 입력란과 `SunreiForm` 매핑 제거 → TS 타입 재생성.

### 마이그레이션 방식

V2 forward migration 대신 `V1__init`을 직접 수정했다. 이미 적용된 마이그레이션을 고친 것이라, 반영하려면 로컬/개발 DB를 초기화해야 한다:

```bash
DB_URL=jdbc:postgresql://localhost:5433/sunrei ./gradlew flywayClean flywayMigrate
```

## 테스트

- 서버: `generateProtocols compileKotlin compileTestKotlin` → BUILD SUCCESSFUL.
- 프론트: sunrei-app·sunrei-admin `tsc --noEmit` 통과. (타입체크가 `SunreiForm.tsx`의 누락 참조 하나를 잡아 함께 수정.)
- 로컬 DB: `flywayClean` + `flywayMigrate` 후 `sunrei_spot`에 `description` 컬럼이 없음을 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)