### PR TITLE
refactor(server): DB 테이블 이름을 단수로 통일

### DIFF
--- a/sunrei-server/src/main/kotlin/com/sunrei/database/SunreiSpotTagTable.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/database/SunreiSpotTagTable.kt
@@ -3,7 +3,7 @@ package com.sunrei.database
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
 
-object SunreiSpotTags : Table("sunrei_spot_tags") {
+object SunreiSpotTags : Table("sunrei_spot_tag") {
     val sunreiSpotId = varchar("sunrei_spot_id", 32).references(SunreiSpots.id, ReferenceOption.CASCADE)
     val tagId = varchar("tag_id", 32).references(Tags.id, ReferenceOption.CASCADE)
 

--- a/sunrei-server/src/main/kotlin/com/sunrei/database/UserTable.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/database/UserTable.kt
@@ -3,14 +3,15 @@ package com.sunrei.database
 import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 import org.jetbrains.exposed.sql.ReferenceOption
 
-object UserTable : ULIDTimestampedTable("users", "U") {
+// "user" is a Postgres reserved word; Exposed quotes it automatically in generated SQL.
+object UserTable : ULIDTimestampedTable("user", "U") {
     val email = varchar("email", 255).uniqueIndex()
     val name = varchar("name", 255).nullable()
     val role = varchar("role", 20).default("user")
         .check { it inList(listOf("user", "admin")) }
 }
 
-object OAuthProviderTable : ULIDTimestampedTable("oauth_providers", "OAUTH") {
+object OAuthProviderTable : ULIDTimestampedTable("oauth_provider", "OAUTH") {
     val userId = varchar("user_id", 32).references(UserTable.id, ReferenceOption.CASCADE)
     val provider = varchar("provider", 64)
     val providerUserId = varchar("provider_user_id", 64)

--- a/sunrei-server/src/main/kotlin/com/sunrei/service/TagService.kt
+++ b/sunrei-server/src/main/kotlin/com/sunrei/service/TagService.kt
@@ -179,7 +179,7 @@ class TagService(
         } > 0
     }
 
-    /** Hard delete a tag (cascades to sunrei_spot_tags). */
+    /** Hard delete a tag (cascades to sunrei_spot_tag). */
     fun delete(id: String): Boolean = transaction {
         Tags.deleteWhere { Tags.id eq id } > 0
     }

--- a/sunrei-server/src/main/resources/db/migration/V1__init.sql
+++ b/sunrei-server/src/main/resources/db/migration/V1__init.sql
@@ -90,27 +90,28 @@ CREATE TABLE sunrei_spot (
 CREATE INDEX idx_sunrei_spot_sunrei_id_deleted_at ON sunrei_spot(sunrei_id, deleted_at);
 CREATE INDEX idx_sunrei_spot_place_id_deleted_at ON sunrei_spot(place_id, deleted_at);
 
--- Spot-level tag join (replaces the old sunrei-level sunrei_tags).
-CREATE TABLE sunrei_spot_tags (
+-- Spot-level tag join (replaces the old sunrei-level sunrei_tag).
+CREATE TABLE sunrei_spot_tag (
   sunrei_spot_id VARCHAR(32) NOT NULL REFERENCES sunrei_spot(id) ON DELETE CASCADE,
   tag_id VARCHAR(32) NOT NULL REFERENCES tag(id) ON DELETE CASCADE,
   PRIMARY KEY (sunrei_spot_id, tag_id));
-CREATE INDEX idx_sst_tag_id ON sunrei_spot_tags(tag_id);
+CREATE INDEX idx_sunrei_spot_tag_tag_id ON sunrei_spot_tag(tag_id);
 
 -- Auth tables (existing shape, unchanged behavior).
-CREATE TABLE users (
+-- "user" is a reserved word in Postgres, so it stays double-quoted everywhere.
+CREATE TABLE "user" (
   id VARCHAR(32) PRIMARY KEY,
   email VARCHAR(255) UNIQUE NOT NULL,
   name VARCHAR(255),
   role VARCHAR(20) DEFAULT 'user' CHECK (role IN ('user', 'admin')),
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP);
-CREATE INDEX idx_users_email ON users(email);
-CREATE INDEX idx_users_role ON users(role);
+CREATE INDEX idx_user_email ON "user"(email);
+CREATE INDEX idx_user_role ON "user"(role);
 
-CREATE TABLE oauth_providers (
+CREATE TABLE oauth_provider (
   id VARCHAR(32) PRIMARY KEY,
-  user_id VARCHAR(32) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  user_id VARCHAR(32) NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
   provider VARCHAR(64) NOT NULL,
   provider_user_id VARCHAR(64) NOT NULL,
   provider_data TEXT,
@@ -121,12 +122,12 @@ CREATE TABLE oauth_providers (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE(user_id, provider),
   UNIQUE(provider, provider_user_id));
-CREATE INDEX idx_oauth_providers_user_id ON oauth_providers(user_id);
-CREATE INDEX idx_oauth_providers_provider ON oauth_providers(provider);
+CREATE INDEX idx_oauth_provider_user_id ON oauth_provider(user_id);
+CREATE INDEX idx_oauth_provider_provider ON oauth_provider(provider);
 
 -- Folded admin reseed (previously V4): one admin account so Google OAuth
 -- (linked by email on first login) can access the admin after the content wipe.
-INSERT INTO users (id, email, name, role, created_at, updated_at)
+INSERT INTO "user" (id, email, name, role, created_at, updated_at)
 VALUES (
   'U00000000000000000000000000',
   'nelson@vcnc.co.kr',


### PR DESCRIPTION
## 배경

도메인 테이블은 단수(`place`, `source`, `tag`, `sunrei`, `sunrei_spot`)인데 조인 테이블과 auth 테이블 세 개만 복수형이라 규칙이 섞여 있었습니다. 단수로 통일했습니다.

| 이전 | 이후 |
|---|---|
| `sunrei_spot_tags` | `sunrei_spot_tag` |
| `users` | `"user"` |
| `oauth_providers` | `oauth_provider` |

인덱스 이름도 테이블 이름을 따라 변경했고, `idx_<table>_<cols>` 규칙에서 벗어나 있던 `idx_sst_tag_id`는 `idx_sunrei_spot_tag_tag_id`로 바꿨습니다.

Kotlin object 이름(`Sunreis`, `UserTable` 등)은 이번 변경 범위에서 제외했습니다.

## 예약어 처리

`user`는 Postgres 예약어라 마이그레이션에서 `"user"`로 인용했습니다. Exposed는 키워드에 해당하는 식별자를 자동으로 인용하므로 Kotlin 쪽은 `Table("user")`로 충분합니다 (프로젝트가 쓰는 exposed-core 0.44.1의 키워드 목록에 `USER`가 포함된 것을 확인).

## ⚠️ 배포 시 주의

V1 baseline을 직접 수정했으므로 **이미 V1이 적용된 환경은 Flyway 체크섬이 불일치**합니다. DB를 드롭한 뒤 재적용해야 합니다. V1 주석에 이미 같은 전제가 적혀 있지만, prod 데이터 여부를 배포 전에 확인해 주세요.

## 검증

로컬 Postgres에 임시 DB를 만들어 확인했습니다 (기존 `sunrei` DB는 건드리지 않았고 임시 DB는 삭제했습니다).

- `compileKotlin` 성공
- 수정된 V1을 빈 DB에 적용 → 8개 테이블 전부 단수로 생성, admin seed row 정상 INSERT
- 별도의 빈 DB에 `seedData=true`로 서버를 띄워 Exposed의 `SchemaUtils.create`가 스키마를 만들게 함 → `user` 테이블 정상 생성되어 자동 인용이 실제로 동작함을 확인
- 태그 필터를 준 `GET /api/map`(조인 테이블 경유) 200, `GET /api/tags` 200, 로그에 SQL 예외 0건

## 남겨둔 것

`SPEC.md`의 스키마 블록에는 옛 이름이 남아 있습니다. #32에서 `sunrei_spot.description`을 제거할 때도 갱신하지 않은 걸 보면 실행 완료된 계획 문서로 고정해 두는 것으로 보여 손대지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
