### PR TITLE
fix(frontend): Google Maps 로드 시 GIS 스크립트를 건너뛰어 로그인이 무한 로딩되는 버그 수정

### DIFF
--- a/sunrei-frontend/packages/sunrei-admin/src/app/login/page.tsx
+++ b/sunrei-frontend/packages/sunrei-admin/src/app/login/page.tsx
@@ -30,8 +30,9 @@ export default function LoginPage() {
       setLoading(true);
       setError(null);
 
-      // Load Google Identity Services
-      if (!window.google) {
+      // Load Google Identity Services. Google Maps also owns window.google,
+      // so check for the GIS namespace specifically.
+      if (!window.google?.accounts?.oauth2) {
         await new Promise<void>((resolve, reject) => {
           const script = document.createElement('script');
           script.src = 'https://accounts.google.com/gsi/client';

--- a/sunrei-frontend/packages/sunrei-app/src/components/auth.tsx
+++ b/sunrei-frontend/packages/sunrei-app/src/components/auth.tsx
@@ -48,7 +48,9 @@ export function useGoogleLogin(onSuccess?: () => void) {
     setError(false);
     setLoading(true);
     try {
-      if (!window.google) {
+      // Google Maps also owns window.google, so check for the GIS namespace
+      // specifically — otherwise the GSI script is never loaded on map pages.
+      if (!window.google?.accounts?.oauth2) {
         await new Promise<void>((resolve, reject) => {
           const sc = document.createElement('script');
           sc.src = 'https://accounts.google.com/gsi/client';
@@ -83,7 +85,8 @@ export function useGoogleLogin(onSuccess?: () => void) {
           setLoading(false);
         },
       });
-      client?.requestAccessToken();
+      if (!client) throw new Error('gis');
+      client.requestAccessToken();
     } catch {
       setError(true);
       setLoading(false);


### PR DESCRIPTION
## 문제

`sunrei.yongseongkimm.com`(app)에서 Google 로그인을 누르면 팝업도 에러도 없이 스피너만 무한히 도는 버그.

## 원인

app은 지도 서비스라 **Google Maps API가 `window.google`을 먼저 생성**한다. 로그인 코드는 `if (!window.google)`로 GIS(Google Identity Services) 스크립트 로드 여부를 판단하기 때문에 GIS 스크립트를 건너뛰고, 이후 흐름이 optional chaining으로 조용히 no-op이 된다:

```
window.google?.accounts?.oauth2?.initTokenClient(...) // → undefined
client?.requestAccessToken()                          // → 아무 일도 안 일어남
```

admin은 `/login` 페이지에 Maps가 없어 정상 동작했다 (라이브 사이트 headless 재현으로 확인: GIS 요청 0건, 팝업 0개, 무한 스피너).

## 수정

- GIS 로드 판단을 `if (!window.google?.accounts?.oauth2)`로 변경 (app + admin 동일 수정)
- app에서 token client 생성 실패 시 조용히 넘어가지 않고 에러를 던져 에러 UI가 표시되도록 변경

## 검증

프로덕션과 동일한 env로 로컬 빌드 후 headless 브라우저 테스트:
- 수정 전(라이브): Maps 로드 상태에서 클릭 → GIS 미로드, 팝업 없음, 무한 스피너
- 수정 후(로컬): 동일 조건에서 GIS 정상 로드, **팝업 정상 오픈**, 에러 시 스피너 해제 확인
- admin 타입 체크(tsc) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)