### PR TITLE
chore(deploy): sunrei-secrets를 SOPS로 이 레포에서 관리

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,17 @@
+# SOPS encryption rules.
+#
+# The sunrei Kubernetes Secret lives in deploy/secrets/secrets.enc.yaml,
+# encrypted with SOPS + Google Cloud KMS. Safe to commit: values are
+# encrypted, key names stay readable so you can see at a glance which
+# keys the project uses. Decrypting requires GCP application-default
+# credentials with cloudkms decrypt permission on the key below.
+#
+# Apply (never client-side `kubectl apply` — it leaks plaintext into the
+# last-applied-configuration annotation):
+#   sops -d deploy/secrets/secrets.enc.yaml | kubectl create -f -   # or replace
+
+creation_rules:
+  # k8s Secret manifests: encrypt only data/stringData values.
+  - path_regex: \.enc\.yaml$
+    gcp_kms: projects/default-487602/locations/asia-northeast3/keyRings/homelab-secrets/cryptoKeys/sops-key
+    encrypted_regex: ^(data|stringData)$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ SunreiSpot에 연결되는 bilingual 태그. `label_en`, `label_ko`를 가지며
 - Release flow: `scripts/release.sh` → auto-increment version → create and push tag → GitHub Actions builds images → GitHub Actions updates Helm chart → ArgoCD auto-syncs
 - Version convention: git tags use `v` prefix (`v0.12.0`), image tags and chart `version` strip it (`0.12.0`), chart `appVersion` keeps it (`v0.12.0`)
 - Verify deployment: `kubectl get pods -n sunrei`, `argocd app get sunrei`
+- Secrets: `deploy/secrets/secrets.enc.yaml` (SOPS + GCP KMS, rules in `.sops.yaml`) — 수동 적용: `sops -d ... | kubectl create/replace -f -` (`kubectl apply` 금지)
 - Common issue: `ImagePullBackOff` — check for `v` prefix mismatch between chart values and actual image tags
 
 자세한 내용은 `deploy/README.md` 참고.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ SunreiSpot에 연결되는 bilingual 태그. `label_en`, `label_ko`를 가지며
 - Release flow: `scripts/release.sh` → auto-increment version → create and push tag → GitHub Actions builds images → GitHub Actions updates Helm chart → ArgoCD auto-syncs
 - Version convention: git tags use `v` prefix (`v0.12.0`), image tags and chart `version` strip it (`0.12.0`), chart `appVersion` keeps it (`v0.12.0`)
 - Verify deployment: `kubectl get pods -n sunrei`, `argocd app get sunrei`
-- Secrets: `deploy/secrets/secrets.enc.yaml` (SOPS + GCP KMS, rules in `.sops.yaml`) — 수동 적용: `sops -d ... | kubectl create/replace -f -` (`kubectl apply` 금지)
+- Secrets: 앱 소유 키는 `deploy/secrets/secrets.enc.yaml` (SOPS + GCP KMS, rules in `.sops.yaml`), 인프라 종속 키(`database-host/password`)는 homelab-infra의 `sunrei-infra-secrets` — 수동 적용: `sops -d ... | kubectl create/replace -f -` (`kubectl apply` 금지)
 - Common issue: `ImagePullBackOff` — check for `v` prefix mismatch between chart values and actual image tags
 
 자세한 내용은 `deploy/README.md` 참고.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -85,11 +85,23 @@ deploy/helm/
 
 ## Secrets
 
-Secrets are stored in a manually-created Kubernetes secret:
+Secrets live in this repo at `deploy/secrets/secrets.enc.yaml` — a Kubernetes
+Secret manifest encrypted with [SOPS](https://github.com/getsops/sops) + Google
+Cloud KMS (rules in `.sops.yaml` at the repo root). Values are encrypted; key
+names stay readable, so the file itself documents which keys the project uses.
 
+Editing and applying (requires GCP credentials with decrypt permission on the
+KMS key):
+
+```bash
+sops deploy/secrets/secrets.enc.yaml                         # edit in place
+sops -d deploy/secrets/secrets.enc.yaml | kubectl create -f -  # first apply
+sops -d deploy/secrets/secrets.enc.yaml | kubectl replace -f - # re-apply
 ```
-kubectl -n sunrei get secret sunrei-secrets
-```
+
+Never client-side `kubectl apply` a decrypted Secret — it leaks the plaintext
+into the `last-applied-configuration` annotation. ArgoCD does not manage this
+file; applying it is a manual step.
 
 Required keys:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -85,10 +85,17 @@ deploy/helm/
 
 ## Secrets
 
-Secrets live in this repo at `deploy/secrets/secrets.enc.yaml` — a Kubernetes
-Secret manifest encrypted with [SOPS](https://github.com/getsops/sops) + Google
-Cloud KMS (rules in `.sops.yaml` at the repo root). Values are encrypted; key
-names stay readable, so the file itself documents which keys the project uses.
+Secrets are split into two Kubernetes Secrets by ownership:
+
+- **`sunrei-secrets`** (app-owned) — managed in this repo at
+  `deploy/secrets/secrets.enc.yaml`, a Secret manifest encrypted with
+  [SOPS](https://github.com/getsops/sops) + Google Cloud KMS (rules in
+  `.sops.yaml` at the repo root). Values are encrypted; key names stay
+  readable, so the file itself documents which keys the project uses.
+- **`sunrei-infra-secrets`** (infrastructure-dependent: `database-host`,
+  `database-password`) — managed in the homelab-infra repo
+  (`k8s/sunrei/infra-secrets.enc.yaml`). These change when the app moves to a
+  different cluster/DB, so they live with the infrastructure.
 
 Editing and applying (requires GCP credentials with decrypt permission on the
 KMS key):
@@ -100,23 +107,23 @@ sops -d deploy/secrets/secrets.enc.yaml | kubectl replace -f - # re-apply
 ```
 
 Never client-side `kubectl apply` a decrypted Secret — it leaks the plaintext
-into the `last-applied-configuration` annotation. ArgoCD does not manage this
-file; applying it is a manual step.
+into the `last-applied-configuration` annotation. ArgoCD does not manage these
+files; applying them is a manual step.
 
 Required keys:
 
-| Key | Used by |
-|-----|---------|
-| `google-maps-api-key` | admin, app |
-| `google-maps-map-id` | admin |
-| `google-oauth-client-id` | admin, app, server |
-| `google-oauth-client-secret` | server |
-| `database-host` | server |
-| `database-password` | server |
-| `jwt-page-token-secret` | server |
-| `aws-access-key-id` | server |
-| `aws-secret-access-key` | server |
-| `auth-jwt-secret` | server |
+| Key | Secret | Used by |
+|-----|--------|---------|
+| `google-maps-api-key` | sunrei-secrets | admin, app |
+| `google-maps-map-id` | sunrei-secrets | admin |
+| `google-oauth-client-id` | sunrei-secrets | admin, app, server |
+| `google-oauth-client-secret` | sunrei-secrets | server |
+| `jwt-page-token-secret` | sunrei-secrets | server |
+| `aws-access-key-id` | sunrei-secrets | server |
+| `aws-secret-access-key` | sunrei-secrets | server |
+| `auth-jwt-secret` | sunrei-secrets | server |
+| `database-host` | sunrei-infra-secrets | server, migration |
+| `database-password` | sunrei-infra-secrets | server, migration |
 
 If a key is missing, the pod will fail to start with `CreateContainerConfigError`.
 

--- a/deploy/helm/templates/migration-job.yaml
+++ b/deploy/helm/templates/migration-job.yaml
@@ -23,14 +23,14 @@ spec:
             - name: DATABASE_HOST
               valueFrom:
                 secretKeyRef:
-                  name: sunrei-secrets
+                  name: sunrei-infra-secrets
                   key: database-host
             - name: FLYWAY_USER
               value: "postgres"
             - name: FLYWAY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: sunrei-secrets
+                  name: sunrei-infra-secrets
                   key: database-password
           resources:
             limits:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -82,7 +82,7 @@ server:
     - name: DATABASE_HOST
       valueFrom:
         secretKeyRef:
-          name: sunrei-secrets
+          name: sunrei-infra-secrets
           key: database-host
     - name: DATABASE_PORT
       value: "5432"
@@ -93,7 +93,7 @@ server:
     - name: DATABASE_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: sunrei-secrets
+          name: sunrei-infra-secrets
           key: database-password
     - name: JWT_PAGE_TOKEN_SECRET
       valueFrom:

--- a/deploy/secrets/secrets.enc.yaml
+++ b/deploy/secrets/secrets.enc.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: sunrei-secrets
+    namespace: sunrei
+type: Opaque
+stringData:
+    database-host: ENC[AES256_GCM,data:Euzktor5XkjMNxyTdiZT8rpC1KGNXDPl+tZ1xGfVUTCd+JA=,iv:xP0KtuWMVdRXYlDHlWbswQ3ZTGpl6PqHTVThWQVjTZE=,tag:R36uCdDfxiIP3u1aM3nauw==,type:str]
+    google-maps-map-id: ENC[AES256_GCM,data:9TY6QYXvXKmHw6o=,iv:uE56Ie8aC1hIVlRZMz91X3MzyTOrBnRfT2C5h+bsGRg=,tag:I20L2salk1v/0lga2g6hWg==,type:str]
+    database-password: ENC[AES256_GCM,data:4KUmRMhcxA/FLYNV,iv:j25hZgTh4B8BxchXgtwXgkD/Amgns48/HuZr2ZLMjzU=,tag:m8haRcSSOQCjguopZPj9tg==,type:str]
+    google-maps-api-key: ENC[AES256_GCM,data:5xrKsTSc3vHSZ3SEGnhZhdQQEsn4ThVp9SBd1FPepX67kQ1Ir7W+,iv:pjqq2px1tDIaPIlRJAsk+F/DIzRvlrYnYv8giN4J/ro=,tag:CpqfIHCx1/IdIR5qk91oXQ==,type:str]
+    jwt-page-token-secret: ENC[AES256_GCM,data:d1JMyIeFu6I6SJnWwA==,iv:DkpEb26W84lrOy2xYFKe6eIMpfk0SNByQTT9maf0XPQ=,tag:6yRR1Au+MN/QjCQgFNRvKg==,type:str]
+    aws-access-key-id: ENC[AES256_GCM,data:I6/u+OtQp06j39vwk1OCzFUGDz0=,iv:5MVkpeWuROWBv6i+HbC0uitCqJMZq6zl8CxSMSOM7qw=,tag:1vGc+d7Pv/6neqzsGNcdXA==,type:str]
+    aws-secret-access-key: ENC[AES256_GCM,data:QKF326zkYaJ7/zHR+yXJCppGPpKVIM85ERreXbb35LMUDZsVYXe/GQ==,iv:uKLGoXa/FfmWWFagLRGh+7S3/22sxHIC1IA4McO2PSA=,tag:74cXYIZbjptodTQ2ehFBoA==,type:str]
+    google-oauth-client-id: ENC[AES256_GCM,data:Yq5dp6X2Dp6EJLXnNvs8A5/N2PUpQvWIh3tlgowSopv1nJnjAHDAH4tx/2z3rjQNhPJo6kES3kNKJF86Zr1X4p5yGarNf6uK,iv:084alSs06eFQKaRUkyRZrcxV247B5Hap+HRWOnItk9E=,tag:6HoPHYnrmqClZ56GeLk6kQ==,type:str]
+    google-oauth-client-secret: ENC[AES256_GCM,data:CRzxnQV8slJRxdmRJtL23F8WOQ8xLtoJ6XPOfBKFFN3rWeo=,iv:lwvquJUeXHnSscQKhxC/7jufOKUjb1p+5P+7tVEVvs0=,tag:7D2vw3L9keKBYHig42MH8A==,type:str]
+    auth-jwt-secret: ENC[AES256_GCM,data:ZWzDo38CjqEfEUGnSi0=,iv:OFNk0ROm6vPZ7LORbxVxxtUKfLdQvToRSWVH0s6DElY=,tag:/anO1bfSCulSXT4o6/3hqw==,type:str]
+sops:
+    gcp_kms:
+        - resource_id: projects/default-487602/locations/asia-northeast3/keyRings/homelab-secrets/cryptoKeys/sops-key
+          created_at: "2026-02-16T03:26:23Z"
+          enc: CiQAcUuTffwsCGC6hFt6BuyytZ8oiq3SvKvnO2uU98wMKPaTmWYSSQBpUNVoGS+2SwwOfhv3NkL0tWLnHj5uDu+u9QnKT+fSEBupjlwCz3nOaavMS2AZTI3ssD9PK/2zTEIk2mtWMCow2OUlUGHEQv8=
+    lastmodified: "2026-02-16T03:26:24Z"
+    mac: ENC[AES256_GCM,data:3D1MRlvIw+LUqGtkiVM+GAa5mBpUgjvBmPGohcUUT1wwbsaJh5kEfn0ke1d7iOXnnmcpOpYPRLb2YlmrPYKaXt0GRzn/cZR+E332vXlN34XL8orG+a3JtPMYI4Qc7+Avikx97Tcug4q3ddEJkS4o6Xfpy/GS3Z4SN5bH8Jgw6GE=,iv:9Ll3CSkPFNV0GTSl3M8iPsO9bSaOdmlUZTekdArCFpQ=,tag:5cnmReV/muMhjECt/igMAg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/deploy/secrets/secrets.enc.yaml
+++ b/deploy/secrets/secrets.enc.yaml
@@ -5,9 +5,7 @@ metadata:
     namespace: sunrei
 type: Opaque
 stringData:
-    database-host: ENC[AES256_GCM,data:Euzktor5XkjMNxyTdiZT8rpC1KGNXDPl+tZ1xGfVUTCd+JA=,iv:xP0KtuWMVdRXYlDHlWbswQ3ZTGpl6PqHTVThWQVjTZE=,tag:R36uCdDfxiIP3u1aM3nauw==,type:str]
     google-maps-map-id: ENC[AES256_GCM,data:9TY6QYXvXKmHw6o=,iv:uE56Ie8aC1hIVlRZMz91X3MzyTOrBnRfT2C5h+bsGRg=,tag:I20L2salk1v/0lga2g6hWg==,type:str]
-    database-password: ENC[AES256_GCM,data:4KUmRMhcxA/FLYNV,iv:j25hZgTh4B8BxchXgtwXgkD/Amgns48/HuZr2ZLMjzU=,tag:m8haRcSSOQCjguopZPj9tg==,type:str]
     google-maps-api-key: ENC[AES256_GCM,data:5xrKsTSc3vHSZ3SEGnhZhdQQEsn4ThVp9SBd1FPepX67kQ1Ir7W+,iv:pjqq2px1tDIaPIlRJAsk+F/DIzRvlrYnYv8giN4J/ro=,tag:CpqfIHCx1/IdIR5qk91oXQ==,type:str]
     jwt-page-token-secret: ENC[AES256_GCM,data:d1JMyIeFu6I6SJnWwA==,iv:DkpEb26W84lrOy2xYFKe6eIMpfk0SNByQTT9maf0XPQ=,tag:6yRR1Au+MN/QjCQgFNRvKg==,type:str]
     aws-access-key-id: ENC[AES256_GCM,data:I6/u+OtQp06j39vwk1OCzFUGDz0=,iv:5MVkpeWuROWBv6i+HbC0uitCqJMZq6zl8CxSMSOM7qw=,tag:1vGc+d7Pv/6neqzsGNcdXA==,type:str]
@@ -20,7 +18,7 @@ sops:
         - resource_id: projects/default-487602/locations/asia-northeast3/keyRings/homelab-secrets/cryptoKeys/sops-key
           created_at: "2026-02-16T03:26:23Z"
           enc: CiQAcUuTffwsCGC6hFt6BuyytZ8oiq3SvKvnO2uU98wMKPaTmWYSSQBpUNVoGS+2SwwOfhv3NkL0tWLnHj5uDu+u9QnKT+fSEBupjlwCz3nOaavMS2AZTI3ssD9PK/2zTEIk2mtWMCow2OUlUGHEQv8=
-    lastmodified: "2026-02-16T03:26:24Z"
-    mac: ENC[AES256_GCM,data:3D1MRlvIw+LUqGtkiVM+GAa5mBpUgjvBmPGohcUUT1wwbsaJh5kEfn0ke1d7iOXnnmcpOpYPRLb2YlmrPYKaXt0GRzn/cZR+E332vXlN34XL8orG+a3JtPMYI4Qc7+Avikx97Tcug4q3ddEJkS4o6Xfpy/GS3Z4SN5bH8Jgw6GE=,iv:9Ll3CSkPFNV0GTSl3M8iPsO9bSaOdmlUZTekdArCFpQ=,tag:5cnmReV/muMhjECt/igMAg==,type:str]
+    lastmodified: "2026-07-26T07:13:08Z"
+    mac: ENC[AES256_GCM,data:+PUBypxQW65r2zvGOQMrZ39f+sjTzaIW5jwx/9s2pSnMGt7t0WTeBmYsaQYrTouBwgSMX5/5dU8K0geqI1u4Fk5agByh6ogK1/Vvkyxe7NiTylEzNR3Mn4tkxKihpbnzH/QW5FZ/zsWp2YScIuGLlLPLOe/6PeUz+q2pgS+NRPQ=,iv:KFkAKq7Bc3snKJK4H9NPPSin2crmMqMZN5wDUDIOxhU=,tag:pOfcUfVc6TC414LUXSqzew==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.11.0


### PR DESCRIPTION
## 배경

`sunrei-secrets` Secret이 homelab-infra(`k8s/sunrei/secrets.enc.yaml`)에 있어서 프로젝트에서 어떤 키를 쓰는지 확인하려면 매번 다른 레포를 봐야 했다.

## 변경

시크릿을 소유 기준으로 두 Secret으로 분리:

- **`sunrei-secrets` (앱 소유, 이 레포)** — `deploy/secrets/secrets.enc.yaml`: Google Maps/OAuth, JWT, AWS 등 앱 키 8개. SOPS(GCP KMS) 암호화로 **키 이름은 평문, 값만 암호화** — 이 파일이 "sunrei가 쓰는 키 목록" 문서 역할 (trader와 같은 패턴, 같은 KMS 키).
- **`sunrei-infra-secrets` (인프라 종속, homelab-infra)** — `database-host`, `database-password`는 클러스터/DB가 바뀌면 함께 바뀌는 값이라 homelab-infra에 남김 (homelab-infra#34).
- helm: server env와 migration Job의 DB 참조를 `sunrei-infra-secrets`로 변경 (`helm template` 렌더 확인).
- `.sops.yaml`, `deploy/README.md`, `AGENTS.md` 문서화.

## 운영 방식 (변경 없음)

적용은 수동, ArgoCD는 시크릿 파일을 관리하지 않는다:

```bash
sops deploy/secrets/secrets.enc.yaml                          # 편집
sops -d deploy/secrets/secrets.enc.yaml | kubectl replace -f - # 적용
```

`kubectl apply` 금지 (plaintext가 last-applied annotation에 남음).

## 검증 / 배포 안전성

- 분리 후 두 파일 모두 `sops -d` 복호화 정상.
- **클러스터에 `sunrei-infra-secrets`(database-host/password 2키)를 이미 생성해 둠** — 이 PR이 머지되어 ArgoCD가 sync해도 pod가 깨지지 않는다. 머지 순서 의존성 없음.
- 기존 in-cluster `sunrei-secrets`의 DB 키 2개는 남아 있어도 무해하며, 정리하려면 머지 후 `sops -d deploy/secrets/secrets.enc.yaml | kubectl replace -f -`로 8키 버전으로 교체하면 된다.

## 참고

이 레포는 public이므로 암호문과 KMS 키 경로가 공개된다. KMS IAM(decrypt 권한) 관리가 유일한 방어선이 되는 점은 인지하고 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
