### PR TITLE
feat(skills): 로그인 없이 admin JWT를 발급해 YouTube 인제스트가 admin API를 쓰도록 변경

### DIFF
--- a/.claude/scripts/auth/mint_token.py
+++ b/.claude/scripts/auth/mint_token.py
@@ -1,0 +1,112 @@
+"""
+Sunrei Admin JWT Minting (no login flow)
+
+Signs a short-lived admin JWT with the server's auth-jwt-secret so automation
+can call /admin endpoints without the Google OAuth browser flow. The server
+validates admin JWTs statelessly (HS256, issuer "sunrei", non-blank
+userId/email, role == "admin"), so a locally signed token is accepted exactly
+like one issued by POST /api/auth/google.
+
+The token is printed to stdout and nothing else, so it can be captured inline
+and kept out of files:
+
+    TOKEN=$(python3 .claude/scripts/auth/mint_token.py)
+
+Ability to mint is gated by KMS access: the signing secret is resolved from
+AUTH_JWT_SECRET, or by decrypting deploy/secrets/secrets.enc.yaml with SOPS
+(needs GCP credentials with decrypt permission on the homelab-secrets key).
+
+Because this secret also signs real user sessions, keep the lifetime short and
+do not persist the token. To revoke, rotate auth-jwt-secret (costs one
+re-login per user).
+
+Usage:
+    python3 .claude/scripts/auth/mint_token.py [--minutes 60]
+"""
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SECRETS_FILE = REPO_ROOT / "deploy" / "secrets" / "secrets.enc.yaml"
+
+ISSUER = "sunrei"  # must equal auth.jwt.issuer in sunrei-server/application.conf
+ADMIN_USER_ID = "U00000000000000000000000000"  # admin seeded by V1__init.sql
+ADMIN_EMAIL = "nelson@vcnc.co.kr"
+
+
+def resolve_secret() -> str:
+    secret = os.environ.get("AUTH_JWT_SECRET")
+    if secret:
+        return secret
+
+    result = subprocess.run(
+        ["sops", "-d", "--extract", '["stringData"]["auth-jwt-secret"]', str(SECRETS_FILE)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        sys.exit(
+            "auth-jwt-secret 복호화 실패. KMS decrypt 권한이 있는 계정으로 "
+            "gcloud 인증이 되어 있는지 확인하세요.\n"
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def mint(secret: str, minutes: int, user_id: str, email: str) -> tuple[str, int]:
+    issued_at = int(time.time())
+    expires_at = issued_at + minutes * 60
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    payload = b64url(
+        json.dumps(
+            {
+                "iss": ISSUER,
+                "sub": user_id,
+                "userId": user_id,
+                "email": email,
+                "role": "admin",
+                "iat": issued_at,
+                "exp": expires_at,
+            },
+            separators=(",", ":"),
+        ).encode()
+    )
+    signing_input = f"{header}.{payload}".encode()
+    signature = b64url(hmac.new(secret.encode(), signing_input, hashlib.sha256).digest())
+
+    return f"{header}.{payload}.{signature}", expires_at
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Mint a short-lived Sunrei admin JWT")
+    parser.add_argument("--minutes", type=int, default=60, help="lifetime in minutes (default 60)")
+    parser.add_argument("--user-id", default=ADMIN_USER_ID)
+    parser.add_argument("--email", default=ADMIN_EMAIL)
+    args = parser.parse_args()
+
+    if args.minutes < 1:
+        sys.exit("--minutes must be at least 1")
+
+    token, expires_at = mint(resolve_secret(), args.minutes, args.user_id, args.email)
+
+    print(token)
+    expires = time.strftime("%H:%M:%S", time.localtime(expires_at))
+    print(f"admin JWT for {args.email}, expires {expires}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/youtube-create-sunrei/SKILL.md
+++ b/.claude/skills/youtube-create-sunrei/SKILL.md
@@ -12,7 +12,7 @@ Create a Sunrei entity with SunreiSpots via the server admin API using collected
 - `.claude/workspace/youtube/{ID}/video_info.json` must exist
 - `.claude/workspace/youtube/{ID}/locations.json` must exist
 - The sunrei-server must be running (for API calls in Steps 2–5)
-- `SUNREI_ADMIN_TOKEN` must be set in `.claude/.env`. If missing or expired, tell the user to run: `uv run --with requests python .claude/scripts/auth/login.py`
+- Admin API access, minted locally in Step 2 — no login flow. Requires `sops` plus GCP credentials with decrypt permission on the homelab KMS key (`gcloud auth application-default login` if decryption fails).
 - `aws-vault` and `aws` CLI must be installed (for S3 registry access in Steps 1.5 and 6)
 
 ## Steps
@@ -75,13 +75,19 @@ curl -s http://localhost:3030/health
 
 If the health check fails, ask the user to start the server first.
 
-Read the admin token from `.claude/.env`:
+Mint a short-lived admin token for the API calls in Steps 4–6:
 
 ```bash
-TOKEN=$SUNREI_ADMIN_TOKEN
+TOKEN=$(python3 .claude/scripts/auth/mint_token.py)
 ```
 
-The token is auto-loaded by `_load_dot_env()` from `.claude/.env`. If `SUNREI_ADMIN_TOKEN` is not set, tell the user to run: `uv run --with requests python .claude/scripts/auth/login.py`
+This signs an admin JWT with the server's `auth-jwt-secret` (decrypted from
+`deploy/secrets/secrets.enc.yaml` via SOPS), so no browser login is needed. The token
+lasts 60 minutes — keep it in the shell variable and never write it to a file. If the
+ingest run outruns the token, mint another one; pass `--minutes N` for a longer window.
+
+If minting fails with a decryption error, the GCP credentials lack KMS decrypt permission —
+tell the user to run `gcloud auth application-default login`.
 
 ### 3. Compose Sunrei Details
 

--- a/.claude/skills/youtube-to-sunrei/SKILL.md
+++ b/.claude/skills/youtube-to-sunrei/SKILL.md
@@ -57,7 +57,7 @@ Checkpoint: User must approve location list before Sunrei creation.
 
 Execute the `/youtube-create-sunrei` skill.
 
-- Requires admin authentication: `SUNREI_ADMIN_TOKEN` must be set in `.claude/.env`. If missing, run: `uv run --with requests python .claude/scripts/auth/login.py`
+- Admin authentication is minted locally — `TOKEN=$(python3 .claude/scripts/auth/mint_token.py)`, no login flow. Needs `sops` + GCP KMS decrypt permission
 - One playlist/trip = one Sunrei: title = playlist title, link = playlist URL, summary/description derived from transcripts; the channel becomes the Source. Select tags if available
 - Build SunreiSpots from extracted locations (spot `context` = each location's per-place summary)
 - Create via server admin API (all requests require `Authorization: Bearer ${TOKEN}` header)


### PR DESCRIPTION
## 배경

YouTube → Sunrei 인제스트 스킬은 지금까지 브라우저 Google OAuth(`login.py`)로 받은 `SUNREI_ADMIN_TOKEN`을 `.claude/.env`에 저장해 admin API를 호출했다. 매번 로그인 브라우저 플로우를 거쳐야 해서 자동 인제스트가 끊긴다.

## 변경

서버의 admin JWT 검증이 stateless(`Authentication.kt`: HS256, issuer `sunrei`, `role == "admin"`, DB 조회 없음)라는 점을 이용해, 로그인 없이 `auth-jwt-secret`으로 직접 admin JWT를 서명한다.

- **`.claude/scripts/auth/mint_token.py`** (신규) — 시크릿을 `AUTH_JWT_SECRET` 환경변수 또는 `deploy/secrets/secrets.enc.yaml`의 SOPS 복호화로 얻어 HS256 admin JWT를 서명하고 **stdout으로만** 출력. 기본 만료 60분(`--minutes N` 조정), 파일에 저장하지 않음.
- **`youtube-create-sunrei` / `youtube-to-sunrei` SKILL.md** — 로그인 안내를 `TOKEN=$(python3 .claude/scripts/auth/mint_token.py)` 인라인 발급으로 교체.

## 보안 특성

- 발급 권한은 **KMS decrypt IAM으로 게이트**된다 — 이미 시크릿에 접근 가능한 사람만 발급할 수 있어 새 권한을 만들지 않는다.
- 이 시크릿은 실제 사용자 세션도 서명하므로 유출 시 폐기 수단은 `auth-jwt-secret` 로테이션(사용자당 재로그인 1회)뿐이다. 따라서 토큰을 짧게 유지하고 파일/CI/타 머신에 두지 않는다. 이 스킬은 로컬 세션 전용.
- `login.py`는 실제 계정 동작 확인용으로 남겨둔다.

## 검증

더미 시크릿으로 발급한 토큰이 서버 요구사항(alg HS256, iss `sunrei`, role `admin`, userId/email non-blank, 서명 유효)을 모두 만족함을 확인. `py_compile` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)