### PR TITLE
feat(youtube): description-based extraction scripts + re-extracted data

### DIFF
--- a/.agents/skills/youtube-create-sunrei/SKILL.md
+++ b/.agents/skills/youtube-create-sunrei/SKILL.md
@@ -15,7 +15,8 @@ server admin API.
 - Run sunrei-server before making local API requests.
 - Use `sops` and GCP credentials that can decrypt the homelab KMS key. If
   decryption fails, run `gcloud auth application-default login`.
-- Install `aws-vault` and the AWS CLI for the channel registry.
+- Use the Admin API for the channel registry. The server owns the S3
+  credentials; do not decrypt or pass AWS keys for registry updates.
 
 ## Steps
 
@@ -64,11 +65,11 @@ HTTP 403.
 
 ### 3. Check the Channel Registry
 
-Ask which `aws-vault` profile to use and keep it for the registry update in
-step 7. Download the channel registry:
+Read the channel registry through the Admin API:
 
 ```bash
-aws-vault exec {profile} -- aws s3 cp s3://sunrei-resources/youtube/{channelId}.json -
+curl -s -H "Authorization: Bearer ${TOKEN}" \
+  "{SERVER_URL}/admin/resources/youtube/{channelId}"
 ```
 
 The registry contains a `sunreis` array:
@@ -279,19 +280,23 @@ in Step 3), update it with Step 8 rather than creating a duplicate.
 On HTTP 201:
 
 - Show the Sunrei ID, title, spot count, and admin link.
-- Update the S3 channel registry with the `aws-vault` profile selected in
-  step 3.
+- Update the S3-backed channel registry through the Admin API.
 
-  1. Download the existing registry:
+  1. Read the existing registry:
      ```bash
-     aws-vault exec {profile} -- aws s3 cp s3://sunrei-resources/youtube/{channelId}.json /tmp/registry.json
+     curl -s -H "Authorization: Bearer ${TOKEN}" \
+       "{SERVER_URL}/admin/resources/youtube/{channelId}"
      ```
   2. If it exists, append the new entry to `sunreis`.
   3. If it does not exist, create a registry with `channelName`, the `link` from
      `video_info.json`, and one `sunreis` entry.
-  4. Upload the updated registry:
+  4. Save the updated registry:
      ```bash
-     aws-vault exec {profile} -- aws s3 cp /tmp/registry.json s3://sunrei-resources/youtube/{channelId}.json --content-type application/json
+     curl -s -X PUT \
+       -H "Authorization: Bearer ${TOKEN}" \
+       -H "Content-Type: application/json" \
+       --data-binary @/tmp/registry.json \
+       "{SERVER_URL}/admin/resources/youtube/{channelId}"
      ```
 
   Use this entry format:
@@ -328,7 +333,7 @@ uploads the result:
 
 ```bash
 uv run python .claude/scripts/youtube/registry_update.py <channelId> <sunreiId1,sunreiId2,...> \
-  [--profile aws-vault-profile] [--channel-name "..."] [--channel-link "..."] [--commit]
+  [--channel-name "..."] [--channel-link "..."] [--commit]
 ```
 
 Pass every live Sunrei for that channel so stale entries are dropped. Run the

--- a/.agents/skills/youtube-create-sunrei/SKILL.md
+++ b/.agents/skills/youtube-create-sunrei/SKILL.md
@@ -268,6 +268,12 @@ review, so pass a transcript-based summary with `--summary` and review the
 result in the admin app. On success, it writes `_create_manifest.json` for the
 registry update in step 7.
 
+Creation produces a draft (`published: false`). Publish only when requested:
+`PUT {SERVER_URL}/admin/sunreis/{id}` with `{"published": true}`.
+
+If a Sunrei with this playlist/video link already exists (HTTP 409, or one found
+in Step 3), update it with Step 8 rather than creating a duplicate.
+
 ### 7. Handle the Response and Update the Registry
 
 On HTTP 201:
@@ -313,6 +319,21 @@ For HTTP 409:
 - Explain that a Sunrei with the same link exists.
 - Show `existingId` and ask whether to skip or update it.
 
+#### Rebuild a stale registry
+
+If step 3 found stale registry entries, rebuild the registry from live Sunrei
+records instead of appending to dead IDs. The helper downloads the registry,
+fetches spots for the given Sunrei IDs, rebuilds the `sunreis` array, and
+uploads the result:
+
+```bash
+uv run python .claude/scripts/youtube/registry_update.py <channelId> <sunreiId1,sunreiId2,...> \
+  [--profile aws-vault-profile] [--channel-name "..."] [--channel-link "..."] [--commit]
+```
+
+Pass every live Sunrei for that channel so stale entries are dropped. Run the
+helper once per channel; one channel can contain several playlists or Sunrei.
+
 For any other error:
 
 - Show the error and offer to retry after correcting the payload.
@@ -323,15 +344,27 @@ For any other error:
 Edit via `PUT {SERVER_URL}/admin/sunreis/{id}`:
 
 - Send only top-level fields that should change. All are optional.
-- Treat `spots` as a merge. An item with an `id` updates that spot and must
-  include `title`. An item without an `id` creates a spot.
-  `{"id": "SS...", "delete": true}` soft-deletes one. Omitted spots remain
-  unchanged.
+- Include `spots` only when changing spots. When `spots` is present, an item
+  with an `id` updates that spot, an item without an `id` creates a new spot,
+  and any existing spot whose `id` is omitted is soft-deleted.
+- To replace all spots, send only the new spot list. Explicit delete entries are
+  rarely needed, because every spot item must include `title`, including
+  `{ "id": "...", "_delete": true }`.
+- Tags update per spot. Send `tagIds` or `tagLabels` only when replacing that
+  spot's tag set.
 - Send one PUT per Sunrei. Start from a fresh `GET /admin/sunreis/{id}`, combine
   all changes, and submit them together. Concurrent PUT requests can overwrite
   one another.
 - If concurrent updates have already left the data inconsistent, recreate the
   Sunrei from `locations.json` instead of repairing spots individually.
+
+For a full spot replacement from `locations.json` (preserves the Sunrei ID,
+source, and published status), use the helper:
+
+```bash
+uv run python .claude/scripts/youtube/update_sunrei_spots.py <ID> <SUNREI_ID> \
+  [--prod] [--commit] [--summary "..."]
+```
 
 ### 9. Clean Up
 

--- a/.agents/skills/youtube-extract-locations/SKILL.md
+++ b/.agents/skills/youtube-extract-locations/SKILL.md
@@ -10,16 +10,52 @@ verify them with the Google Maps Places API.
 
 ## Prerequisites
 
-- Require `.claude/workspace/youtube/{ID}/video_info.json` and
-  `.claude/workspace/youtube/{ID}/transcripts.json`.
-- If either file is missing, ask the user to complete the preceding workflow
-  step.
+- Require `.claude/workspace/youtube/{ID}/video_info.json`.
+- The transcript-driven path (Steps 5–7) also requires
+  `.claude/workspace/youtube/{ID}/transcripts.json`. The description-first path
+  uses descriptions only and skips the caption API.
+- If a required file is missing, ask the user to complete the preceding step.
+
+## Description-first fast path
+
+Some channels list every visited place in the description. When they do, extract
+and geocode locations from descriptions before fetching transcripts:
+
+```bash
+uv run python .claude/scripts/youtube/extract_from_descriptions.py <ID> all   # or: fetch | parse | geocode
+```
+
+Use this path for:
+
+- Map-link channels, such as @saturdaytokyo / 토요일의 도쿄. Descriptions contain
+  a Google Maps link per place (`maps.app.goo.gl`, `goo.gl/maps`,
+  `maps.google.com`, or `g.page`). The script resolves each link to the creator's
+  exact pin, then verifies the Places result is within about 200 m.
+- Structured-block channels, such as 비밀이야 bimirya. Descriptions contain a
+  `* 가게 정보` block with `- <name>` and `- 주소 : <address>`. The script pairs
+  each address with the nearest preceding name and geocodes by name plus area.
+
+The script caches intermediate files as `descriptions.json`, `staging.json`, and
+`resolved_links.json`, so reruns can resume from any stage. If this path covers
+the playlist, skip Steps 4–7 and go straight to Step 9.
+
+## Web-research fallback
+
+For TV-show clip compilations whose titles name a dish but not a venue, such as
+스트리트푸드파이터, identify the real vendors through web research. Cross-check
+Korean fan blogs with local sources, dedupe clips to distinct vendors, and
+geocode the result:
+
+```bash
+uv run python .claude/scripts/youtube/geocode_food_vendors.py <ID> <vendors.json>
+```
 
 ## Steps
 
 ### 1. Load Data
 
-Read both JSON files from `.claude/workspace/youtube/{ID}/`.
+Read `video_info.json` from `.claude/workspace/youtube/{ID}/`. For the
+transcript-driven path, also read `transcripts.json`.
 
 ### 2. Load Google Maps API Key
 
@@ -75,9 +111,11 @@ Parse the video description for Google Maps links:
 - `https://maps.google.com/...`
 - `https://goo.gl/maps/...`
 - `https://maps.app.goo.gl/...`
+- `https://g.page/...` (Google Business profile links)
 
 Treat these as high-confidence locations because the creator shared them
-directly.
+directly. The fast-path script resolves short links to exact pins automatically;
+if parsing by hand, follow the redirect and use the resolved coordinates.
 
 ### 5. Extract Location Mentions
 
@@ -142,10 +180,17 @@ Before geocoding, clean and filter the extracted locations:
   of inventing one or sending the bad value to geocoding.
 - When a video has no chapters or map links, identify the main places from its
   title and description and search for them directly.
+- Validate accepted coordinates against the playlist's region. Out-of-region
+  pins are often geocode errors, especially when a foreign place name is matched
+  by Korean transliteration. Re-geocode outliers with country and city context.
+  If the creator genuinely visited an out-of-region place, keep it and flag it
+  for review. For a single-country playlist, run:
+  `uv run python .claude/scripts/youtube/cleanup_geocodes.py <ID> japan|france|italy`
 
 ### 7. Geocode Locations
 
-For each extracted location that doesn't already have coordinates (from Google Maps links), use the Places API:
+For each extracted location that does not already have coordinates from Google
+Maps links, use the Places API:
 
 ```bash
 curl -s -X POST "https://places.googleapis.com/v1/places:searchText" \
@@ -167,8 +212,10 @@ Guard against two common errors:
   with plausible coordinates but the wrong `googleMapsId`. Search for the
   business name and area together.
 - Compare `displayName` with the extracted name, allowing for translation and
-  romanization. If they do not match, refine the query or flag the result. Do
-  not accept the first result silently.
+  romanization. Refine obvious mismatches, but do not invent a phonetic
+  correction when the venue name appears only in speech. If the returned
+  business is plausibly the spoken venue, keep it and flag only genuine
+  uncertainty.
 
 Use the helper for a single lookup or to fill missing coordinates in
 `locations.json`:

--- a/.agents/skills/youtube-extract-locations/SKILL.md
+++ b/.agents/skills/youtube-extract-locations/SKILL.md
@@ -298,13 +298,19 @@ creation.
 ## Automated Candidate Extraction
 
 For a new-video run workspace containing `metadata.json`, captions, Whisper
-output, and video OCR, generate un-geocoded candidates with:
+output, and video OCR, first build the normalized source timeline:
+
+```bash
+uv run python .claude/scripts/youtube/evidence_timeline.py <RUN_DIR>
+```
+
+Then generate un-geocoded candidates with:
 
 ```bash
 uv run python .claude/scripts/youtube/extract_locations_headless.py <RUN_DIR>
 ```
 
-The script processes timed windows so locations near the end of a long video
-are not lost to input truncation. It records verbatim evidence by modality and
-sets every location to `decision: pending`. Do not convert these candidates to
+The extractor sends Codex the channel, title, description, and one relevant
+timeline window at a time. It records verbatim evidence by source and sets every
+location to `decision: pending`. Do not convert these candidates to
 `locations.json` or geocode them until names, scope, and evidence are approved.

--- a/.agents/skills/youtube-extract-locations/SKILL.md
+++ b/.agents/skills/youtube-extract-locations/SKILL.md
@@ -5,8 +5,8 @@ description: Extract and verify places mentioned in YouTube videos. Use when the
 
 # Extract Locations from YouTube Videos
 
-Identify relevant places from video metadata and transcripts, then geocode and
-verify them with the Google Maps Places API.
+Identify relevant places from descriptions, captions, audio, and on-screen
+text, then geocode and verify them with the Google Maps Places API.
 
 ## Prerequisites
 
@@ -38,6 +38,10 @@ Use this path for:
 The script caches intermediate files as `descriptions.json`, `staging.json`, and
 `resolved_links.json`, so reruns can resume from any stage. If this path covers
 the playlist, skip Steps 4–7 and go straight to Step 9.
+
+Scheduled renewal still captures the other modalities for audit and proper-name
+correction. Description links take precedence when the sources disagree about
+the identity of a place.
 
 ## Web-research fallback
 
@@ -290,3 +294,17 @@ Save to `.claude/workspace/youtube/{ID}/locations.json`:
 
 After saving the file, report its path and ask whether to continue with Sunrei
 creation.
+
+## Automated Candidate Extraction
+
+For a new-video run workspace containing `metadata.json`, captions, Whisper
+output, and video OCR, generate un-geocoded candidates with:
+
+```bash
+uv run python .claude/scripts/youtube/extract_locations_headless.py <RUN_DIR>
+```
+
+The script processes timed windows so locations near the end of a long video
+are not lost to input truncation. It records verbatim evidence by modality and
+sets every location to `decision: pending`. Do not convert these candidates to
+`locations.json` or geocode them until names, scope, and evidence are approved.

--- a/.agents/skills/youtube-extract-transcript/SKILL.md
+++ b/.agents/skills/youtube-extract-transcript/SKILL.md
@@ -155,6 +155,48 @@ For each transcript:
    timestamps. `youtube-extract-locations` uses this narration to write each
    place description.
 
+For a long transcript, run the headless Codex reviewer in small, resumable
+batches:
+
+```bash
+uv run python .claude/scripts/youtube/review_transcripts.py "{ID}" \
+  --video-id "{VIDEO_ID}"
+```
+
+Use `--all` only for an intentional full-workspace backfill. The reviewer:
+
+- Keeps `transcripts.json` unchanged.
+- Writes correction proposals and uncertain passages to
+  `transcript_review.json`.
+- Writes the resulting transcript to `transcripts.reviewed.json`.
+- Validates the segment index and original text before accepting a proposal, so
+  segment count and timing cannot change.
+- Uses aligned segments from `audio_transcript.json` and `onscreen_text.json`
+  when those files exist. Conflicts remain flagged instead of being resolved
+  from a plausible text-only guess.
+- Runs Codex in an empty temporary directory with an ephemeral, read-only
+  session. It does not load user MCP configuration or project rules, and AWS,
+  SOPS, Google, Admin API, and GitHub credentials are removed from the child
+  process environment.
+
+Corrections default to `"decision": "pending"` and are not copied into the
+reviewed transcript. Change reviewed proposals to `accept` or `reject`, then
+rebuild without starting another Codex call:
+
+```bash
+uv run python .claude/scripts/youtube/review_transcripts.py "{ID}" \
+  --video-id "{VIDEO_ID}" --max-new-chunks 0
+```
+
+Use `transcript_review_hints.json` in the workspace for verified spellings of
+people, channels, restaurants, and other recurring entities. Hints are scoped
+per video so a name such as `나폴리맛피아` does not cause ordinary uses of
+`마피아` or a business such as `와규 마피아` to be rewritten.
+
+Do not accept a plausible reconstruction when the intended wording is
+uncertain. Recheck the flagged timestamp against the audio and on-screen text;
+leave the item pending when the sources still disagree.
+
 #### Correct OCR in Context
 
 Read the full `fullText` before editing individual segments. For each correction,

--- a/.agents/skills/youtube-extract-transcript/SKILL.md
+++ b/.agents/skills/youtube-extract-transcript/SKILL.md
@@ -86,7 +86,8 @@ Use these limits:
 - Fetch a single video immediately.
 - For a playlist, wait a random 60–90 seconds between videos. Tests in July
   2026 found that 14–20 second intervals triggered a block after roughly 10–20
-  requests, while 60–90 second intervals completed 25 requests.
+  requests, while 60–90 second intervals completed later runs of up to 165
+  videos without blocks.
 - After a block, wait about 10 minutes and retry the same video. Stop after four
   consecutive blocks.
 
@@ -112,6 +113,31 @@ uv run --with youtube-transcript-api --with python-dotenv \
 - Saves each result as it completes. Rerunning the command skips successful
   videos and retries failed ones.
 - Prints success and no-transcript counts.
+
+#### Re-derive locations after video edits
+
+When a creator re-edits a video, old timestamps can drift and places can be cut.
+Re-extract the transcript before reusing an older `locations.json`. Keep
+verified geocodes for places that still appear; a place's map pin does not
+change when the video is re-cut. Back up the old file first:
+
+```bash
+mv .claude/workspace/youtube/{ID}/locations.json \
+   .claude/workspace/youtube/{ID}/locations.legacy.json
+```
+
+For large playlists, split the matching into subagent batches. Each batch should
+match legacy places against the current narration, flag places that were cut,
+extract new places, and return a verbatim `quote` from the current transcript
+for each retained place. Map those quotes back to fresh timestamps in the
+segment list. Then merge the batches, geocode only new places, and run
+country-aware cleanup:
+
+```bash
+uv run python .claude/scripts/youtube/prep_redrive_batches.py {ID} [batch_size]
+uv run python .claude/scripts/youtube/merge_redrive.py {ID}
+uv run python .claude/scripts/youtube/cleanup_geocodes.py {ID} japan|france|italy
+```
 
 ### 3. Audit and Clean Transcript
 

--- a/.agents/skills/youtube-fetch-info/SKILL.md
+++ b/.agents/skills/youtube-fetch-info/SKILL.md
@@ -197,3 +197,12 @@ Set `channel.handle` to `customUrl`; omit it when the channel has no handle. Set
 
 After saving the file, report its path and ask whether to continue with transcript
 extraction.
+
+## Automated Playlist Checks
+
+Do not overwrite a curated `video_info.json` during a scheduled check. Keep the
+playlist IDs and enabled flags in `.claude/config/youtube-renewal.json`, and let
+`renew_playlists.py` compare the live playlist with its local state. Dynamic
+metadata and run state belong under
+`.claude/workspace/youtube/automation/`; they are uploaded as artifacts when
+requested and are not committed to Git.

--- a/.agents/skills/youtube-fetch-info/SKILL.md
+++ b/.agents/skills/youtube-fetch-info/SKILL.md
@@ -17,6 +17,11 @@ It paginates playlists and writes `video_info.json` in the format shown below.
 uv run python .claude/scripts/youtube/fetch_info.py "<URL>" [--videos all|1,3,5|first:N]
 ```
 
+`--videos` controls which playlist entries are written to `selectedVideos`.
+Downstream transcript and create scripts process only that array. Use
+`--videos all` for a real ingest; use `first:1` or explicit indices only for
+disposable tests.
+
 Follow the remaining steps directly only when the script cannot handle the
 request.
 

--- a/.agents/skills/youtube-to-sunrei/SKILL.md
+++ b/.agents/skills/youtube-to-sunrei/SKILL.md
@@ -109,7 +109,8 @@ uv run python .claude/scripts/youtube/renew_playlists.py
 ```
 
 A committed run discovers new videos, collects captions, Whisper output, and
-video OCR, then runs the structured Codex reviewers:
+video OCR, then builds a timestamped evidence timeline and runs the structured
+Codex reviewers:
 
 ```bash
 uv run python .claude/scripts/youtube/renew_playlists.py --commit [--upload]
@@ -121,6 +122,11 @@ risking duplicate work. The job is resumable and stops at `review_pending`. It
 does not geocode, publish, change Sunrei spots, or update the channel registry.
 Use `youtube-create-sunrei` only after transcript corrections and location
 candidates have explicit decisions.
+
+S3 runs retain `metadata.json`, each raw text source, and the normalized
+`evidence_timeline.json` alongside the derived review files. Codex receives the
+metadata plus one relevant timeline window at a time; it does not receive the
+video or raw media.
 
 Operational details, S3 paths, and launchd setup are documented in
 `.claude/scripts/youtube/AUTOMATION.md`.

--- a/.agents/skills/youtube-to-sunrei/SKILL.md
+++ b/.agents/skills/youtube-to-sunrei/SKILL.md
@@ -9,6 +9,30 @@ Run the four YouTube skills in sequence, pausing for approval at each checkpoint
 
 Accept either a video URL or a playlist URL.
 
+## Choose the Extraction Strategy
+
+Choose the Step 3 location path from the content type:
+
+- Description-first: Use this for channels that put a Google Maps link or a
+  structured `* 가게 정보` block per place in every description, such as food
+  vlogs. Run `extract_from_descriptions.py` and skip transcripts.
+- Transcript-driven: travel/architecture vlogs that name places only in the
+  narration. Extract transcripts first (Step 2), then match places from them.
+- Web-research: TV-show clip compilations whose titles name a dish but not a
+  venue, such as 스트리트푸드파이터. Research the real vendors and geocode with
+  `geocode_food_vendors.py`.
+
+Inspect a few descriptions before choosing. Per-place map links or `가게 정보`
+blocks mean description-first; unstructured descriptions require transcripts or
+web research.
+
+## Re-Derive After Edits
+
+If videos were re-edited after a prior ingest, re-extract transcripts before
+reusing `locations.json`. Re-derive locations from the current transcript while
+reusing verified geocodes. Back up the old file as `locations.legacy.json` and
+follow the re-derivation section of `youtube-extract-transcript`.
+
 ## Workflow
 
 ### 1. Fetch Metadata
@@ -38,7 +62,8 @@ Do not extract locations until all retained transcripts are approved.
 Run `youtube-extract-locations`.
 
 - Determine each video's geographic scope and theme.
-- Collect locations from descriptions, map links, and transcripts.
+- Collect locations with the chosen path: description-first, transcript-driven,
+  or web research. Follow `youtube-extract-locations` for the detailed steps.
 - Geocode and verify each place.
 - Let the user add, edit, or remove locations.
 - Save the approved list to `.claude/workspace/youtube/{ID}/locations.json`.

--- a/.agents/skills/youtube-to-sunrei/SKILL.md
+++ b/.agents/skills/youtube-to-sunrei/SKILL.md
@@ -26,6 +26,12 @@ Inspect a few descriptions before choosing. Per-place map links or `가게 정�
 blocks mean description-first; unstructured descriptions require transcripts or
 web research.
 
+This optimization applies to an interactive one-time ingest. Daily renewal
+still collects captions, audio transcription, and on-screen text for every new
+video, including description-first channels. The extra evidence is retained for
+name correction and audit even when description links remain the primary place
+source.
+
 ## Re-Derive After Edits
 
 If videos were re-edited after a prior ingest, re-extract transcripts before
@@ -92,3 +98,29 @@ Inspect `.claude/workspace/youtube/{ID}/` before starting:
 
 If a step fails, report the error and retry that step only. Preserve intermediate
 files so the user can stop at any checkpoint and continue later.
+
+## Daily Renewal
+
+Playlist policy is stored in `.claude/config/youtube-renewal.json`. To inspect
+enabled playlists without changing state, run:
+
+```bash
+uv run python .claude/scripts/youtube/renew_playlists.py
+```
+
+A committed run discovers new videos, collects captions, Whisper output, and
+video OCR, then runs the structured Codex reviewers:
+
+```bash
+uv run python .claude/scripts/youtube/renew_playlists.py --commit [--upload]
+```
+
+Before discovery, the job reads video IDs from the configured production
+Sunrei's spot links. If that lookup fails, it skips the playlist instead of
+risking duplicate work. The job is resumable and stops at `review_pending`. It
+does not geocode, publish, change Sunrei spots, or update the channel registry.
+Use `youtube-create-sunrei` only after transcript corrections and location
+candidates have explicit decisions.
+
+Operational details, S3 paths, and launchd setup are documented in
+`.claude/scripts/youtube/AUTOMATION.md`.

--- a/.claude/config/youtube-renewal.json
+++ b/.claude/config/youtube-renewal.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": 1,
+  "artifactStore": {
+    "bucket": "sunrei-resources",
+    "prefix": "youtube/artifacts/v1",
+    "region": "ap-northeast-2",
+    "public": true
+  },
+  "defaults": {
+    "maxNewVideosPerRun": 2,
+    "captionDelaySeconds": {
+      "min": 60,
+      "max": 90
+    },
+    "transcriptReviewChunkSize": 600,
+    "evidence": {
+      "captions": true,
+      "audio": true,
+      "videoOcr": true,
+      "whisperModel": "base",
+      "ocrLanguages": ["ko", "en"],
+      "ocrIntervalSeconds": 1.0
+    }
+  },
+  "playlists": [
+    {
+      "id": "PLRLht13xoCf6Y9WiydRPHK8ks_FZG8rdC",
+      "name": "도쿄 맛집",
+      "sunreiId": "SR01kymcw7rt33057gxjmcmqcqm2",
+      "enabled": true,
+      "locationStrategy": "description_first"
+    },
+    {
+      "id": "PLDarQlAimXcFD3CqCK8TGGDLeUOGJDj6z",
+      "name": "일본 건축여행",
+      "sunreiId": "SR01kyhwcyy5f1tf40nvhhxgc17x",
+      "enabled": true,
+      "locationStrategy": "multimodal"
+    },
+    {
+      "id": "PLkmBZE3qxSdH0bvPK3Fn4pY7jrcWKIX5J",
+      "name": "비밀이야 in 이탈리아",
+      "sunreiId": "SR01kyhw8vv345x6ywas7my5p8te",
+      "enabled": true,
+      "locationStrategy": "multimodal"
+    },
+    {
+      "id": "PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI",
+      "name": "비밀이야 in 프랑스",
+      "sunreiId": "SR01kyhwcxvhhbhftbxtq7h252zw",
+      "enabled": true,
+      "locationStrategy": "multimodal"
+    },
+    {
+      "id": "PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi",
+      "name": "비밀이야 in 일본",
+      "sunreiId": "SR01kyj3jcwveajd0dyy9a7ktcsp",
+      "enabled": true,
+      "locationStrategy": "multimodal"
+    },
+    {
+      "id": "PLMorkLyAs-imjd7Ra23jioyXg37ywAHhv",
+      "name": "푸드 트립",
+      "sunreiId": "SR01kz0c3w1ax9fz01wnpdn2a824",
+      "enabled": true,
+      "locationStrategy": "multimodal"
+    },
+    {
+      "id": "PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c",
+      "name": "스트리트푸드파이터 시즌 1",
+      "sunreiId": "SR01kyhxp2gwq2nfkqw9nt0na55y",
+      "enabled": false,
+      "disabledReason": "completed_playlist",
+      "locationStrategy": "web_research"
+    },
+    {
+      "id": "PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2",
+      "name": "스트리트푸드파이터 시즌 2",
+      "sunreiId": "SR01kyhxp3f4201e3v8k5h1tg47v",
+      "enabled": false,
+      "disabledReason": "completed_playlist",
+      "locationStrategy": "web_research"
+    },
+    {
+      "id": "PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF",
+      "name": "비밀이야 in 한국",
+      "sunreiId": "SR01kyhxg7bhjyxt4xj9semgvbhv",
+      "enabled": false,
+      "disabledReason": "not_selected_for_daily_renewal",
+      "locationStrategy": "multimodal"
+    },
+    {
+      "id": "PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs",
+      "name": "비밀이야 in 싱가포르",
+      "sunreiId": "SR01kyhwcx1w4n61ds2k99gc8ekt",
+      "enabled": false,
+      "disabledReason": "not_selected_for_daily_renewal",
+      "locationStrategy": "multimodal"
+    }
+  ]
+}

--- a/.claude/launchd/com.yongseongkim.sunrei-youtube-renewal.plist
+++ b/.claude/launchd/com.yongseongkim.sunrei-youtube-renewal.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.yongseongkim.sunrei-youtube-renewal</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>/Users/yongseongkim/Documents/workspace.nosync/sunrei/.claude/scripts/youtube/run_daily_renewal.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/yongseongkim/Documents/workspace.nosync/sunrei</string>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>4</integer>
+    <key>Minute</key>
+    <integer>30</integer>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LowPriorityIO</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/yongseongkim/Documents/workspace.nosync/sunrei/.claude/workspace/youtube/automation/logs/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/yongseongkim/Documents/workspace.nosync/sunrei/.claude/workspace/youtube/automation/logs/launchd.err.log</string>
+</dict>
+</plist>

--- a/.claude/scripts/youtube/AUTOMATION.md
+++ b/.claude/scripts/youtube/AUTOMATION.md
@@ -16,9 +16,12 @@ check, but never changes the Admin API, a Sunrei, or its spots.
    - YouTube captions
    - Whisper transcription of the audio
    - OCR of text visible in the video
-6. Run transcript review and location candidate extraction with `codex exec`.
-7. Save the run as `review_pending`.
-8. With `--upload`, gzip JSON artifacts and upload them under an immutable S3
+6. Normalize the reviewed transcript, Whisper output, and OCR into one
+   timestamp-ordered `evidence_timeline.json`.
+7. Give Codex the video metadata and the relevant timeline window, then extract
+   location candidates and supporting details.
+8. Save the run as `review_pending`.
+9. With `--upload`, gzip JSON artifacts and upload them under an immutable S3
    run path. Raw audio and video are deleted by the evidence scripts and are
    never artifacts.
 
@@ -83,6 +86,20 @@ JSON files are stored as `.json.gz` with raw and compressed SHA-256 values in
 `manifest.json`. The per-video `latest.json` pointer changes only after every
 run object and its manifest upload successfully.
 
+The immutable run keeps both source and derived artifacts:
+
+| Role | Files |
+| --- | --- |
+| Source | `metadata.json`, `captions.json`, `audio_transcript.json`, `onscreen_text.json` |
+| Normalized source | `transcripts.json`, `evidence_timeline.json` |
+| Review and derived | `transcript_review.json`, `transcripts.reviewed.json`, `location_candidates.json` |
+
+`metadata.json` contains the channel, title, description, playlist, and video
+URL. `evidence_timeline.json` records every selected transcript, Whisper, and
+OCR segment with its source and start/end time. The raw modality files remain
+available so a bad timeline or Codex result can be reproduced and debugged.
+Every manifest entry includes its artifact role and SHA-256.
+
 The S3 uploader decrypts the existing `aws-access-key-id` and
 `aws-secret-access-key` values from `deploy/secrets/secrets.enc.yaml`. Codex
 runs in an empty, read-only temporary directory without AWS, SOPS, Google,
@@ -112,6 +129,6 @@ does not approve the data. Geocoding, updating `locations.json`, and calling the
 Admin API remain separate approved actions.
 
 After accepting transcript corrections, rebuild `transcripts.reviewed.json`
-with `review_transcripts.py --max-new-chunks 0`, then rerun location extraction
-with `extract_locations_headless.py --restart`. The location extractor prefers
-the reviewed transcript over raw captions.
+with `review_transcripts.py --max-new-chunks 0`, rebuild the timeline with
+`evidence_timeline.py --force`, then rerun location extraction with
+`extract_locations_headless.py --restart`.

--- a/.claude/scripts/youtube/AUTOMATION.md
+++ b/.claude/scripts/youtube/AUTOMATION.md
@@ -1,0 +1,117 @@
+# YouTube Renewal Automation
+
+The renewal job checks selected playlists for new videos and prepares a
+multimodal, reviewable ingest. It reads production Sunrei spots as a duplicate
+check, but never changes the Admin API, a Sunrei, or its spots.
+
+## Workflow
+
+1. Read `.claude/config/youtube-renewal.json`.
+2. Fetch every enabled playlist from the YouTube Data API.
+3. Read the configured production Sunrei and collect video IDs from its spot
+   links. If this lookup fails, stop processing that playlist.
+4. Compare remote video IDs with the production IDs, existing playlist
+   workspace, and local automation state.
+5. For each new video, attempt all three evidence sources:
+   - YouTube captions
+   - Whisper transcription of the audio
+   - OCR of text visible in the video
+6. Run transcript review and location candidate extraction with `codex exec`.
+7. Save the run as `review_pending`.
+8. With `--upload`, gzip JSON artifacts and upload them under an immutable S3
+   run path. Raw audio and video are deleted by the evidence scripts and are
+   never artifacts.
+
+The job retries failed videos on a later run. A video becomes known only after
+all local review artifacts are ready. Videos removed from a playlist are
+reported but never deleted from S3 or Sunrei automatically.
+
+## Playlist Policy
+
+Playlist inclusion belongs in `.claude/config/youtube-renewal.json`, so the
+policy is reviewed in Git. Dynamic state and downloaded results belong under
+`.claude/workspace/youtube/automation/`, which is ignored by Git.
+
+Each existing playlist entry includes its production `sunreiId`. The current
+policy enables the selected active food and travel playlists, disables the
+completed Street Food Fighter seasons, and leaves the Korea and Singapore
+playlists outside daily renewal. An explicit `--playlist` argument can run a
+disabled entry for testing or backfill.
+
+## Commands
+
+Inspect new videos without changing local state:
+
+```bash
+uv run python .claude/scripts/youtube/renew_playlists.py
+```
+
+Mark the current remote playlist contents as the initial baseline without
+processing old videos:
+
+```bash
+uv run python .claude/scripts/youtube/renew_playlists.py --bootstrap --commit
+```
+
+Process at most one new video locally:
+
+```bash
+uv run python .claude/scripts/youtube/renew_playlists.py \
+  --commit --max-videos 1
+```
+
+Process and upload pending artifacts:
+
+```bash
+uv run python .claude/scripts/youtube/renew_playlists.py \
+  --commit --upload
+```
+
+Do not use `--bootstrap` after normal operation starts. It intentionally treats
+every current remote video as already known.
+
+## Artifact Layout
+
+Each uploaded run uses this immutable prefix:
+
+```text
+s3://sunrei-resources/youtube/artifacts/v1/
+  playlists/{playlistId}/videos/{videoId}/runs/{runId}/
+```
+
+JSON files are stored as `.json.gz` with raw and compressed SHA-256 values in
+`manifest.json`. The per-video `latest.json` pointer changes only after every
+run object and its manifest upload successfully.
+
+The S3 uploader decrypts the existing `aws-access-key-id` and
+`aws-secret-access-key` values from `deploy/secrets/secrets.enc.yaml`. Codex
+runs in an empty, read-only temporary directory without AWS, SOPS, Google,
+GitHub, YouTube, or Admin API credentials.
+
+The renewal process itself uses a short-lived Admin JWT to read each production
+Sunrei before discovery. The token is not passed to Codex, and the automation
+does not issue Admin API write requests.
+
+## Scheduling
+
+The launchd definition runs every day at 04:30 local time:
+
+```text
+.claude/launchd/com.yongseongkim.sunrei-youtube-renewal.plist
+```
+
+Test a committed run manually before loading the agent. After validation, link
+the plist into `~/Library/LaunchAgents` and load it with `launchctl bootstrap`.
+The Mac must be on, and the saved Codex CLI login must remain valid.
+
+## Approval Boundary
+
+`transcript_review.json` corrections and `location_candidates.json` locations
+start with `decision: pending`. S3 upload preserves that state for review; it
+does not approve the data. Geocoding, updating `locations.json`, and calling the
+Admin API remain separate approved actions.
+
+After accepting transcript corrections, rebuild `transcripts.reviewed.json`
+with `review_transcripts.py --max-new-chunks 0`, then rerun location extraction
+with `extract_locations_headless.py --restart`. The location extractor prefers
+the reviewed transcript over raw captions.

--- a/.claude/scripts/youtube/AUTOMATION.md
+++ b/.claude/scripts/youtube/AUTOMATION.md
@@ -70,6 +70,19 @@ uv run python .claude/scripts/youtube/renew_playlists.py \
   --commit --upload
 ```
 
+Back up existing workspace JSON and create a fresh baseline for every
+configured playlist:
+
+```bash
+uv run --with boto3 python \
+  .claude/scripts/youtube/sync_workspace_s3.py --commit
+```
+
+Run this command before removing historical workspace data from Git. Without
+`--commit`, it validates the JSON, checks for credential patterns, fetches the
+current YouTube and production baselines, and prints the upload plan without
+changing S3.
+
 Do not use `--bootstrap` after normal operation starts. It intentionally treats
 every current remote video as already known.
 
@@ -99,6 +112,27 @@ URL. `evidence_timeline.json` records every selected transcript, Whisper, and
 OCR segment with its source and start/end time. The raw modality files remain
 available so a bad timeline or Codex result can be reproduced and debugged.
 Every manifest entry includes its artifact role and SHA-256.
+
+Playlist baselines and historical workspace snapshots use separate immutable
+paths:
+
+```text
+playlists/{playlistId}/snapshots/{snapshotId}/
+playlists/{playlistId}/workspace-snapshots/{snapshotId}/
+workspaces/{workspaceId}/snapshots/{snapshotId}/
+```
+
+A playlist baseline stores the latest channel, playlist, video title,
+description, duration, thumbnail, and the known-video state used for renewal.
+A workspace snapshot preserves the existing JSON hierarchy, including source,
+review, derived, and intermediate files needed for debugging. Raw media,
+automation runtime state, logs, and non-JSON files are excluded.
+
+Each snapshot has a manifest with raw and compressed SHA-256 values. The sync
+command reads every uploaded object back and verifies both hashes before it
+updates the corresponding `latest.json` or `workspace-latest.json` pointer. If
+the artifact store is public, it also verifies the pointer without AWS
+credentials.
 
 The S3 uploader decrypts the existing `aws-access-key-id` and
 `aws-secret-access-key` values from `deploy/secrets/secrets.enc.yaml`. Codex

--- a/.claude/scripts/youtube/_common.py
+++ b/.claude/scripts/youtube/_common.py
@@ -4,11 +4,13 @@
 - Admin token is minted locally (no login flow) — see auth/mint_token.py.
 - All HTTP sets a real User-Agent (prod Cloudflare 403s urllib's default).
 """
+import base64
 import json
 import os
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -51,6 +53,16 @@ def load_env():
     return env
 
 
+def jwt_is_usable(token, minimum_seconds=60):
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        value = json.loads(base64.urlsafe_b64decode(payload))
+        return int(value["exp"]) > int(time.time()) + minimum_seconds
+    except (IndexError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+
+
 def admin_token():
     """Resolve an admin JWT: env var, then .claude/.env, then mint one locally.
 
@@ -58,7 +70,7 @@ def admin_token():
     (see auth/mint_token.py), so no SUNREI_ADMIN_TOKEN needs to be pre-set.
     """
     tok = os.environ.get("SUNREI_ADMIN_TOKEN") or load_env().get("SUNREI_ADMIN_TOKEN")
-    if tok:
+    if tok and jwt_is_usable(tok):
         return tok
     mint = ROOT / ".claude" / "scripts" / "auth" / "mint_token.py"
     if mint.is_file():

--- a/.claude/scripts/youtube/build_streetfood.py
+++ b/.claude/scripts/youtube/build_streetfood.py
@@ -1,0 +1,115 @@
+"""Build locations.json for the 스트리트 푸드 파이터 playlists (Seasons 1 & 2).
+
+The clips themselves carry no location info; this maps each clip's playlist
+position to the city/region the show visited, pins it to that city's well-known
+food market/district (verifiable, geocodable), and writes one spot per clip.
+Same-city clips share one Place (same googleMapsId) so the public map aggregates
+them into a single card per market.
+
+Usage:
+    uv run python .claude/scripts/youtube/build_streetfood.py <PLAYLIST_ID>
+"""
+import json
+import re
+import sys
+
+from _common import WS_ROOT, load_google_api_key
+from extract_desc_locations import search
+
+# playlist_id -> [(start_pos, end_pos, city_label, market_query)]
+SEASONS = {
+    "PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c": [   # Season 1
+        (0, 11, "중국 청두", "Kuanzhai Alley Chengdu"),
+        (12, 20, "홍콩", "Temple Street Night Market Hong Kong"),
+        (21, 29, "태국 방콕", "Yaowarat Road Bangkok"),
+        (30, 40, "일본 도쿄", "Tsukiji Market Tokyo"),
+        (41, 51, "미국 하와이", "KCC Farmers Market Honolulu"),
+        (52, 62, "태국 푸껫", "Phuket Old Town"),
+        (63, 73, "일본 후쿠오카", "Nakasu Yatai Fukuoka"),
+        (74, 85, "중국 하얼빈", "Central Street Harbin"),
+    ],
+    "PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2": [   # Season 2
+        (0, 13, "터키 이스탄불", "Eminonu Istanbul"),
+        (14, 26, "베트남 하노이", "Hanoi Old Quarter"),
+        (27, 38, "미국 뉴욕", "Greenwich Village New York"),
+        (39, 49, "중국 시안", "Muslim Quarter Xi'an"),
+        (50, 63, "멕시코", "Centro Historico Mexico City"),
+        (64, 74, "대만 타이베이", "Ningxia Night Market Taipei"),
+        (75, 87, "이탈리아 시칠리아 팔레르모", "Ballaro Market Palermo"),
+        (88, 100, "중국 우한", "Hubu Alley Wuhan"),
+        (101, 113, "말레이시아 페낭", "New Lane Penang"),
+        (114, 127, "중국 연변", "Yanji West Market Yanbian"),
+        (128, 128, "미국 뉴욕", "Greenwich Village New York"),
+        (129, 130, "멕시코", "Centro Historico Mexico City"),
+        (131, 131, "베트남 하노이", "Hanoi Old Quarter"),
+        (132, 132, "중국 연변", "Yanji West Market Yanbian"),
+    ],
+}
+
+
+def clean_title(t):
+    return re.sub(r"#\S+", "", t).strip(" -|·")
+
+
+def main():
+    if not sys.argv[1:]:
+        print(__doc__)
+        sys.exit(1)
+    pid = sys.argv[1]
+    spans = SEASONS.get(pid)
+    if not spans:
+        print(f"No city mapping for {pid}")
+        sys.exit(1)
+    key = load_google_api_key()
+    ws = WS_ROOT / pid
+    info = json.load(open(ws / "video_info.json"))
+    clips = info["selectedVideos"]
+
+    # geocode each unique market once
+    geo = {}
+    for s, e, city, q in spans:
+        if q in geo:
+            continue
+        res, err = search(key, q)
+        if err:
+            print(f"  GEO FAIL '{q}': {err}")
+            geo[q] = None
+        else:
+            geo[q] = res
+            print(f"  geo '{q}' -> {res['displayName']} @ {res['latitude']:.4f},{res['longitude']:.4f}")
+
+    videos = []
+    for s, e, city, q in spans:
+        res = geo.get(q)
+        if not res:
+            continue
+        for pos in range(s, e + 1):
+            if pos >= len(clips):
+                break
+            c = clips[pos]
+            title = clean_title(c["title"])
+            if not title:
+                continue
+            videos.append({
+                "videoId": c["videoId"],
+                "title": title[:128],
+                "concept": city,
+                "locations": [{
+                    "name": res["displayName"],
+                    "address": res["address"],
+                    "latitude": res["latitude"],
+                    "longitude": res["longitude"],
+                    "googleMapsId": res["googleMapsId"],
+                    "googleMapsUri": res["googleMapsUri"],
+                    "description": f"스트리트 푸드 파이터 {city} 편. {title}",
+                    "videoUrlWithTimestamp": f"https://www.youtube.com/watch?v={c['videoId']}",
+                }],
+            })
+    out = ws / "locations.json"
+    json.dump({"videos": videos}, open(out, "w"), ensure_ascii=False, indent=2)
+    n = len(videos)
+    print(f"\n{pid}: {n} clips -> spots across {len({s[3] for s in spans})} markets -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/cleanup_geocodes.py
+++ b/.claude/scripts/youtube/cleanup_geocodes.py
@@ -1,0 +1,73 @@
+"""Country-aware geocode cleanup for re-derived playlists.
+
+For a playlist whose videos are all in one country, find spots whose pin is
+missing or landed outside that country (a common failure when geocoding a
+foreign place by its Korean-transliterated name), and re-geocode with stronger
+country/city context derived from the video concept.
+
+Usage: uv run python cleanup_geocodes.py <ID> <country>
+  country: japan | france | italy
+"""
+import json
+import re
+import sys
+import time
+
+from _common import load_google_api_key, workspace
+from geocode import search
+
+BOUNDS = {
+    "japan": (30, 46, 128, 146),
+    "france": (41, 51, -5, 10),
+    "italy": (35, 47, 6, 19),
+}
+COUNTRY_TERM = {"japan": "Japan 日本", "france": "France", "italy": "Italy Italia"}
+
+
+def in_bounds(lat, lng, b):
+    if lat is None or lng is None:
+        return False
+    return b[0] <= lat <= b[1] and b[2] <= lng <= b[3]
+
+
+def city_from_concept(concept):
+    # concepts look like "일본 건축여행 - 東京都 広尾" / "비밀이야 in 프랑스 - 파리 8구"
+    parts = re.split(r"[-–—]", concept or "")
+    if len(parts) < 2:
+        return ""
+    return parts[-1].strip().replace("도", "도 ").strip()[:30]
+
+
+def main():
+    ws_id, country = sys.argv[1], sys.argv[2]
+    if country not in BOUNDS:
+        print("country must be japan|france|italy"); sys.exit(1)
+    ws = workspace(ws_id)
+    key = load_google_api_key()
+    bounds = BOUNDS[country]
+    data = json.load(open(ws / "locations.json"))
+    fixed = unfixed = 0
+    for v in data["videos"]:
+        city = city_from_concept(v.get("concept", ""))
+        for l in v["locations"]:
+            needs = (not l.get("googleMapsId")) or (not in_bounds(l.get("latitude"), l.get("longitude"), bounds))
+            if not needs:
+                continue
+            name = re.sub(r"\s*\(.*?\)\s*", " ", l.get("name", "")).strip()
+            q = f"{name} {city} {COUNTRY_TERM[country]}".strip()
+            res, err = search(key, q)
+            if err or not (res or {}).get("googleMapsId") or not in_bounds(res["latitude"], res["longitude"], bounds):
+                l["geocodeWarning"] = f"cleanup unable to pin in {country}: {err or res.get('displayName') if res else 'no result'}"
+                unfixed += 1
+            else:
+                l.pop("geocodeWarning", None)
+                l.update(address=res["address"], latitude=res["latitude"], longitude=res["longitude"],
+                         googleMapsId=res["googleMapsId"], googleMapsUri=res["googleMapsUri"])
+                fixed += 1
+            time.sleep(0.3)
+    json.dump(data, open(ws / "locations.json", "w"), ensure_ascii=False, indent=2)
+    print(f"{ws_id}: cleanup fixed {fixed}, still unplaced {unfixed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/codex_headless.py
+++ b/.claude/scripts/youtube/codex_headless.py
@@ -1,0 +1,92 @@
+"""Run Codex headlessly with structured output and no ingest credentials."""
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+SECRET_ENV_NAMES = {
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "CODEX_API_KEY",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GOOGLE_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_MAPS_API_KEY",
+    "KUBECONFIG",
+    "OPENAI_API_KEY",
+    "SUNREI_ADMIN_TOKEN",
+    "YOUTUBE_API_KEY",
+}
+SECRET_ENV_PREFIXES = (
+    "AWS_",
+    "GOOGLE_",
+    "SOPS_",
+    "SUNREI_",
+    "YOUTUBE_",
+)
+
+
+def sanitized_environment():
+    """Keep Codex login state while removing ingest and deployment credentials."""
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if name not in SECRET_ENV_NAMES and not name.startswith(SECRET_ENV_PREFIXES)
+    }
+
+
+def read_json(path):
+    with Path(path).open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def run_structured(prompt, schema_file, model=None, timeout=900, temp_prefix="sunrei-codex-"):
+    """Return the JSON object from an isolated ``codex exec`` invocation."""
+    schema_file = Path(schema_file).resolve()
+    if not schema_file.is_file():
+        raise FileNotFoundError(schema_file)
+
+    with tempfile.TemporaryDirectory(prefix=temp_prefix) as temp_dir:
+        output = Path(temp_dir) / "result.json"
+        command = [
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--skip-git-repo-check",
+            "--sandbox",
+            "read-only",
+            "--output-schema",
+            str(schema_file),
+            "--output-last-message",
+            str(output),
+            "--color",
+            "never",
+            "-C",
+            temp_dir,
+        ]
+        if model:
+            command.extend(["--model", model])
+        command.append("-")
+        result = subprocess.run(
+            command,
+            input=prompt,
+            text=True,
+            capture_output=True,
+            env=sanitized_environment(),
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            details = result.stderr.strip() or result.stdout.strip()
+            raise RuntimeError(f"codex exec failed ({result.returncode}): {details[-2000:]}")
+        if not output.is_file():
+            raise RuntimeError("codex exec did not write its final response")
+        value = read_json(output)
+        if not isinstance(value, dict):
+            raise RuntimeError("codex exec returned a non-object JSON value")
+        return value

--- a/.claude/scripts/youtube/evidence_timeline.py
+++ b/.claude/scripts/youtube/evidence_timeline.py
@@ -1,0 +1,264 @@
+"""Build a timestamped transcript, Whisper, and OCR evidence timeline.
+
+The input JSON files remain unchanged. The resulting
+``evidence_timeline.json`` is the normalized source passed to location
+extraction and stored in S3 for debugging.
+
+Usage:
+    uv run python .claude/scripts/youtube/evidence_timeline.py RUN_DIR
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _common import workspace
+
+OUTPUT_FILE = "evidence_timeline.json"
+RAW_INPUT_FILES = (
+    "metadata.json",
+    "captions.json",
+    "audio_transcript.json",
+    "onscreen_text.json",
+)
+SOURCE_FILES = {
+    "transcript": (
+        "transcripts.reviewed.json",
+        "transcripts.json",
+        "captions.json",
+    ),
+    "whisper": ("audio_transcript.json",),
+    "ocr": ("onscreen_text.json",),
+}
+SOURCE_ORDER = {"transcript": 0, "whisper": 1, "ocr": 2}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workspace", help="Workspace ID or run directory")
+    parser.add_argument("--video-id")
+    parser.add_argument("--force", action="store_true")
+    return parser.parse_args()
+
+
+def read_json(path):
+    with Path(path).open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def write_json(path, value):
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as file:
+        json.dump(value, file, ensure_ascii=False, indent=2)
+        file.write("\n")
+    temporary.replace(path)
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_file(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def unwrap_video(value, video_id=None):
+    if not isinstance(value, dict):
+        return {}
+    if value.get("videoId"):
+        return value
+    for video in value.get("videos", []):
+        if video_id is None or video.get("videoId") == video_id:
+            return video
+    return {}
+
+
+def segment_end(segment):
+    start = float(segment.get("start") or 0)
+    if segment.get("end") is not None:
+        return float(segment["end"])
+    return start + float(segment.get("duration") or 0)
+
+
+def input_records(run_dir):
+    records = []
+    input_names = list(RAW_INPUT_FILES)
+    for candidates in SOURCE_FILES.values():
+        for file_name in candidates:
+            if file_name not in input_names:
+                input_names.append(file_name)
+    for file_name in input_names:
+        path = run_dir / file_name
+        if not path.is_file():
+            continue
+        value = read_json(path)
+        error = value.get("error") if isinstance(value, dict) else None
+        records.append(
+            {
+                "file": file_name,
+                "sha256": sha256_file(path),
+                "status": "error" if error else "ready",
+                **({"error": str(error)} if error else {}),
+            }
+        )
+    return records
+
+
+def input_fingerprint(records):
+    digest = hashlib.sha256()
+    for record in sorted(records, key=lambda value: value["file"]):
+        digest.update(record["file"].encode())
+        digest.update(record["sha256"].encode())
+    return digest.hexdigest()
+
+
+def selected_source(run_dir, candidates):
+    for file_name in candidates:
+        path = run_dir / file_name
+        if path.is_file():
+            return path
+    return None
+
+
+def normalized_segments(video):
+    segments = []
+    for segment in video.get("segments", []):
+        text = str(segment.get("text") or "").strip()
+        if not text:
+            continue
+        start = float(segment.get("start") or 0)
+        event = {
+            "startSeconds": round(start, 3),
+            "endSeconds": round(max(start, segment_end(segment)), 3),
+            "text": text,
+        }
+        if segment.get("confidence") is not None:
+            event["confidence"] = float(segment["confidence"])
+        segments.append(event)
+    return segments
+
+
+def segments_fingerprint(segments):
+    normalized = json.dumps(segments, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def build_timeline(run_dir, video_id):
+    run_dir = Path(run_dir)
+    records = input_records(run_dir)
+    sources = {}
+    events = []
+    seen_segments = {}
+
+    for source, candidates in SOURCE_FILES.items():
+        path = selected_source(run_dir, candidates)
+        if path is None:
+            sources[source] = {"status": "missing"}
+            continue
+        value = read_json(path)
+        video = unwrap_video(value, video_id)
+        error = video.get("error") or (
+            value.get("error") if isinstance(value, dict) else None
+        )
+        if error:
+            sources[source] = {
+                "status": "error",
+                "file": path.name,
+                "sha256": sha256_file(path),
+                "error": str(error),
+            }
+            continue
+        segments = normalized_segments(video)
+        if not segments:
+            sources[source] = {
+                "status": "empty",
+                "file": path.name,
+                "sha256": sha256_file(path),
+                "segmentCount": 0,
+            }
+            continue
+        fingerprint = segments_fingerprint(segments)
+        summary = {
+            "status": "ready",
+            "file": path.name,
+            "sha256": sha256_file(path),
+            "language": video.get("language", "unknown"),
+            "segmentCount": len(segments),
+        }
+        if video.get("source"):
+            summary["origin"] = video["source"]
+        if fingerprint in seen_segments:
+            summary["status"] = "duplicate"
+            summary["duplicateOf"] = seen_segments[fingerprint]
+            sources[source] = summary
+            continue
+        seen_segments[fingerprint] = source
+        sources[source] = summary
+        for segment in segments:
+            events.append({"source": source, **segment})
+
+    events.sort(
+        key=lambda event: (
+            event["startSeconds"],
+            SOURCE_ORDER[event["source"]],
+            event["endSeconds"],
+            event["text"],
+        )
+    )
+    return {
+        "schemaVersion": 1,
+        "videoId": video_id,
+        "generatedAt": utc_now(),
+        "inputFingerprint": input_fingerprint(records),
+        "inputs": records,
+        "sources": sources,
+        "durationSeconds": max(
+            (event["endSeconds"] for event in events),
+            default=0,
+        ),
+        "events": events,
+    }
+
+
+def ensure_timeline(run_dir, video_id, force=False):
+    run_dir = Path(run_dir)
+    output = run_dir / OUTPUT_FILE
+    records = input_records(run_dir)
+    fingerprint = input_fingerprint(records)
+    if output.is_file() and not force:
+        cached = read_json(output)
+        if (
+            cached.get("schemaVersion") == 1
+            and cached.get("videoId") == video_id
+            and cached.get("inputFingerprint") == fingerprint
+        ):
+            return cached, output
+    value = build_timeline(run_dir, video_id)
+    write_json(output, value)
+    return value, output
+
+
+def main():
+    args = parse_args()
+    run_dir = workspace(args.workspace)
+    metadata_path = run_dir / "metadata.json"
+    metadata = read_json(metadata_path) if metadata_path.is_file() else {}
+    video_id = args.video_id or metadata.get("videoId") or metadata.get("id")
+    if not video_id:
+        raise ValueError("No video ID was supplied or found in metadata.json")
+    timeline, output = ensure_timeline(run_dir, video_id, force=args.force)
+    ready = sum(1 for source in timeline["sources"].values() if source["status"] == "ready")
+    print(
+        f"timeline: {len(timeline['events'])} events, {ready} distinct sources -> {output}"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.claude/scripts/youtube/extract_desc_locations.py
+++ b/.claude/scripts/youtube/extract_desc_locations.py
@@ -1,0 +1,259 @@
+"""Extract locations from a YouTube playlist by parsing video descriptions.
+
+For channels whose descriptions carry structured "가게 정보 / [name] / 주소:" blocks
+(e.g. 비밀이야), this pulls restaurant name + address straight from the description
+— no transcripts needed — geocodes each via Places Text Search (name + address), and
+writes locations.json in the schema create_sunrei.py expects.
+
+Usage:
+    uv run python .claude/scripts/youtube/extract_desc_locations.py <PLAYLIST_ID|URL>
+
+Writes .claude/workspace/youtube/{ID}/locations.json. Re-runnable: skips locations
+already carrying coords (incremental). Prints progress per video.
+"""
+import json
+import re
+import sys
+import time
+
+from _common import WS_ROOT, http_json, load_google_api_key
+
+API = "https://www.googleapis.com/youtube/v3"
+PLACES = "https://places.googleapis.com/v1/places:searchText"
+FIELDS = ("places.displayName,places.formattedAddress,places.location,"
+          "places.id,places.googleMapsUri")
+
+BRACKET = re.compile(r"^\s*【?\[([^\[\]]+?)\]】?\s*$")
+ADDR = re.compile(r"주소\s*[:：]\s*(.+)")
+# A Korean road address reliably has a road suffix (로/길/대로/번길) next to a digit.
+ADDR_PAT = re.compile(r"특별자치도|특별자치시|특별시|광역시|(?:로|길|대로|번길|가길)\s*\d")
+TS = re.compile(r"^\s*\d{1,2}:\d{2}")
+TITLE_SEP = re.compile(r"[|｜ㅣ│]")
+NAME_FORBID = re.compile(r"주소|번호|전화|팩스|영업|휴무|가게|정보|메뉴|가격|먹자|마시자|놀러|다니자|방랑기|"
+                         r":|~|\d{1,2}:\d{2}|\d{3,}")
+
+
+def is_addr_line(s):
+    """A bare Korean address line: a road-suffix+number, not a timestamp."""
+    s = s.strip()
+    if not s or TS.match(s) or len(s) < 8:
+        return False
+    return bool(ADDR_PAT.search(s))
+
+
+def is_name_line(s):
+    """A dash/bullet restaurant-name line within 가게 정보 (not an address/hours/phone)."""
+    s2 = s.lstrip("-*• ").strip()
+    if not (2 <= len(s2) <= 25):
+        return False
+    if "#" in s2:                       # hashtag line ("#비밀이야 #맃집 ..."), not a venue
+        return False
+    if len(re.findall(r"[가-힣]", s2)) < 2:
+        return False
+    return not NAME_FORBID.search(s2)
+BOILER = ("먹자", "가게 정보", "가게정보", "비즈니스 문의", "본 영상은",
+          "업로드 시간", "인스타그램", "네이버 블로그", "워크숍", "워크샵")
+
+
+def get_videos(key, ids):
+    """Batch-fetch snippet (title+description) for up to 50 video ids."""
+    out = {}
+    for i in range(0, len(ids), 50):
+        batch = ",".join(ids[i:i + 50])
+        st, body = http_json("GET", f"{API}/videos?id={batch}&part=snippet&key={key}")
+        if st != 200:
+            print(f"  videos API {st}: {str(body)[:200]}")
+            continue
+        for it in body.get("items", []):
+            out[it["id"]] = it["snippet"]
+    return out
+
+
+def parse_pairs(desc):
+    """Yield (name, address) from a description's 가게 정보 section.
+
+    Handles three description formats the channel uses:
+      A) [name] bracket + a following 주소:/address line  (multi-venue videos)
+      B) no name line, only a 주소: line                   (name comes from title)
+      C) a '- name' bullet line + a following 주소: line   (dash list, no brackets)
+    The current venue name is whichever of these most recently preceded an address.
+    """
+    lines = desc.splitlines()
+    start = 0
+    for i, ln in enumerate(lines):
+        if "가게 정보" in ln or "가게정보" in ln:
+            start = i + 1
+            break
+    pairs, cur_name = [], None
+    for ln in lines[start:]:
+        s = ln.strip()
+        mb = BRACKET.match(s)
+        if mb:
+            cur_name = mb.group(1).strip()
+            continue
+        ma = ADDR.search(s)
+        if ma:
+            addr = ma.group(1).strip().strip("*-—• ")
+            if addr:
+                pairs.append((cur_name, addr))   # cur_name may be None -> address-only geocode
+            continue
+        if is_addr_line(s):                       # bare address line (no '주소:' label)
+            pairs.append((cur_name, s.strip("*-—• ")))
+            continue
+        if is_name_line(s):
+            cur_name = s.lstrip("-*• ").strip()
+    return pairs
+
+
+def title_fallback_name(title):
+    """Last |-separated token of the title, cleaned (for bracket-less descs)."""
+    parts = TITLE_SEP.split(title)
+    name = parts[-1].strip()
+    name = re.sub(r"\[.*?\]|\(.*?\)|#[\w]+", "", name).strip(" ·-—ㅣ")
+    return name if 1 < len(name) <= 30 else None
+
+
+def intro_context(desc, name, addr):
+    """First meaningful prose line(s) from the description; fallback if none."""
+    for ln in desc.splitlines():
+        s = ln.strip()
+        if len(s) < 8 or s.startswith("#") or s.startswith("*") or s.startswith("-"):
+            continue
+        if any(b in s for b in BOILER):
+            continue
+        if BRACKET.match(s) or ADDR.search(s) or is_addr_line(s):
+            continue
+        if TS.match(s):  # chapter timestamp
+            continue
+        if len(re.findall(r"[가-힣]", s)) < 4:  # phone/number/emoji-only lines
+            continue
+        return s[:300]
+    region = addr.split()[0] if addr else ""
+    return f"{name} — 비밀이야 in 한국 영상에서 소개한 {region} 맛집."
+
+
+def search(key, query):
+    st, body = http_json("POST", PLACES,
+                         headers={"X-Goog-Api-Key": key, "X-Goog-FieldMask": FIELDS},
+                         body={"textQuery": query, "languageCode": "ko"})
+    if st != 200:
+        return None, f"HTTP {st}: {str(body)[:160]}"
+    places = (body or {}).get("places") or []
+    if not places:
+        return None, "no result"
+    p = places[0]
+    loc = p.get("location", {})
+    return {
+        "displayName": p.get("displayName", {}).get("text"),
+        "address": p.get("formattedAddress"),
+        "latitude": loc.get("latitude"),
+        "longitude": loc.get("longitude"),
+        "googleMapsId": p.get("id"),
+        "googleMapsUri": p.get("googleMapsUri"),
+    }, None
+
+
+def norm(s):
+    return re.sub(r"[\s\-·]", "", (s or "").lower())
+
+
+def main():
+    if not sys.argv[1:]:
+        print(__doc__)
+        sys.exit(1)
+    key = load_google_api_key()
+    if not key:
+        print("No Google API key in application-local.conf.")
+        sys.exit(1)
+    pid = sys.argv[1]
+    if "list=" in pid:
+        pid = re.search(r"list=([\w-]+)", pid).group(1)
+    ws = WS_ROOT / pid
+    info = json.load(open(ws / "video_info.json"))
+    vids = [v for v in info["selectedVideos"]
+            if not re.search(r"(?i)#?shorts", v.get("title", ""))]
+    print(f"{len(vids)} long-form videos (shorts filtered)")
+
+    # load existing locations.json to allow incremental resume
+    locfile = ws / "locations.json"
+    data = json.load(open(locfile)) if locfile.is_file() else {"videos": []}
+    by_vid = {v["videoId"]: v for v in data.get("videos", [])}
+
+    all_ids = [v["videoId"] for v in vids]
+    snippets = get_videos(key, all_ids)
+    print(f"fetched {len(snippets)}/{len(all_ids)} descriptions")
+
+    total_geo = total_skip = total_flag = 0
+    for v in vids:
+        vid = v["videoId"]
+        sn = snippets.get(vid)
+        if not sn:
+            continue
+        desc = sn.get("description", "")
+        pairs = parse_pairs(desc)
+        fb = title_fallback_name(v.get("title", ""))
+        if not pairs and fb:                       # nothing parsed; last-ditch title guess
+            am = ADDR.search(desc)
+            if am:
+                pairs = [(fb, am.group(1).strip().strip("*-—• "))]
+        if not pairs:
+            continue
+        pairs = [(n, a) for n, a in pairs if a]    # keep None names -> geocode by address
+        entry = by_vid.get(vid) or {
+            "videoId": vid, "title": v["title"], "concept": "",
+            "locations": [],
+        }
+        entry["title"] = v["title"]
+        # index existing geocoded names to skip rework
+        done = {l["name"] for l in entry["locations"]
+                if l.get("latitude") and l.get("googleMapsId")}
+        intro = None
+        for name, addr in pairs:
+            name = (name or "").strip()
+            if name and name in done:
+                continue
+            if intro is None:
+                intro = intro_context(desc, name, addr)
+            res, err = search(key, f"{name} {addr}".strip())
+            total_geo += 1
+            loc = {"name": name, "address": addr, "description": intro,
+                   "videoUrlWithTimestamp": f"https://www.youtube.com/watch?v={vid}"}
+            if err:
+                loc["geocodeWarning"] = f"geocode failed: {err}"
+                total_flag += 1
+                time.sleep(0.05)
+                continue
+            loc.update(address=res["address"], latitude=res["latitude"],
+                       longitude=res["longitude"], googleMapsId=res["googleMapsId"],
+                       googleMapsUri=res["googleMapsUri"])
+            if not name:                            # address-only geocode -> take the name back
+                loc["name"] = res.get("displayName") or ""
+                if not loc["name"]:
+                    loc["geocodeWarning"] = "no displayName for address-only geocode"
+                    total_flag += 1
+            elif not (norm(name) in norm(res["displayName"])
+                      or norm(res["displayName"]) in norm(name)):
+                loc["geocodeWarning"] = (f"displayName '{res['displayName']}' "
+                                         f"!= '{name}'; verify")
+                total_flag += 1
+            entry["locations"].append(loc)
+            done.add(loc["name"])
+            time.sleep(0.05)
+        if entry["locations"]:
+            region = entry["locations"][0]["address"].split()[0] if entry["locations"][0].get("address") else ""
+            entry["concept"] = region
+            by_vid[vid] = entry
+            n_ok = sum(1 for l in entry["locations"] if l.get("latitude"))
+            print(f"  {vid}  {v['title'][:34]:36s}  {n_ok}/{len(entry['locations'])} geocoded")
+
+    data["videos"] = list(by_vid.values())
+    json.dump(data, open(locfile, "w"), ensure_ascii=False, indent=2)
+    n_spots = sum(len(v.get("locations", [])) for v in data["videos"])
+    n_ok = sum(1 for v in data["videos"] for l in v.get("locations", [])
+               if l.get("latitude") and l.get("googleMapsId"))
+    print(f"\nvideos with spots: {len(data['videos'])}  spots: {n_spots}  "
+          f"geocoded: {n_ok}  flagged: {total_flag}  -> {locfile}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/extract_from_descriptions.py
+++ b/.claude/scripts/youtube/extract_from_descriptions.py
@@ -1,0 +1,365 @@
+"""Description-first location extractor for food/travel YouTube playlists.
+
+Many channels (e.g. @saturdaytokyo) put a Google Maps link and a timestamped
+chapter for every visited place inside each video description. That lets us
+extract and geocode locations without touching the caption API (which is
+IP-rate-limited). This tool:
+
+  1. fetch   — pull `snippet` (title+description) for every selected video via
+               the YouTube Data API (cheap; 50 ids per call) → descriptions.json
+  2. parse   — read chapters (timestamp + place name) and Google Maps links from
+               each description; resolve each short link (HTTP redirect) to a
+               full Maps URL and pull the place name + precise coords + feature
+               id → staging.json
+  3. geocode — for every place, run a location-biased Places API text search to
+               fill the canonical Place ID + formatted address, verifying against
+               the link coords; emit locations.json
+
+Usage:
+    uv run python extract_from_descriptions.py <ID> fetch
+    uv run python extract_from_descriptions.py <ID> parse
+    uv run python extract_from_descriptions.py <ID> geocode
+    uv run python extract_from_descriptions.py <ID> all
+
+<ID> is the folder under .claude/workspace/youtube/. Stages cache their output so
+re-runs are cheap and the workflow can resume at any stage.
+"""
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+from _common import WS_ROOT, http_json, load_google_api_key, workspace
+from geocode import name_matches
+
+API = "https://www.googleapis.com/youtube/v3"
+PLACES = "https://places.googleapis.com/v1/places:searchText"
+UA = "sunrei-ingest/1.0"
+FIELDS = "places.displayName,places.formattedAddress,places.location,places.id,places.googleMapsUri"
+
+MAP_LINK_RE = re.compile(
+    r"https?://(?:maps\.google\.com|goo\.gl/maps|maps\.app\.goo\.gl|g\.page)/\S+"
+)
+CHAPTER_RE = re.compile(r"^\s*(\d{1,2}:\d{2}(?::\d{2})?)\s*(.*)$")
+EMOJO_LEAD_RE = re.compile(r"^[\s\W_]+", re.UNICODE)  # strip leading emoji/symbol noise crudely
+
+
+def load_selected(ws):
+    info = json.load(open(ws / "video_info.json"))
+    return info.get("selectedVideos", []), info
+
+
+def ts_to_sec(ts):
+    parts = [int(p) for p in ts.split(":")]
+    if len(parts) == 3:
+        return parts[0] * 3600 + parts[1] * 60 + parts[2]
+    return parts[0] * 60 + parts[1]
+
+
+def clean_name(raw):
+    # drop trailing url-ish / map-link fragments and stray punctuation/emoji
+    s = MAP_LINK_RE.sub("", raw)
+    s = re.sub(r"http\S*", "", s)
+    s = s.strip(" \t-–—•|·:*#")
+    s = re.sub(r"\s+", " ", s)
+    return s
+
+
+# --------------------------------------------------------------------------- fetch
+def stage_fetch(key, ws):
+    vids, _ = load_selected(ws)
+    desc_file = ws / "descriptions.json"
+    if desc_file.is_file():
+        cached = json.load(open(desc_file))
+    else:
+        cached = {}
+    ids = [v["videoId"] for v in vids if v["videoId"] not in cached]
+    fetched = 0
+    for i in range(0, len(ids), 50):
+        chunk = ids[i:i + 50]
+        url = f"{API}/videos?part=snippet&id=" + ",".join(chunk) + "&key=" + key
+        st, body = http_json("GET", url)
+        if st != 200:
+            print("videos API", st, str(body)[:200]); sys.exit(1)
+        found = {it["id"]: it["snippet"] for it in body.get("items", [])}
+        for vid in chunk:
+            sn = found.get(vid)
+            cached[vid] = {
+                "videoId": vid,
+                "title": (sn or {}).get("title", ""),
+                "description": (sn or {}).get("description", ""),
+            } if sn else {"videoId": vid, "title": "", "description": "", "missing": True}
+            fetched += 1
+        json.dump(cached, open(desc_file, "w"), ensure_ascii=False, indent=2)
+    print(f"fetch: {fetched} new, {len(cached)} total -> {desc_file}")
+    return cached
+
+
+# --------------------------------------------------------------------------- parse
+def resolve_link(link, cache):
+    """Resolve a short Maps URL to {name,lat,lng,featureId,resolvedUrl} or None."""
+    if link in cache:
+        return cache[link]
+    res = None
+    try:
+        req = urllib.request.Request(link, headers={"User-Agent": UA}, method="HEAD")
+        with urllib.request.urlopen(req, timeout=20) as r:
+            final = r.url
+        res = parse_resolved_url(final)
+    except Exception:
+        try:
+            # some links need a GET to resolve
+            req = urllib.request.Request(link, headers={"User-Agent": UA})
+            with urllib.request.urlopen(req, timeout=20) as r:
+                final = r.url
+            res = parse_resolved_url(final)
+        except Exception as e:
+            res = {"error": str(e)}
+    cache[link] = res
+    time.sleep(0.25)  # be gentle on goo.gl resolution
+    return res
+
+
+def parse_resolved_url(url):
+    dec = urllib.parse.unquote(url)
+    out = {"resolvedUrl": url}
+    # place name in path: /maps/place/<name>/@
+    m = re.search(r"/maps/place/([^/]+)/@", dec)
+    if m:
+        out["name"] = m.group(1).replace("+", " ").strip()
+    # precise coords from !8m2!3d<lat>!4d<lng>
+    m = re.search(r"!8m2!3d(-?[\d.]+)!4d(-?[\d.]+)", dec)
+    if m:
+        out["latitude"] = float(m.group(1))
+        out["longitude"] = float(m.group(2))
+    else:
+        m = re.search(r"@(-?[\d.]+),(-?[\d.]+),", dec)
+        if m:
+            out["latitude"] = float(m.group(1))
+            out["longitude"] = float(m.group(2))
+    # feature id 0x..:0x..
+    m = re.search(r"0x[0-9a-f]+:0x[0-9a-f]+", dec)
+    if m:
+        out["featureId"] = m.group(0)
+    return out
+
+
+# ---- structured description blocks (e.g. 비밀이야's "* 가게 정보" sections) ----
+ADDR_RE = re.compile(r"^\s*[-*]?\s*(주소|地址|住所|address|addr)\s*[:：]\s*(.+)$", re.IGNORECASE)
+NAMEKEY_RE = re.compile(r"^\s*[-*]?\s*(상호|이름|가게명|식당명|name)\s*[:：]\s*(.+)$", re.IGNORECASE)
+PHONE_RE = re.compile(r"^\s*[-*]?\s*(전화|연락처|phone|tel)\s*[:：]", re.IGNORECASE)
+DASHLINE_RE = re.compile(r"^\s*[-*•]\s*(.+)$")
+BLOCK_NOISE_RE = re.compile(r"광고|협찬|업로드|문의|영업|휴무|시간|전화|연락|링크|주소|http|www|naver|블로그", re.IGNORECASE)
+
+
+def parse_blocks(desc):
+    """Extract structured venue blocks. Each `주소:` line is paired with the
+    nearest preceding plausible venue name (a dash line or 상호/이름 value)."""
+    if not desc:
+        return []
+    blocks, pending = [], ""
+    for ln in desc.splitlines():
+        s = ln.strip()
+        if not s:
+            continue
+        am = ADDR_RE.match(s)
+        if am:
+            addr = am.group(2).strip().rstrip(".,;")
+            if pending and addr:
+                blocks.append({"name": pending, "address": addr})
+            pending = ""
+            continue
+        nm = NAMEKEY_RE.match(s)
+        if nm:
+            pending = nm.group(2).strip()
+            continue
+        dm = DASHLINE_RE.match(s)
+        if dm and not PHONE_RE.match(s):
+            cand = dm.group(1).strip()
+            if cand and not BLOCK_NOISE_RE.search(cand) and len(cand) <= 80:
+                pending = cand
+    return blocks
+
+
+def area_from_address(addr):
+    parts = [p.strip() for p in (addr or "").split(",") if p.strip()]
+    return " ".join(parts[-2:]) if len(parts) >= 2 else (parts[-1] if parts else "")
+
+
+def stage_parse(ws):
+    vids, info = load_selected(ws)
+    descs = json.load(open(ws / "descriptions.json"))
+    link_cache_file = ws / "resolved_links.json"
+    link_cache = json.load(open(link_cache_file)) if link_cache_file.is_file() else {}
+
+    videos = []
+    n_links = n_resolved = n_with_coords = n_blocks = 0
+    for v in vids:
+        vid = v["videoId"]
+        d = descs.get(vid, {})
+        desc = d.get("description", "")
+        title = d.get("title") or v.get("title", "")
+        # chapters
+        chapters = []
+        for line in desc.splitlines():
+            cm = CHAPTER_RE.match(line)
+            if cm:
+                name = clean_name(cm.group(2))
+                if name and len(name) <= 60:
+                    chapters.append({"timestamp": cm.group(1), "sec": ts_to_sec(cm.group(1)), "name": name})
+        # map links (dedup, preserve order)
+        links = []
+        seen = set()
+        for lk in MAP_LINK_RE.findall(desc):
+            lk = lk.rstrip(".,;)]}>)\"'")
+            if lk not in seen:
+                seen.add(lk)
+                links.append(lk)
+        # resolve links
+        resolved = []
+        for lk in links:
+            r = resolve_link(lk, link_cache)
+            resolved.append({"link": lk, **(r or {})})
+            n_links += 1
+            if r and r.get("latitude") is not None:
+                n_resolved += 1
+                n_with_coords += 1
+        json.dump(link_cache, open(link_cache_file, "w"), ensure_ascii=False, indent=2)
+        blocks = parse_blocks(desc)
+        n_blocks += len(blocks)
+        videos.append({
+            "videoId": vid,
+            "title": title,
+            "url": v.get("url") or f"https://www.youtube.com/watch?v={vid}",
+            "chapters": chapters,
+            "mapLinks": links,
+            "resolved": resolved,
+            "blocks": blocks,
+        })
+    out = {"playlistId": info.get("id"), "videos": videos}
+    json.dump(out, open(ws / "staging.json", "w"), ensure_ascii=False, indent=2)
+    print(f"parse: {len(videos)} videos, {n_links} links, {n_with_coords} with coords, {n_blocks} blocks -> staging.json")
+    return out
+
+
+# --------------------------------------------------------------------------- geocode
+def text_search(key, name, lat=None, lng=None):
+    body = {"textQuery": name, "languageCode": "ko"}
+    if lat is not None and lng is not None:
+        body["locationBias"] = {"circle": {"center": {"latitude": lat, "longitude": lng}, "radius": 200}}
+    st, resp = http_json("POST", PLACES,
+                         headers={"X-Goog-Api-Key": key, "X-Goog-FieldMask": FIELDS}, body=body)
+    if st != 200:
+        return None, f"HTTP {st}: {str(resp)[:160]}"
+    places = (resp or {}).get("places") or []
+    if not places:
+        return None, "no result"
+    p = places[0]
+    loc = p.get("location", {})
+    return {
+        "displayName": p.get("displayName", {}).get("text"),
+        "address": p.get("formattedAddress"),
+        "latitude": loc.get("latitude"),
+        "longitude": loc.get("longitude"),
+        "googleMapsId": p.get("id"),
+        "googleMapsUri": p.get("googleMapsUri"),
+    }, None
+
+
+def close(a, b, tol=0.002):
+    try:
+        return abs(float(a) - float(b)) < tol
+    except Exception:
+        return False
+
+
+def stage_geocode(key, ws):
+    staging = json.load(open(ws / "staging.json"))
+    locs_file = ws / "locations.json"
+    existing = {v["videoId"]: v for v in (json.load(open(locs_file))["videos"] if locs_file.is_file() else {"videos": []}).get("videos", [])}
+    out_videos = []
+    done = flagged = 0
+    for v in staging["videos"]:
+        vid = v["videoId"]
+        # only (re)geocode videos not already finalized
+        if vid in existing:
+            out_videos.append(existing[vid]); continue
+        places = []
+        for r in v["resolved"]:
+            if r.get("latitude") is None:
+                continue
+            name = r.get("name") or ""
+            res, err = text_search(key, name or "음식점", r["latitude"], r["longitude"])
+            entry = {
+                "name": name or (res or {}).get("displayName", ""),
+                "source": "description_link",
+                "googleMapsUri": r.get("resolvedUrl"),
+            }
+            if err:
+                # fall back to the link coords directly
+                entry.update(latitude=r["latitude"], longitude=r["longitude"],
+                             address="", geocodeWarning=f"text search: {err}")
+                flagged += 1
+            else:
+                entry.update(address=res["address"], latitude=res["latitude"], longitude=res["longitude"],
+                             googleMapsId=res["googleMapsId"], googleMapsUri=res.get("googleMapsUri") or entry["googleMapsUri"])
+                done += 1
+                # verify against creator pin
+                if not (close(entry["latitude"], r["latitude"]) and close(entry["longitude"], r["longitude"])):
+                    entry["geocodeWarning"] = f"coords differ from link pin ({r['latitude']:.5f},{r['longitude']:.5f})"
+                    flagged += 1
+            places.append(entry)
+        # structured description blocks (name + address, no creator pin)
+        have_ids = {p.get("googleMapsId") for p in places if p.get("googleMapsId")}
+        for b in v.get("blocks", []):
+            bname = (b.get("name") or "").strip()
+            if not bname:
+                continue
+            res, err = text_search(key, f"{bname} {area_from_address(b.get('address', ''))}".strip())
+            bentry = {"name": bname, "source": "description_block", "address": b.get("address", "")}
+            if err or not (res or {}).get("googleMapsId"):
+                bentry["geocodeWarning"] = f"block geocode failed: {err or 'no id'}"
+                flagged += 1
+            else:
+                if res["googleMapsId"] in have_ids:
+                    continue  # same place already captured via a map link
+                bentry.update(address=res.get("address") or bentry["address"],
+                              latitude=res["latitude"], longitude=res["longitude"],
+                              googleMapsId=res["googleMapsId"], googleMapsUri=res["googleMapsUri"])
+                done += 1
+                have_ids.add(res["googleMapsId"])
+                if not name_matches(bname, res.get("displayName", "")):
+                    bentry["geocodeWarning"] = f"displayName '{res.get('displayName')}' vs '{bname}'"
+                    flagged += 1
+            places.append(bentry)
+            time.sleep(0.3)
+        out_videos.append({
+            "videoId": vid, "title": v["title"], "concept": "",
+            "locations": places,
+        })
+        time.sleep(0.3)  # gentle on Places API
+    json.dump({"videos": out_videos}, open(locs_file, "w"), ensure_ascii=False, indent=2)
+    print(f"geocode: {done} resolved, {flagged} flagged -> {locs_file}")
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__); sys.exit(1)
+    ws_id, stage = args[0], (args[1] if len(args) > 1 else "all")
+    ws = workspace(ws_id)
+    key = load_google_api_key()
+    if not key:
+        print("No Google API key."); sys.exit(1)
+    if stage in ("fetch", "all"):
+        stage_fetch(key, ws)
+    if stage in ("parse", "all"):
+        stage_parse(ws)
+    if stage in ("geocode", "all"):
+        stage_geocode(key, ws)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/extract_locations_headless.py
+++ b/.claude/scripts/youtube/extract_locations_headless.py
@@ -1,0 +1,317 @@
+"""Extract reviewable location candidates from caption, audio, and video OCR.
+
+This script does not geocode, update a Sunrei, or upload data. It writes
+``location_candidates.json`` with ``review_pending`` status.
+
+Usage:
+    uv run python .claude/scripts/youtube/extract_locations_headless.py WORKSPACE
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _common import workspace
+from codex_headless import run_structured
+
+SCHEMA_FILE = Path(__file__).with_name("location_candidates.schema.json")
+EVIDENCE_FILES = {
+    "captions": "captions.json",
+    "audio": "audio_transcript.json",
+    "onscreen": "onscreen_text.json",
+}
+CONFIDENCE = {"low": 0, "medium": 1, "high": 2}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workspace")
+    parser.add_argument("--window-seconds", type=float, default=1200)
+    parser.add_argument("--overlap-seconds", type=float, default=10)
+    parser.add_argument("--model")
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--restart", action="store_true")
+    return parser.parse_args()
+
+
+def read_json(path):
+    with Path(path).open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def write_json(path, value):
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as file:
+        json.dump(value, file, ensure_ascii=False, indent=2)
+        file.write("\n")
+    temporary.replace(path)
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_files(paths):
+    digest = hashlib.sha256()
+    for path in sorted(paths, key=lambda value: value.name):
+        digest.update(path.name.encode())
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def unwrap_video(value, video_id=None):
+    if not isinstance(value, dict):
+        return {}
+    if value.get("videoId"):
+        return value
+    for video in value.get("videos", []):
+        if video_id is None or video.get("videoId") == video_id:
+            return video
+    return {}
+
+
+def load_metadata(ws):
+    for file_name in ("metadata.json", "video_info.json"):
+        path = ws / file_name
+        if path.is_file():
+            value = read_json(path)
+            if value.get("type") == "video" or value.get("videoId"):
+                return value
+    raise FileNotFoundError(f"No single-video metadata found in {ws}")
+
+
+def load_evidence(ws, video_id):
+    evidence = {}
+    paths = []
+    for source, file_name in EVIDENCE_FILES.items():
+        path = ws / file_name
+        if not path.is_file():
+            continue
+        paths.append(path)
+        video = unwrap_video(read_json(path), video_id)
+        if video.get("segments"):
+            evidence[source] = video
+
+    # Prefer the human-reviewed transcript whenever it exists. Pending reviews
+    # are content-equivalent to the source; accepted corrections then flow into
+    # a restarted location extraction without changing this interface.
+    transcript_path = ws / "transcripts.reviewed.json"
+    if transcript_path.is_file():
+        paths.append(transcript_path)
+        video = unwrap_video(read_json(transcript_path), video_id)
+        if video.get("segments"):
+            evidence["captions"] = video
+    return evidence, paths
+
+
+def segment_end(segment):
+    start = float(segment.get("start") or 0)
+    if segment.get("end") is not None:
+        return float(segment["end"])
+    return start + float(segment.get("duration") or 0)
+
+
+def duration_of(evidence):
+    return max(
+        (segment_end(segment) for video in evidence.values() for segment in video.get("segments", [])),
+        default=0,
+    )
+
+
+def windows(duration, size, overlap):
+    if duration <= 0:
+        yield 0.0, 0.0
+        return
+    start = 0.0
+    while start < duration:
+        end = min(duration, start + size)
+        yield start, end
+        if end >= duration:
+            break
+        start = max(start + 1, end - overlap)
+
+
+def evidence_window(evidence, start, end):
+    result = {}
+    for source, video in evidence.items():
+        segments = []
+        for segment in video.get("segments", []):
+            segment_start = float(segment.get("start") or 0)
+            if segment_end(segment) < start or segment_start > end:
+                continue
+            segments.append(
+                {
+                    "text": segment.get("text", ""),
+                    "start": segment_start,
+                    "end": segment_end(segment),
+                }
+            )
+        if segments:
+            result[source] = segments
+    return result
+
+
+def make_prompt(metadata, evidence, start, end):
+    payload = {
+        "videoId": metadata.get("videoId") or metadata.get("id"),
+        "title": metadata.get("title", ""),
+        "channelName": metadata.get("channelName", ""),
+        "description": metadata.get("description", "")[:12000],
+        "window": {"startSeconds": start, "endSeconds": end},
+        "evidence": evidence_window(evidence, start, end),
+    }
+    return """Extract real places that are visited, filmed, or presented as a
+destination in this YouTube video. Return only JSON matching the supplied
+schema. Do not run commands, inspect files, browse the web, or geocode.
+
+Use the title and description together with all available caption, audio, and
+on-screen OCR evidence. A place supported by a creator-provided description or
+multiple modalities is stronger than a name inferred from one corrupted ASR
+token. Preserve verified Korean and foreign spellings. Do not translate or
+normalize a name when that would hide a source conflict.
+
+Include restaurants, shops, attractions, buildings, viewpoints, and other
+specific destinations central to the video. Exclude places mentioned only as a
+comparison, generic streets or neighborhoods without a specific destination,
+the creator's home, sponsors, and locations inferred only from background
+scenery. Do not invent a venue name from an address, dish, or generic category.
+
+Every location must include at least one verbatim evidence quote. Use
+startSeconds 0 for title or description evidence. Mark needsVerification when
+sources disagree, the exact business name is uncertain, or only weak OCR/ASR
+supports the candidate. Put unresolved conflicts in issues.
+
+Write description as two to five Korean sentences suitable for a Sunrei spot.
+Describe why the video visits the place, its relevant atmosphere or geographic
+context, and the dishes, preparation, taste, texture, or creator assessment
+actually supported by the evidence. Include useful timestamps in parentheses.
+Do not turn uncertain ASR wording into a factual claim. Keep reason separate as
+a concise explanation of why the place identity is accepted or flagged.
+
+Input:
+""" + json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def norm_name(value):
+    return re.sub(r"[^0-9a-z가-힣ぁ-んァ-ン一-龥]", "", (value or "").lower())
+
+
+def merge_unique(values):
+    output = []
+    seen = set()
+    for value in values:
+        key = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        if key not in seen:
+            seen.add(key)
+            output.append(value)
+    return output
+
+
+def merge_location(existing, incoming):
+    existing["aliases"] = merge_unique(existing.get("aliases", []) + incoming.get("aliases", []))
+    existing["evidence"] = merge_unique(existing.get("evidence", []) + incoming.get("evidence", []))
+    existing["needsVerification"] = bool(
+        existing.get("needsVerification") or incoming.get("needsVerification")
+    )
+    if CONFIDENCE.get(incoming.get("confidence"), -1) > CONFIDENCE.get(existing.get("confidence"), -1):
+        existing["confidence"] = incoming["confidence"]
+    for field in ("area", "category"):
+        if not existing.get(field) and incoming.get(field):
+            existing[field] = incoming[field]
+    if len(incoming.get("description", "")) > len(existing.get("description", "")):
+        existing["description"] = incoming["description"]
+    if incoming.get("reason") and incoming["reason"] not in existing.get("reason", ""):
+        existing["reason"] = (existing.get("reason", "") + " " + incoming["reason"]).strip()
+
+
+def extract(metadata, evidence, model, timeout, window_seconds, overlap_seconds):
+    results = []
+    for start, end in windows(duration_of(evidence), window_seconds, overlap_seconds):
+        print(f"location extraction [{start:.0f}:{end:.0f}]", flush=True)
+        result = run_structured(
+            make_prompt(metadata, evidence, start, end),
+            SCHEMA_FILE,
+            model=model,
+            timeout=timeout,
+            temp_prefix="sunrei-location-extract-",
+        )
+        result["window"] = {"startSeconds": start, "endSeconds": end}
+        results.append(result)
+    return results
+
+
+def merge_results(metadata, source_sha, results):
+    locations = {}
+    issues = []
+    concepts = []
+    scopes = []
+    for result in results:
+        if result.get("concept") and result["concept"] not in concepts:
+            concepts.append(result["concept"])
+        if result.get("geographicScope") and result["geographicScope"] not in scopes:
+            scopes.append(result["geographicScope"])
+        issues.extend(result.get("issues", []))
+        for location in result.get("locations", []):
+            key = norm_name(location.get("name"))
+            if not key:
+                continue
+            if key in locations:
+                merge_location(locations[key], location)
+            else:
+                location["decision"] = "pending"
+                locations[key] = location
+    return {
+        "schemaVersion": 1,
+        "status": "review_pending",
+        "videoId": metadata.get("videoId") or metadata.get("id"),
+        "title": metadata.get("title", ""),
+        "sourceSha256": source_sha,
+        "generatedAt": utc_now(),
+        "concept": " / ".join(concepts),
+        "geographicScope": " / ".join(scopes),
+        "locations": list(locations.values()),
+        "issues": merge_unique(issues),
+        "windows": [result["window"] for result in results],
+    }
+
+
+def main():
+    args = parse_args()
+    if args.window_seconds <= 0 or args.overlap_seconds < 0:
+        raise ValueError("window-seconds must be positive and overlap-seconds cannot be negative")
+    ws = workspace(args.workspace)
+    output = ws / "location_candidates.json"
+    if output.is_file() and not args.restart:
+        print(f"cached -> {output}")
+        return
+
+    metadata = load_metadata(ws)
+    video_id = metadata.get("videoId") or metadata.get("id")
+    evidence, evidence_paths = load_evidence(ws, video_id)
+    if not evidence:
+        raise ValueError(f"No timed transcript, audio, or OCR evidence found in {ws}")
+    metadata_path = ws / ("metadata.json" if (ws / "metadata.json").is_file() else "video_info.json")
+    source_sha = sha256_files([metadata_path] + evidence_paths)
+    results = extract(
+        metadata,
+        evidence,
+        args.model,
+        args.timeout,
+        args.window_seconds,
+        args.overlap_seconds,
+    )
+    write_json(output, merge_results(metadata, source_sha, results))
+    print(f"review pending -> {output}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (FileNotFoundError, ValueError, RuntimeError, subprocess.TimeoutExpired) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.claude/scripts/youtube/extract_locations_headless.py
+++ b/.claude/scripts/youtube/extract_locations_headless.py
@@ -1,4 +1,4 @@
-"""Extract reviewable location candidates from caption, audio, and video OCR.
+"""Extract locations from video metadata and timestamped source evidence.
 
 This script does not geocode, update a Sunrei, or upload data. It writes
 ``location_candidates.json`` with ``review_pending`` status.
@@ -18,13 +18,9 @@ from pathlib import Path
 
 from _common import workspace
 from codex_headless import run_structured
+from evidence_timeline import ensure_timeline
 
 SCHEMA_FILE = Path(__file__).with_name("location_candidates.schema.json")
-EVIDENCE_FILES = {
-    "captions": "captions.json",
-    "audio": "audio_transcript.json",
-    "onscreen": "onscreen_text.json",
-}
 CONFIDENCE = {"low": 0, "medium": 1, "high": 2}
 
 
@@ -64,17 +60,6 @@ def sha256_files(paths):
     return digest.hexdigest()
 
 
-def unwrap_video(value, video_id=None):
-    if not isinstance(value, dict):
-        return {}
-    if value.get("videoId"):
-        return value
-    for video in value.get("videos", []):
-        if video_id is None or video.get("videoId") == video_id:
-            return video
-    return {}
-
-
 def load_metadata(ws):
     for file_name in ("metadata.json", "video_info.json"):
         path = ws / file_name
@@ -83,44 +68,6 @@ def load_metadata(ws):
             if value.get("type") == "video" or value.get("videoId"):
                 return value
     raise FileNotFoundError(f"No single-video metadata found in {ws}")
-
-
-def load_evidence(ws, video_id):
-    evidence = {}
-    paths = []
-    for source, file_name in EVIDENCE_FILES.items():
-        path = ws / file_name
-        if not path.is_file():
-            continue
-        paths.append(path)
-        video = unwrap_video(read_json(path), video_id)
-        if video.get("segments"):
-            evidence[source] = video
-
-    # Prefer the human-reviewed transcript whenever it exists. Pending reviews
-    # are content-equivalent to the source; accepted corrections then flow into
-    # a restarted location extraction without changing this interface.
-    transcript_path = ws / "transcripts.reviewed.json"
-    if transcript_path.is_file():
-        paths.append(transcript_path)
-        video = unwrap_video(read_json(transcript_path), video_id)
-        if video.get("segments"):
-            evidence["captions"] = video
-    return evidence, paths
-
-
-def segment_end(segment):
-    start = float(segment.get("start") or 0)
-    if segment.get("end") is not None:
-        return float(segment["end"])
-    return start + float(segment.get("duration") or 0)
-
-
-def duration_of(evidence):
-    return max(
-        (segment_end(segment) for video in evidence.values() for segment in video.get("segments", [])),
-        default=0,
-    )
 
 
 def windows(duration, size, overlap):
@@ -136,44 +83,44 @@ def windows(duration, size, overlap):
         start = max(start + 1, end - overlap)
 
 
-def evidence_window(evidence, start, end):
-    result = {}
-    for source, video in evidence.items():
-        segments = []
-        for segment in video.get("segments", []):
-            segment_start = float(segment.get("start") or 0)
-            if segment_end(segment) < start or segment_start > end:
-                continue
-            segments.append(
-                {
-                    "text": segment.get("text", ""),
-                    "start": segment_start,
-                    "end": segment_end(segment),
-                }
-            )
-        if segments:
-            result[source] = segments
-    return result
+def timeline_window(timeline, start, end):
+    return [
+        event
+        for event in timeline.get("events", [])
+        if event.get("endSeconds", 0) >= start
+        and event.get("startSeconds", 0) <= end
+    ]
 
 
-def make_prompt(metadata, evidence, start, end):
+def make_prompt(metadata, timeline, start, end):
     payload = {
-        "videoId": metadata.get("videoId") or metadata.get("id"),
-        "title": metadata.get("title", ""),
-        "channelName": metadata.get("channelName", ""),
-        "description": metadata.get("description", "")[:12000],
-        "window": {"startSeconds": start, "endSeconds": end},
-        "evidence": evidence_window(evidence, start, end),
+        "metadata": {
+            "videoId": metadata.get("videoId") or metadata.get("id"),
+            "title": metadata.get("title", ""),
+            "description": metadata.get("description", ""),
+            "channelId": metadata.get("channelId", ""),
+            "channelName": metadata.get("channelName", ""),
+            "playlistId": metadata.get("playlistId", ""),
+            "playlistTitle": metadata.get("playlistTitle", ""),
+            "publishedAt": metadata.get("publishedAt"),
+            "url": metadata.get("url", ""),
+        },
+        "timeline": {
+            "window": {"startSeconds": start, "endSeconds": end},
+            "sourceStatus": timeline.get("sources", {}),
+            "events": timeline_window(timeline, start, end),
+        },
     }
     return """Extract real places that are visited, filmed, or presented as a
 destination in this YouTube video. Return only JSON matching the supplied
 schema. Do not run commands, inspect files, browse the web, or geocode.
 
-Use the title and description together with all available caption, audio, and
-on-screen OCR evidence. A place supported by a creator-provided description or
-multiple modalities is stronger than a name inferred from one corrupted ASR
-token. Preserve verified Korean and foreign spellings. Do not translate or
-normalize a name when that would hide a source conflict.
+Use metadata together with the timestamped transcript, Whisper, and OCR events.
+A place supported by a creator-provided description or multiple sources is
+stronger than a name inferred from one corrupted ASR token. Preserve verified
+Korean and foreign spellings. Do not translate or normalize a name when that
+would hide a source conflict. A source marked duplicate is not independent
+support; inspect sourceStatus and origin before comparing modalities.
 
 Include restaurants, shops, attractions, buildings, viewpoints, and other
 specific destinations central to the video. Exclude places mentioned only as a
@@ -181,10 +128,11 @@ comparison, generic streets or neighborhoods without a specific destination,
 the creator's home, sponsors, and locations inferred only from background
 scenery. Do not invent a venue name from an address, dish, or generic category.
 
-Every location must include at least one verbatim evidence quote. Use
-startSeconds 0 for title or description evidence. Mark needsVerification when
-sources disagree, the exact business name is uncertain, or only weak OCR/ASR
-supports the candidate. Put unresolved conflicts in issues.
+Every location must include at least one verbatim evidence quote. Label timed
+evidence as transcript, whisper, or ocr exactly as it appears in the timeline.
+Use startSeconds 0 for title or description evidence. Mark needsVerification
+when sources disagree, the exact business name is uncertain, or only weak
+OCR/ASR supports the candidate. Put unresolved conflicts in issues.
 
 Write description as two to five Korean sentences suitable for a Sunrei spot.
 Describe why the video visits the place, its relevant atmosphere or geographic
@@ -229,12 +177,16 @@ def merge_location(existing, incoming):
         existing["reason"] = (existing.get("reason", "") + " " + incoming["reason"]).strip()
 
 
-def extract(metadata, evidence, model, timeout, window_seconds, overlap_seconds):
+def extract(metadata, timeline, model, timeout, window_seconds, overlap_seconds):
     results = []
-    for start, end in windows(duration_of(evidence), window_seconds, overlap_seconds):
+    for start, end in windows(
+        float(timeline.get("durationSeconds") or 0),
+        window_seconds,
+        overlap_seconds,
+    ):
         print(f"location extraction [{start:.0f}:{end:.0f}]", flush=True)
         result = run_structured(
-            make_prompt(metadata, evidence, start, end),
+            make_prompt(metadata, timeline, start, end),
             SCHEMA_FILE,
             model=model,
             timeout=timeout,
@@ -292,14 +244,14 @@ def main():
 
     metadata = load_metadata(ws)
     video_id = metadata.get("videoId") or metadata.get("id")
-    evidence, evidence_paths = load_evidence(ws, video_id)
-    if not evidence:
+    timeline, timeline_path = ensure_timeline(ws, video_id)
+    if not timeline.get("events"):
         raise ValueError(f"No timed transcript, audio, or OCR evidence found in {ws}")
     metadata_path = ws / ("metadata.json" if (ws / "metadata.json").is_file() else "video_info.json")
-    source_sha = sha256_files([metadata_path] + evidence_paths)
+    source_sha = sha256_files([metadata_path, timeline_path])
     results = extract(
         metadata,
-        evidence,
+        timeline,
         args.model,
         args.timeout,
         args.window_seconds,

--- a/.claude/scripts/youtube/extract_onscreen_text.py
+++ b/.claude/scripts/youtube/extract_onscreen_text.py
@@ -93,12 +93,20 @@ def download_video(video_url: str, video_id: str) -> str:
     os.remove(video_path)  # yt-dlp skips download if file exists
 
     ydl_opts = {
-        "format": "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/best[height<=720]",
+        # OCR does not need audio. Prefer a progressive or video-only stream to
+        # avoid failures from downloading and merging two separate formats.
+        "format": "best[height<=720][ext=mp4]/best[height<=720]/bestvideo[height<=720][ext=mp4]/bestvideo[height<=720]",
         "outtmpl": video_path,
         "quiet": True,
         "no_warnings": True,
-        "merge_output_format": "mp4",
     }
+    # Optional auth for members-only videos (see whisper_transcribe.py).
+    cf = os.environ.get("SUNREI_YT_COOKIES")
+    cb = os.environ.get("SUNREI_YT_BROWSER")
+    if cf:
+        ydl_opts["cookiefile"] = cf
+    elif cb:
+        ydl_opts["cookiesfrombrowser"] = (cb,)
 
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         ydl.download([video_url])

--- a/.claude/scripts/youtube/geocode_food_vendors.py
+++ b/.claude/scripts/youtube/geocode_food_vendors.py
@@ -1,0 +1,162 @@
+"""Geocode food-vendor research (from research subagents) into a playlist locations.json.
+
+Input: a JSON file holding an array of vendor entries produced by a research
+agent. Entries may use any of these field names (case-insensitive-ish):
+  name_original / name / vendor_name      -> primary geocode term (local script)
+  name_korean / name_ko                   -> Korean display name
+  city / City                             -> city (also used as the grouping unit)
+  district                                -> area context
+  dish / dish_korean / dish_original      -> dish(es)
+  address                                 -> address hint (NOT used as the query)
+  source                                  -> source URL
+
+The script:
+  - groups entries by vendor (name_original, falling back to name_korean),
+    merging their dishes into one description,
+  - geocodes each distinct vendor with a name+area text search (never the bare
+    address), and verifies the displayName loosely,
+  - writes/merges into <playlist workspace>/locations.json grouped by city.
+
+Usage:
+    uv run python geocode_food_vendors.py <PLAYLIST_ID> <vendors.json> [--source-url-tag SFF2|SFF1]
+"""
+import json
+import re
+import sys
+import time
+
+from _common import load_google_api_key, workspace
+from geocode import search, name_matches
+
+KOREAN_PREFIX = {
+    "Chengdu": "청두", "Harbin": "하얼빈",
+    "Istanbul": "이스탄불", "Hanoi": "하노이", "New York": "뉴욕",
+    "Xi'an": "시안", "Wuhan": "우한", "Mexico City": "멕시코시티",
+    "Taipei": "타이베이", "Sicily": "시칠리아", "Penang": "페낭",
+}
+
+
+def field(e, *keys):
+    for k in keys:
+        if k in e and e[k]:
+            return e[k]
+    return ""
+
+
+def first_source(e):
+    s = field(e, "source", "sources", "sourceUrl")
+    if isinstance(s, list):
+        s = s[0] if s else ""
+    return s or ""
+
+
+def norm_key(s):
+    return re.sub(r"\s+", "", (s or "")).lower()
+
+
+def geocode_query(name, district, city):
+    parts = [p for p in [name, district, city] if p]
+    return " ".join(parts)
+
+
+def load_vendors(path):
+    data = json.load(open(path))
+    # the agent may return {"city":..., "vendors":[...]} or a bare list
+    if isinstance(data, dict) and "vendors" in data:
+        data = data["vendors"]
+    return data
+
+
+def main():
+    args = sys.argv[1:]
+    if len(args) < 2:
+        print(__doc__); sys.exit(1)
+    ws_id, vendors_file = args[0], args[1]
+    ws = workspace(ws_id)
+    key = load_google_api_key()
+    entries = load_vendors(vendors_file)
+
+    # group entries by vendor
+    groups = {}
+    order = []
+    for e in entries:
+        name = field(e, "name_original", "vendor_original", "vendor_name_original", "name", "vendor_name")
+        name_ko = field(e, "name_korean", "vendor_korean", "vendor_name_ko", "name_ko")
+        keyname = name or name_ko
+        gk = norm_key(keyname)
+        if not gk:
+            continue
+        if gk not in groups:
+            groups[gk] = {"name": name, "name_ko": name_ko, "city": field(e, "city", "City"),
+                          "district": field(e, "district"), "dishes": [], "sources": [], "note": ""}
+            order.append(gk)
+        g = groups[gk]
+        dish = field(e, "dish_korean", "dish_ko", "dish", "dish_original")
+        if dish and dish not in g["dishes"]:
+            g["dishes"].append(dish)
+        src = first_source(e)
+        if src and src not in g["sources"]:
+            g["sources"].append(src)
+        if not g["city"]:
+            g["city"] = field(e, "city", "City")
+        if not g["note"]:
+            g["note"] = field(e, "note", "notes")
+
+    # geocode each vendor
+    geocoded = {}
+    ok = warn = 0
+    for gk in order:
+        g = groups[gk]
+        q = geocode_query(g["name"], g["district"], g["city"])
+        res, err = search(key, q)
+        entry = {
+            "name": g["name_ko"] or g["name"],
+            "nameOriginal": g["name"],
+            "city": g["city"],
+            "dishes": g["dishes"],
+            "source": "web_research",
+            "sourceUrl": g["sources"][0] if g["sources"] else "",
+            "description": (", ".join(g["dishes"]) + (" — " + g["note"] if g["note"] else ""))[:400],
+        }
+        if err or not res.get("googleMapsId"):
+            entry["geocodeWarning"] = f"geocode failed: {err or 'no id'}"
+            warn += 1
+        else:
+            entry.update(address=res["address"], latitude=res["latitude"], longitude=res["longitude"],
+                         googleMapsId=res["googleMapsId"], googleMapsUri=res["googleMapsUri"])
+            # loose name check across scripts (original names rarely match displayName verbatim)
+            if not (name_matches(g["name"], res.get("displayName", "")) or name_matches(g["name_ko"], res.get("displayName", ""))):
+                entry["geocodeWarning"] = f"displayName '{res.get('displayName')}' vs '{g['name'] or g['name_ko']}'"
+                warn += 1
+            else:
+                ok += 1
+        geocoded[gk] = entry
+        time.sleep(0.3)
+
+    # group by city -> locations.json
+    locfile = ws / "locations.json"
+    if locfile.is_file():
+        out = json.load(open(locfile))
+    else:
+        out = {"videos": []}
+    existing_cities = {v.get("videoId"): v for v in out["videos"]}
+
+    for gk in order:
+        e = geocoded[gk]
+        city = e["city"] or "Unknown"
+        vid = f"city:{city}"
+        v = existing_cities.get(vid)
+        if v is None:
+            ko = KOREAN_PREFIX.get(city, city)
+            v = {"videoId": vid, "title": f"{ko} ({city})", "concept": f"스트리트푸드파이터 — {ko} 편",
+                 "locations": []}
+            out["videos"].append(v); existing_cities[vid] = v
+        if not any(l.get("googleMapsId") == e.get("googleMapsId") and e.get("googleMapsId") for l in v["locations"]):
+            v["locations"].append(e)
+
+    json.dump(out, open(locfile, "w"), ensure_ascii=False, indent=2)
+    print(f"geocode_food_vendors: {ok} ok, {warn} flagged, {len(order)} vendors -> {locfile}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/location_candidates.schema.json
+++ b/.claude/scripts/youtube/location_candidates.schema.json
@@ -36,7 +36,16 @@
               "properties": {
                 "source": {
                   "type": "string",
-                  "enum": ["title", "description", "captions", "audio", "onscreen"]
+                  "enum": [
+                    "title",
+                    "description",
+                    "transcript",
+                    "whisper",
+                    "ocr",
+                    "captions",
+                    "audio",
+                    "onscreen"
+                  ]
                 },
                 "quote": { "type": "string" },
                 "startSeconds": { "type": "number", "minimum": 0 }

--- a/.claude/scripts/youtube/location_candidates.schema.json
+++ b/.claude/scripts/youtube/location_candidates.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["concept", "geographicScope", "locations", "issues"],
+  "properties": {
+    "concept": { "type": "string" },
+    "geographicScope": { "type": "string" },
+    "locations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "aliases",
+          "category",
+          "area",
+          "evidence",
+          "description",
+          "reason",
+          "confidence",
+          "needsVerification"
+        ],
+        "properties": {
+          "name": { "type": "string" },
+          "aliases": { "type": "array", "items": { "type": "string" } },
+          "category": { "type": "string" },
+          "area": { "type": "string" },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["source", "quote", "startSeconds"],
+              "properties": {
+                "source": {
+                  "type": "string",
+                  "enum": ["title", "description", "captions", "audio", "onscreen"]
+                },
+                "quote": { "type": "string" },
+                "startSeconds": { "type": "number", "minimum": 0 }
+              }
+            }
+          },
+          "description": { "type": "string" },
+          "reason": { "type": "string" },
+          "confidence": { "type": "string", "enum": ["high", "medium", "low"] },
+          "needsVerification": { "type": "boolean" }
+        }
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["summary", "startSeconds", "sources"],
+        "properties": {
+          "summary": { "type": "string" },
+          "startSeconds": { "type": "number", "minimum": 0 },
+          "sources": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/.claude/scripts/youtube/merge_enrich.py
+++ b/.claude/scripts/youtube/merge_enrich.py
@@ -1,0 +1,42 @@
+"""Merge _enrich_*.json descriptions back into a workspace locations.json.
+
+Each _enrich_N.json is [{"videoId","name","description"}]. This replaces the
+matching location's description (matched by videoId + exact name).
+
+Usage:
+    uv run python .claude/scripts/youtube/merge_enrich.py <ID>
+"""
+import json
+import sys
+from pathlib import Path
+
+from _common import WS_ROOT
+
+
+def main():
+    if not sys.argv[1:]:
+        print(__doc__)
+        sys.exit(1)
+    ws = WS_ROOT / sys.argv[1]
+    locfile = ws / "locations.json"
+    data = json.load(open(locfile))
+    enrich = {}
+    for p in sorted(ws.glob("_enrich_*.json")):
+        for e in json.load(open(p)):
+            enrich[(e["videoId"], e["name"])] = e["description"]
+    updated = missing = 0
+    for v in data.get("videos", []):
+        vid = v.get("videoId")
+        for loc in v.get("locations", []):
+            key = (vid, loc.get("name"))
+            if key in enrich:
+                loc["description"] = enrich[key]
+                updated += 1
+            else:
+                missing += 1
+    json.dump(data, open(locfile, "w"), ensure_ascii=False, indent=2)
+    print(f"updated {updated} descriptions, {missing} kept as-is ({len(enrich)} enrich entries) -> {locfile}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/merge_redrive.py
+++ b/.claude/scripts/youtube/merge_redrive.py
@@ -1,0 +1,171 @@
+"""Merge re-derivation batch results into a fresh locations.json.
+
+Inputs (in <playlist workspace>/):
+  locations.legacy.json   - old geocoded places (pre-edit) -> reuse geocode + context
+  transcripts.json        - fresh transcripts with segments -> quote -> timestamp
+  batch_N_result.json     - agent output: [{videoId, places:[{name,status,quote,areaHint,context}]}]
+
+For each video:
+  - confirmed place that matches a legacy place (by name) -> reuse legacy geocode +
+    context, refresh timestamp from the quote.
+  - new place (or confirmed with no legacy match) -> geocode by name + areaHint,
+    use agent context.
+  - removed -> dropped.
+Writes locations.json.
+
+Usage: uv run python merge_redrive.py <ID>
+"""
+import glob
+import json
+import re
+import sys
+import time
+
+from _common import load_google_api_key, workspace
+from geocode import search
+
+SEG_JOIN_RE = re.compile(r"\s+")
+
+
+def norm(s):
+    return re.sub(r"\s+", "", (s or "")).lower()
+
+
+def legacy_index(legacy_videos):
+    """videoId -> list of legacy place dicts (with normalized name)."""
+    idx = {}
+    for v in legacy_videos:
+        places = []
+        for l in v.get("locations", []):
+            d = dict(l)
+            d["_norm"] = norm(l.get("name"))
+            places.append(d)
+        idx[v["videoId"]] = places
+    return idx
+
+
+def match_legacy(place_name, legacy_places):
+    n = norm(place_name)
+    if not n:
+        return None
+    # exact normalized first
+    for lp in legacy_places:
+        if lp["_norm"] and lp["_norm"] == n:
+            return lp
+    # substring either way
+    for lp in legacy_places:
+        if lp["_norm"] and (lp["_norm"] in n or n in lp["_norm"]):
+            return lp
+    return None
+
+
+def ts_for_quote(segments, quote):
+    if not quote:
+        return None
+    q = norm(quote)
+    if len(q) < 4:
+        return None
+    ntexts = [norm(s.get("text", "")) for s in segments]
+    offsets = []
+    cum = 0
+    for nt in ntexts:
+        offsets.append(cum)
+        cum += len(nt)
+    total = "".join(ntexts)
+    probe = q[:24]
+    pos = total.find(probe)
+    if pos < 0:
+        pos = total.find(q)
+    if pos < 0:
+        # try last 20 chars (quote may start mid-join)
+        pos = total.find(q[-20:])
+    if pos < 0:
+        return None
+    for i, nt in enumerate(ntexts):
+        if offsets[i] <= pos < offsets[i] + max(len(nt), 1):
+            return segments[i].get("start")
+    return None
+
+
+def main():
+    ws_id = sys.argv[1]
+    ws = workspace(ws_id)
+    key = load_google_api_key()
+    legacy_videos = json.load(open(ws / "locations.legacy.json"))["videos"]
+    legacy = legacy_index(legacy_videos)
+    legacy_concept = {v["videoId"]: v.get("concept", "") for v in legacy_videos}
+    transcripts = {v["videoId"]: v for v in json.load(open(ws / "transcripts.json"))["videos"]}
+    info = json.load(open(ws / "video_info.json"))
+    sel_order = [v["videoId"] for v in info["selectedVideos"]]
+    titles = {v["videoId"]: (v.get("title") or "") for v in info["selectedVideos"]}
+
+    results = {}
+    for f in sorted(glob.glob(str(ws / "batch_*_result.json"))):
+        for entry in json.load(open(f)):
+            results[entry["videoId"]] = entry.get("places", [])
+
+    out_videos = []
+    n_conf = n_reused = n_new = n_geo_new = n_removed = n_notfound = 0
+    for vid in sel_order:
+        segs = transcripts.get(vid, {}).get("segments", [])
+        leg_places = legacy.get(vid, [])
+        agent_places = results.get(vid, [])
+        if not agent_places and not leg_places:
+            continue
+        concept = legacy_concept.get(vid, "")
+        # concept from legacy video if present else from title
+        # (legacy video concept stored separately)
+        locs = []
+        for ap in agent_places:
+            status = ap.get("status", "new")
+            name = ap.get("name", "").strip()
+            quote = ap.get("quote", "")
+            ts = ts_for_quote(segs, quote)
+            if status == "removed":
+                n_removed += 1
+                continue
+            lp = match_legacy(name, leg_places) if status == "confirmed" else None
+            if lp:
+                entry = {
+                    "name": lp.get("name", name),
+                    "address": lp.get("address", ""),
+                    "latitude": lp.get("latitude"),
+                    "longitude": lp.get("longitude"),
+                    "googleMapsId": lp.get("googleMapsId"),
+                    "googleMapsUri": lp.get("googleMapsUri"),
+                    "source": "transcript_mention",
+                    "description": ap.get("context") or lp.get("description") or "",
+                }
+                n_reused += 1; n_conf += 1
+            else:
+                # geocode fresh
+                area = ap.get("areaHint", "")
+                res, err = search(key, f"{name} {area}".strip())
+                entry = {
+                    "name": name,
+                    "source": "transcript_mention",
+                    "description": ap.get("context", ""),
+                }
+                if err or not (res or {}).get("googleMapsId"):
+                    entry["geocodeWarning"] = f"geocode failed: {err or 'no id'}"
+                    n_notfound += 1
+                else:
+                    entry.update(address=res["address"], latitude=res["latitude"],
+                                 longitude=res["longitude"], googleMapsId=res["googleMapsId"],
+                                 googleMapsUri=res["googleMapsUri"])
+                    n_geo_new += 1; n_new += 1
+                time.sleep(0.3)
+            if ts is not None:
+                entry["timestamp"] = ts
+                entry["videoUrlWithTimestamp"] = f"https://www.youtube.com/watch?v={vid}&t={int(ts)}"
+            locs.append(entry)
+        if locs:
+            out_videos.append({"videoId": vid, "title": titles.get(vid, ""), "concept": concept, "locations": locs})
+
+    json.dump({"videos": out_videos}, open(ws / "locations.json", "w"), ensure_ascii=False, indent=2)
+    print(f"{ws_id}: {len(out_videos)} videos, reused {n_reused} legacy geocodes, geocoded {n_geo_new} new, "
+          f"{n_notfound} geocode-failed, {n_removed} removed -> locations.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/prep_redrive_batches.py
+++ b/.claude/scripts/youtube/prep_redrive_batches.py
@@ -1,0 +1,60 @@
+"""Prepare re-derivation batch files from legacy locations + fresh transcripts.
+
+For a playlist, emit batch_N.json files (N videos each) of the form:
+  [{videoId, title, concept, legacyPlaces:[{name, oldTimestamp, context}],
+    transcript: <cleanedText>}]
+A subagent reads one batch file, re-derives places against the CURRENT transcript,
+and returns fresh timestamps + new/removed status. Legacy geocodes are reused at
+merge time, so the agent only handles fuzzy transcript matching + new places.
+
+Usage: uv run python prep_redrive_batches.py <ID> [batch_size]
+"""
+import json
+import sys
+from _common import workspace
+
+BATCH_SIZE = 8
+
+
+def main():
+    ws_id = sys.argv[1]
+    size = int(sys.argv[2]) if len(sys.argv) > 2 else BATCH_SIZE
+    ws = workspace(ws_id)
+    legacy = {v["videoId"]: v for v in json.load(open(ws / "locations.legacy.json"))["videos"]}
+    transcripts = {v["videoId"]: v for v in json.load(open(ws / "transcripts.json"))["videos"]}
+    info = json.load(open(ws / "video_info.json"))
+    sel = info["selectedVideos"]
+
+    batch = []
+    bi = 0
+    for v in sel:
+        vid = v["videoId"]
+        leg = legacy.get(vid)
+        lp = []
+        concept = ""
+        if leg:
+            concept = leg.get("concept", "")
+            for l in leg.get("locations", []):
+                lp.append({"name": l.get("name", ""), "oldTimestamp": l.get("timestamp"),
+                           "context": (l.get("description") or "")[:200]})
+        tr = transcripts.get(vid, {})
+        entry = {
+            "videoId": vid,
+            "title": tr.get("title") or v.get("title", ""),
+            "concept": concept,
+            "isNew": leg is None,
+            "legacyPlaces": lp,
+            "transcript": tr.get("cleanedText", ""),
+        }
+        batch.append(entry)
+        if len(batch) >= size:
+            json.dump(batch, open(ws / f"batch_{bi}.json", "w"), ensure_ascii=False, indent=2)
+            bi += 1; batch = []
+    if batch:
+        json.dump(batch, open(ws / f"batch_{bi}.json", "w"), ensure_ascii=False, indent=2)
+        bi += 1
+    print(f"{ws_id}: wrote {bi} batch files (~{size} videos each) from {len(sel)} videos")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/registry_update.py
+++ b/.claude/scripts/youtube/registry_update.py
@@ -1,0 +1,82 @@
+"""Refresh the S3-backed channel registry through the Admin API.
+
+For a YouTube channel, reads the current registry, rebuilds entries from live
+Sunrei spot data, and asks the server to save the JSON. AWS credentials remain
+owned by the Ktor server.
+
+Usage:
+    uv run python registry_update.py <channelId> <sunreiId1,sunreiId2,...> \
+        [--channel-name "..."] [--channel-link "..."] [--local] [--commit]
+"""
+import json
+import sys
+
+from _common import admin_api, admin_token
+
+def videoIdOf(link):
+    if not link:
+        return None
+    if "v=" in link:
+        return link.split("v=")[-1].split("&")[0]
+    return None
+
+
+def main():
+    args = sys.argv[1:]
+    if len(args) < 2:
+        print(__doc__)
+        sys.exit(1)
+    channel_id = args[0]
+    sunrei_ids = args[1].split(",")
+    name = sys.argv[sys.argv.index("--channel-name") + 1] if "--channel-name" in args else ""
+    link = sys.argv[sys.argv.index("--channel-link") + 1] if "--channel-link" in args else ""
+    commit = "--commit" in args
+    prod = "--local" not in args
+    token = admin_token()
+    if not token:
+        print("Could not resolve an Admin API token.")
+        sys.exit(1)
+
+    existing = {}
+    status, body = admin_api(
+        "GET", f"/admin/resources/youtube/{channel_id}", token, prod=prod
+    )
+    if status == 200 and isinstance(body, dict):
+        existing = body
+    elif status != 404:
+        print(f"registry GET failed: HTTP {status}: {str(body)[:300]}")
+        sys.exit(1)
+
+    # Full rebuild: existing entries are stale (post-DB-reset dead IDs), so build
+    # the sunreis array only from the live Sunrei IDs given. Keep channelName/link.
+    entries = []
+    for sid in sunrei_ids:
+        st, body = admin_api("GET", f"/admin/sunreis/{sid}", token, prod=prod)
+        if st != 200:
+            print(f"skip {sid}: GET {st}"); continue
+        spots = []
+        for s in body.get("spots", []):
+            spots.append({"spotId": s.get("id"), "videoId": videoIdOf(s.get("youtubeLink")),
+                          "videoTitle": (s.get("title") or "")[:200]})
+        entries.append({"sunreiId": sid, "createdAt": body.get("createdAt"), "spots": spots})
+        print(f"  {sid}: {len(spots)} spots")
+
+    out = {"channelName": existing.get("channelName") or name,
+           "link": existing.get("link") or link,
+           "sunreis": entries}
+    if commit:
+        status, body = admin_api(
+            "PUT", f"/admin/resources/youtube/{channel_id}", token, body=out, prod=prod
+        )
+        if status != 200:
+            print(f"registry PUT failed: HTTP {status}: {str(body)[:300]}")
+            sys.exit(1)
+        print(f"saved registry through Admin API: {channel_id}")
+    else:
+        blob = json.dumps(out, ensure_ascii=False, indent=2).encode()
+        print(f"[dry-run] would save {channel_id} ({len(blob)} bytes, {len(entries)} Sunrei entries)")
+    print(f"registry: channel={out['channelName']} sunreis={[r['sunreiId'] for r in out['sunreis']]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/renew_playlists.py
+++ b/.claude/scripts/youtube/renew_playlists.py
@@ -1,0 +1,735 @@
+"""Discover and prepare new videos from configured YouTube playlists.
+
+The command is a dry run unless ``--commit`` is supplied. A committed run
+collects captions, a Whisper transcript, and video OCR; runs the isolated Codex
+transcript and location reviewers; and stops at ``review_pending``. Add
+``--upload`` to store the JSON artifacts in S3. It reads production Sunrei spots
+to avoid duplicate processing, but never changes the Admin API or a Sunrei.
+
+Usage:
+    uv run python .claude/scripts/youtube/renew_playlists.py
+    uv run python .claude/scripts/youtube/renew_playlists.py --commit [--upload]
+"""
+
+import argparse
+import copy
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import urllib.parse
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _common import (
+    ROOT,
+    WS_ROOT,
+    admin_api,
+    admin_token,
+    http_json,
+    load_env,
+    load_google_api_key,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG = ROOT / ".claude" / "config" / "youtube-renewal.json"
+AUTOMATION_ROOT = WS_ROOT / "automation"
+STATE_FILE = AUTOMATION_ROOT / "state.json"
+RUNS_ROOT = AUTOMATION_ROOT / "runs"
+YOUTUBE_API = "https://www.googleapis.com/youtube/v3"
+YOUTUBE_VIDEO_ID = re.compile(
+    r"(?:[?&]v=|youtu\.be/|/embed/|/shorts/)([A-Za-z0-9_-]{11})"
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--state", type=Path, default=STATE_FILE)
+    parser.add_argument("--playlist", action="append", dest="playlist_ids")
+    parser.add_argument("--max-videos", type=int)
+    parser.add_argument("--bootstrap", action="store_true", help="Mark current remote videos as known")
+    parser.add_argument("--commit", action="store_true", help="Write state and process new videos")
+    parser.add_argument("--upload", action="store_true", help="Upload review-pending JSON artifacts")
+    return parser.parse_args()
+
+
+def read_json(path):
+    with Path(path).open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as file:
+        json.dump(value, file, ensure_ascii=False, indent=2)
+        file.write("\n")
+    temporary.replace(path)
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def new_run_id():
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def youtube_get(api_key, resource, params):
+    query = dict(params)
+    query["key"] = api_key
+    url = f"{YOUTUBE_API}/{resource}?{urllib.parse.urlencode(query)}"
+    status, body = http_json("GET", url, timeout=60)
+    if status != 200:
+        raise RuntimeError(f"YouTube API {resource} failed ({status}): {str(body)[:500]}")
+    return body or {}
+
+
+def fetch_playlist(api_key, playlist_id):
+    metadata = youtube_get(
+        api_key,
+        "playlists",
+        {"id": playlist_id, "part": "snippet,contentDetails"},
+    ).get("items", [])
+    if not metadata:
+        raise RuntimeError(f"Playlist not found: {playlist_id}")
+    playlist_snippet = metadata[0].get("snippet", {})
+    videos = []
+    page_token = None
+    while True:
+        params = {
+            "playlistId": playlist_id,
+            "part": "snippet,contentDetails",
+            "maxResults": 50,
+        }
+        if page_token:
+            params["pageToken"] = page_token
+        body = youtube_get(api_key, "playlistItems", params)
+        for item in body.get("items", []):
+            snippet = item.get("snippet", {})
+            video_id = (
+                item.get("contentDetails", {}).get("videoId")
+                or snippet.get("resourceId", {}).get("videoId")
+            )
+            title = snippet.get("title", "")
+            if not video_id or title in {"Deleted video", "Private video"}:
+                continue
+            videos.append(
+                {
+                    "videoId": video_id,
+                    "title": title,
+                    "channelName": snippet.get("videoOwnerChannelTitle")
+                    or playlist_snippet.get("channelTitle", ""),
+                    "position": snippet.get("position", len(videos)),
+                    "playlistAddedAt": snippet.get("publishedAt"),
+                    "url": f"https://www.youtube.com/watch?v={video_id}",
+                }
+            )
+        page_token = body.get("nextPageToken")
+        if not page_token:
+            break
+    return {
+        "id": playlist_id,
+        "title": playlist_snippet.get("title", ""),
+        "channelId": playlist_snippet.get("channelId", ""),
+        "channelName": playlist_snippet.get("channelTitle", ""),
+        "videos": videos,
+    }
+
+
+def best_thumbnail(thumbnails):
+    for key in ("maxres", "standard", "high", "medium", "default"):
+        if thumbnails.get(key, {}).get("url"):
+            return thumbnails[key]["url"]
+    return None
+
+
+def fetch_video_details(api_key, video_ids):
+    output = {}
+    for offset in range(0, len(video_ids), 50):
+        chunk = video_ids[offset : offset + 50]
+        body = youtube_get(
+            api_key,
+            "videos",
+            {"id": ",".join(chunk), "part": "snippet,contentDetails"},
+        )
+        for item in body.get("items", []):
+            snippet = item.get("snippet", {})
+            output[item["id"]] = {
+                "description": snippet.get("description", ""),
+                "publishedAt": snippet.get("publishedAt"),
+                "duration": item.get("contentDetails", {}).get("duration"),
+                "thumbnailUrl": best_thumbnail(snippet.get("thumbnails", {})),
+                "channelId": snippet.get("channelId"),
+                "channelName": snippet.get("channelTitle"),
+            }
+    return output
+
+
+def existing_video_ids(playlist_id):
+    path = WS_ROOT / playlist_id / "video_info.json"
+    if not path.is_file():
+        return []
+    value = read_json(path)
+    return [
+        video.get("videoId")
+        for video in value.get("selectedVideos", [])
+        if video.get("videoId")
+    ]
+
+
+def youtube_video_id(link):
+    if not isinstance(link, str):
+        return None
+    value = link.strip()
+    if re.fullmatch(r"[A-Za-z0-9_-]{11}", value):
+        return value
+    match = YOUTUBE_VIDEO_ID.search(value)
+    return match.group(1) if match else None
+
+
+def production_video_ids(sunrei_id, token):
+    status, body = admin_api(
+        "GET", f"/admin/sunreis/{sunrei_id}", token, prod=True
+    )
+    if status != 200 or not isinstance(body, dict):
+        raise RuntimeError(
+            f"Production Sunrei baseline GET failed for {sunrei_id} "
+            f"(HTTP {status}): {str(body)[:500]}"
+        )
+    spots = body.get("spots")
+    if not isinstance(spots, list):
+        raise RuntimeError(f"Production Sunrei {sunrei_id} has no spots array")
+    return sorted(
+        {
+            video_id
+            for spot in spots
+            if isinstance(spot, dict)
+            for video_id in [youtube_video_id(spot.get("youtubeLink"))]
+            if video_id
+        }
+    )
+
+
+def load_state(path):
+    if not path.is_file():
+        return {"schemaVersion": 1, "updatedAt": None, "playlists": {}}
+    value = read_json(path)
+    if value.get("schemaVersion") != 1:
+        raise ValueError(f"Unsupported state schema in {path}")
+    return value
+
+
+def playlist_state(state, playlist_id):
+    return state["playlists"].setdefault(
+        playlist_id,
+        {
+            "knownVideoIds": existing_video_ids(playlist_id),
+            "videos": {},
+            "lastCheckedAt": None,
+            "remoteVideoCount": None,
+        },
+    )
+
+
+def discover(remote_videos, current_state, external_known=None):
+    known = set(current_state.get("knownVideoIds", []))
+    known.update(external_known or [])
+    known.update(
+        video_id
+        for video_id, value in current_state.get("videos", {}).items()
+        if value.get("status") in {"review_pending", "approved"}
+    )
+    pending_ids = {
+        video_id
+        for video_id, value in current_state.get("videos", {}).items()
+        if value.get("status") not in {"review_pending", "approved"}
+    }
+    by_id = {video["videoId"]: video for video in remote_videos}
+    pending = [by_id[video_id] for video_id in pending_ids if video_id in by_id]
+    new = [
+        video
+        for video in remote_videos
+        if video["videoId"] not in known and video["videoId"] not in pending_ids
+    ]
+    return sorted(pending, key=lambda video: video.get("position", 0)) + sorted(
+        new, key=lambda video: video.get("position", 0)
+    )
+
+
+def parse_json_output(output):
+    decoder = json.JSONDecoder()
+    candidates = []
+    for index, character in enumerate(output):
+        if character != "{":
+            continue
+        try:
+            value, consumed = decoder.raw_decode(output[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            top_level_shape = int(
+                bool(value.get("videoId"))
+                and (isinstance(value.get("segments"), list) or bool(value.get("error")))
+            )
+            candidates.append((top_level_shape, consumed, value))
+    if not candidates:
+        raise RuntimeError(f"Command did not return a JSON object: {output[-1000:]}")
+    return max(candidates, key=lambda candidate: (candidate[0], candidate[1]))[2]
+
+
+def child_environment():
+    env = os.environ.copy()
+    local = load_env()
+    for name in ("SUNREI_YT_COOKIES", "SUNREI_YT_BROWSER"):
+        if local.get(name) and not env.get(name):
+            env[name] = local[name]
+    return env
+
+
+def run_json_command(command, timeout):
+    result = subprocess.run(
+        command,
+        text=True,
+        capture_output=True,
+        env=child_environment(),
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"Command failed ({result.returncode}): {details[-2000:]}")
+    return parse_json_output(result.stdout)
+
+
+def cached_or_run(path, command, timeout):
+    if path.is_file():
+        cached = read_json(path)
+        valid_shape = bool(cached.get("videoId")) and (
+            isinstance(cached.get("segments"), list) or bool(cached.get("error"))
+        )
+        if valid_shape and not cached.get("error"):
+            return cached
+    value = run_json_command(command, timeout)
+    write_json(path, value)
+    return value
+
+
+def attempt_json(path, command, timeout, video_id):
+    try:
+        return cached_or_run(path, command, timeout)
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as error:
+        value = {"videoId": video_id, "error": str(error)[-2000:]}
+        write_json(path, value)
+        return value
+
+
+def normalized_segments(video):
+    segments = []
+    for segment in video.get("segments", []):
+        start = float(segment.get("start") or 0)
+        duration = segment.get("duration")
+        if duration is None and segment.get("end") is not None:
+            duration = max(0, float(segment["end"]) - start)
+        segments.append(
+            {
+                "text": segment.get("text", ""),
+                "start": start,
+                "duration": float(duration or 0),
+            }
+        )
+    return segments
+
+
+def has_segments(value):
+    return isinstance(value, dict) and bool(value.get("segments")) and not value.get("error")
+
+
+def write_primary_transcript(run_dir, metadata, captions, audio, onscreen):
+    primary = captions if has_segments(captions) else audio if has_segments(audio) else onscreen
+    if not has_segments(primary):
+        raise RuntimeError("Captions, audio transcription, and OCR all produced no segments")
+    source = (
+        "youtube_captions"
+        if primary is captions
+        else "whisper"
+        if primary is audio
+        else "ocr_frames"
+    )
+    segments = normalized_segments(primary)
+    full_text = " ".join(segment["text"] for segment in segments)
+    value = {
+        "videos": [
+            {
+                "videoId": metadata["videoId"],
+                "title": metadata.get("title", ""),
+                "language": primary.get("language", "unknown"),
+                "source": source,
+                "segments": segments,
+                "fullText": full_text,
+                "cleanedText": full_text,
+                "approved": False,
+            }
+        ]
+    }
+    write_json(run_dir / "transcripts.json", value)
+    return value
+
+
+def command_uv(*args):
+    return ["uv", "run", *args]
+
+
+def collect_evidence(run_dir, metadata, evidence_config):
+    video_id = metadata["videoId"]
+    video_url = metadata["url"]
+    results = {}
+    if evidence_config.get("captions", True):
+        results["captions"] = attempt_json(
+            run_dir / "captions.json",
+            command_uv(
+                "--with",
+                "youtube-transcript-api",
+                "--with",
+                "python-dotenv",
+                "python",
+                str(SCRIPT_DIR / "extract_transcript.py"),
+                video_id,
+            ),
+            600,
+            video_id,
+        )
+    else:
+        results["captions"] = {"videoId": video_id, "error": "disabled"}
+
+    if evidence_config.get("audio", True):
+        results["audio"] = attempt_json(
+            run_dir / "audio_transcript.json",
+            command_uv(
+                "--python",
+                "3.11",
+                "--with",
+                "yt-dlp",
+                "--with",
+                "openai-whisper",
+                "python",
+                str(SCRIPT_DIR / "whisper_transcribe.py"),
+                video_url,
+                evidence_config.get("whisperModel", "base"),
+            ),
+            7200,
+            video_id,
+        )
+    else:
+        results["audio"] = {"videoId": video_id, "error": "disabled"}
+
+    if evidence_config.get("videoOcr", True):
+        languages = ",".join(evidence_config.get("ocrLanguages", ["ko", "en"]))
+        results["onscreen"] = attempt_json(
+            run_dir / "onscreen_text.json",
+            command_uv(
+                "--python",
+                "3.11",
+                "--with",
+                "easyocr",
+                "--with",
+                "opencv-python-headless",
+                "--with",
+                "yt-dlp",
+                "python",
+                str(SCRIPT_DIR / "extract_onscreen_text.py"),
+                video_url,
+                "--lang",
+                languages,
+                "--interval",
+                str(evidence_config.get("ocrIntervalSeconds", 1.0)),
+            ),
+            7200,
+            video_id,
+        )
+    else:
+        results["onscreen"] = {"videoId": video_id, "error": "disabled"}
+    return results
+
+
+def run_checked(command, timeout):
+    result = subprocess.run(
+        command,
+        text=True,
+        capture_output=True,
+        env=child_environment(),
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"Command failed ({result.returncode}): {details[-2000:]}")
+    if result.stdout.strip():
+        print(result.stdout.strip(), flush=True)
+
+
+def update_run_manifest(run_dir, metadata, status, stages, error=None):
+    value = {
+        "schemaVersion": 1,
+        "playlistId": metadata["playlistId"],
+        "videoId": metadata["videoId"],
+        "runId": metadata["runId"],
+        "status": status,
+        "updatedAt": utc_now(),
+        "stages": stages,
+    }
+    if error:
+        value["error"] = error
+    write_json(run_dir / "run_manifest.json", value)
+
+
+def process_video(
+    config,
+    config_path,
+    playlist,
+    remote_playlist,
+    item,
+    details,
+    record,
+    state,
+    state_path,
+    upload,
+):
+    run_id = record.get("runId") or new_run_id()
+    run_dir = RUNS_ROOT / playlist["id"] / item["videoId"] / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "type": "video",
+        "id": item["videoId"],
+        "videoId": item["videoId"],
+        "playlistId": playlist["id"],
+        "playlistTitle": remote_playlist["title"],
+        "locationStrategy": playlist.get("locationStrategy", "multimodal"),
+        "runId": run_id,
+        **item,
+        **details,
+    }
+    write_json(run_dir / "metadata.json", metadata)
+    write_json(
+        run_dir / "descriptions.json",
+        {item["videoId"]: {"videoId": item["videoId"], "title": item["title"], "description": metadata.get("description", "")}},
+    )
+    record.update(
+        {
+            "runId": run_id,
+            "status": "collecting",
+            "title": item.get("title", ""),
+            "position": item.get("position"),
+            "runDirectory": str(run_dir.relative_to(ROOT)),
+            "updatedAt": utc_now(),
+        }
+    )
+    state["updatedAt"] = utc_now()
+    write_json(state_path, state)
+    stages = {"metadata": "completed", "evidence": "running"}
+    update_run_manifest(run_dir, metadata, "collecting", stages)
+
+    evidence = collect_evidence(run_dir, metadata, config["defaults"]["evidence"])
+    write_primary_transcript(
+        run_dir,
+        metadata,
+        evidence["captions"],
+        evidence["audio"],
+        evidence["onscreen"],
+    )
+    stages["evidence"] = "completed"
+    record["status"] = "reviewing"
+    record["updatedAt"] = utc_now()
+    write_json(state_path, state)
+    update_run_manifest(run_dir, metadata, "reviewing", stages)
+
+    run_checked(
+        command_uv(
+            "python",
+            str(SCRIPT_DIR / "review_transcripts.py"),
+            str(run_dir),
+            "--all",
+            "--chunk-size",
+            str(config["defaults"].get("transcriptReviewChunkSize", 600)),
+        ),
+        7200,
+    )
+    stages["transcriptReview"] = "completed"
+    record["status"] = "extracting_locations"
+    record["updatedAt"] = utc_now()
+    write_json(state_path, state)
+    update_run_manifest(run_dir, metadata, "extracting_locations", stages)
+
+    run_checked(
+        command_uv(
+            "python",
+            str(SCRIPT_DIR / "extract_locations_headless.py"),
+            str(run_dir),
+        ),
+        7200,
+    )
+    stages["locationCandidates"] = "completed"
+
+    if upload:
+        record["status"] = "uploading"
+        record["updatedAt"] = utc_now()
+        write_json(state_path, state)
+        update_run_manifest(run_dir, metadata, "uploading", stages)
+        run_checked(
+            command_uv(
+                "--with",
+                "boto3",
+                "python",
+                str(SCRIPT_DIR / "upload_artifacts.py"),
+                str(run_dir),
+                "--playlist-id",
+                playlist["id"],
+                "--video-id",
+                item["videoId"],
+                "--run-id",
+                run_id,
+                "--config",
+                str(config_path),
+                "--commit",
+            ),
+            900,
+        )
+        stages["artifactUpload"] = "completed"
+
+    record["status"] = "review_pending"
+    record["updatedAt"] = utc_now()
+    record.pop("error", None)
+    update_run_manifest(run_dir, metadata, "review_pending", stages)
+
+
+def main():
+    args = parse_args()
+    if args.upload and not args.commit:
+        raise ValueError("--upload requires --commit")
+    config = read_json(args.config)
+    if config.get("schemaVersion") != 1:
+        raise ValueError(f"Unsupported config schema in {args.config}")
+    state = load_state(args.state)
+    working_state = state if args.commit else copy.deepcopy(state)
+    api_key = load_google_api_key()
+    if not api_key:
+        raise RuntimeError("No YouTube API key found in application-local.conf")
+
+    selected = set(args.playlist_ids or [])
+    playlists = [
+        playlist
+        for playlist in config.get("playlists", [])
+        if (playlist.get("enabled") or playlist["id"] in selected)
+        and (not selected or playlist["id"] in selected)
+    ]
+    missing = selected - {playlist["id"] for playlist in config.get("playlists", [])}
+    if missing:
+        raise ValueError(f"Unknown playlists: {', '.join(sorted(missing))}")
+    max_videos = args.max_videos or config["defaults"].get("maxNewVideosPerRun", 2)
+    if max_videos < 1:
+        raise ValueError("max-videos must be positive")
+    remaining = max_videos
+    had_failures = False
+    print(f"mode={'commit' if args.commit else 'dry-run'} playlists={len(playlists)} maxVideos={max_videos}")
+
+    for playlist in playlists:
+        current = playlist_state(working_state, playlist["id"])
+        remote = fetch_playlist(api_key, playlist["id"])
+        current["lastCheckedAt"] = utc_now()
+        current["remoteVideoCount"] = len(remote["videos"])
+        production_ids = []
+        if playlist.get("sunreiId"):
+            try:
+                token = admin_token()
+                if not token:
+                    raise RuntimeError(
+                        "Could not resolve an Admin API token for the production baseline"
+                    )
+                production_ids = production_video_ids(playlist["sunreiId"], token)
+            except RuntimeError as error:
+                had_failures = True
+                current["productionBaselineError"] = str(error)
+                print(f"{playlist['name']}: blocked: {error}", file=sys.stderr)
+                continue
+            current["productionVideoIds"] = production_ids
+            current["productionCheckedAt"] = utc_now()
+            current.pop("productionBaselineError", None)
+        if args.bootstrap:
+            current["knownVideoIds"] = [video["videoId"] for video in remote["videos"]]
+            current["videos"] = {}
+            print(
+                f"{playlist['name']}: bootstrap {len(remote['videos'])} known videos "
+                f"production={len(production_ids)}"
+            )
+            continue
+
+        candidates = discover(remote["videos"], current, production_ids)
+        remote_ids = {video["videoId"] for video in remote["videos"]}
+        removed_count = sum(
+            1 for video_id in current.get("knownVideoIds", []) if video_id not in remote_ids
+        )
+        print(
+            f"{playlist['name']}: remote={len(remote['videos'])} "
+            f"known={len(current.get('knownVideoIds', []))} "
+            f"production={len(production_ids)} "
+            f"pending/new={len(candidates)} removed={removed_count}"
+        )
+        for item in candidates:
+            marker = "retry" if item["videoId"] in current.get("videos", {}) else "new"
+            print(f"  [{marker}] {item['videoId']} {item['title']}")
+        if not args.commit or remaining <= 0:
+            continue
+
+        chosen = candidates[:remaining]
+        details = fetch_video_details(api_key, [item["videoId"] for item in chosen])
+        for item in chosen:
+            video_id = item["videoId"]
+            record = current["videos"].setdefault(video_id, {"status": "discovered"})
+            try:
+                process_video(
+                    config,
+                    args.config,
+                    playlist,
+                    remote,
+                    item,
+                    details.get(video_id, {}),
+                    record,
+                    working_state,
+                    args.state,
+                    args.upload,
+                )
+                if video_id not in current["knownVideoIds"]:
+                    current["knownVideoIds"].append(video_id)
+                print(f"  review pending: {video_id}")
+            except (OSError, RuntimeError, subprocess.TimeoutExpired) as error:
+                had_failures = True
+                record["status"] = "failed"
+                record["error"] = str(error)[-2000:]
+                record["updatedAt"] = utc_now()
+                print(f"  failed: {video_id}: {error}", file=sys.stderr)
+            working_state["updatedAt"] = utc_now()
+            write_json(args.state, working_state)
+            remaining -= 1
+            if remaining <= 0:
+                break
+
+        delay = config["defaults"].get("captionDelaySeconds", {})
+        if remaining > 0 and chosen:
+            time.sleep(random.uniform(delay.get("min", 60), delay.get("max", 90)))
+
+    if args.commit:
+        working_state["updatedAt"] = utc_now()
+        write_json(args.state, working_state)
+        print(f"state -> {args.state}")
+    if had_failures:
+        raise RuntimeError("One or more playlists could not be renewed; see the errors above")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (FileNotFoundError, KeyError, ValueError, RuntimeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.claude/scripts/youtube/renew_playlists.py
+++ b/.claude/scripts/youtube/renew_playlists.py
@@ -557,6 +557,15 @@ def process_video(
         7200,
     )
     stages["transcriptReview"] = "completed"
+    run_checked(
+        command_uv(
+            "python",
+            str(SCRIPT_DIR / "evidence_timeline.py"),
+            str(run_dir),
+        ),
+        120,
+    )
+    stages["evidenceTimeline"] = "completed"
     record["status"] = "extracting_locations"
     record["updatedAt"] = utc_now()
     write_json(state_path, state)

--- a/.claude/scripts/youtube/review_transcripts.py
+++ b/.claude/scripts/youtube/review_transcripts.py
@@ -1,0 +1,521 @@
+"""Review transcript segments with Codex headless mode.
+
+The source transcript is never changed. Every proposal is recorded in
+``transcript_review.json`` for human approval, and only accepted corrections
+are applied to ``transcripts.reviewed.json``.
+
+Usage:
+    uv run python .claude/scripts/youtube/review_transcripts.py {ID} \
+      --video-id VIDEO_ID
+    uv run python .claude/scripts/youtube/review_transcripts.py {ID} --all
+"""
+import argparse
+import copy
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _common import workspace
+from codex_headless import run_structured
+
+SCHEMA_VERSION = 1
+SCHEMA_FILE = Path(__file__).with_name("transcript_review.schema.json")
+CONFIDENCE_RANK = {"none": 0, "high": 1, "medium": 2}
+AUXILIARY_FILES = {
+    "audio": "audio_transcript.json",
+    "onscreen": "onscreen_text.json",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workspace", help="Workspace ID or directory")
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--video-id", action="append", dest="video_ids")
+    selection.add_argument("--all", action="store_true", help="Review every non-empty transcript")
+    parser.add_argument("--source", default="transcripts.json")
+    parser.add_argument("--hints", default="transcript_review_hints.json")
+    parser.add_argument("--chunk-size", type=int, default=600)
+    parser.add_argument("--max-chars", type=int, default=50000)
+    parser.add_argument("--context", type=int, default=3)
+    parser.add_argument("--model", help="Codex model; defaults to the configured model")
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument(
+        "--max-new-chunks",
+        type=int,
+        help="Stop after this many uncached chunks; useful for staged reviews",
+    )
+    parser.add_argument(
+        "--apply-confidence",
+        choices=CONFIDENCE_RANK,
+        default="none",
+        help="Bulk-apply pending corrections at this confidence (default: none)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print the planned chunks only")
+    parser.add_argument("--restart", action="store_true", help="Discard a stale or partial review")
+    return parser.parse_args()
+
+
+def read_json(path):
+    with path.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def write_json(path, value):
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as file:
+        json.dump(value, file, ensure_ascii=False, indent=2)
+        file.write("\n")
+    temporary.replace(path)
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for block in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_descriptions(ws):
+    path = ws / "descriptions.json"
+    if not path.is_file():
+        return {}
+    data = read_json(path)
+    if isinstance(data, dict):
+        return {
+            video_id: value.get("description", "") if isinstance(value, dict) else ""
+            for video_id, value in data.items()
+        }
+    return {}
+
+
+def load_hints(path):
+    if not path.is_file():
+        return {"global": [], "videos": {}}
+    data = read_json(path)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return {
+        "global": data.get("global", []),
+        "videos": data.get("videos", {}),
+    }
+
+
+def video_hints(hints, video_id):
+    values = list(hints.get("global", []))
+    specific = hints.get("videos", {}).get(video_id, [])
+    if isinstance(specific, dict):
+        specific = specific.get("canonicalEntities", [])
+    values.extend(specific)
+    return [value for value in values if isinstance(value, str) and value.strip()]
+
+
+def load_auxiliary_evidence(ws):
+    evidence = {}
+    for source, file_name in AUXILIARY_FILES.items():
+        path = ws / file_name
+        if not path.is_file():
+            continue
+        value = read_json(path)
+        videos = value.get("videos", []) if isinstance(value, dict) else []
+        if isinstance(value, dict) and value.get("videoId"):
+            videos = [value]
+        for video in videos:
+            video_id = video.get("videoId")
+            if video_id:
+                evidence.setdefault(video_id, {})[source] = video
+    return evidence
+
+
+def segment_end(segment):
+    start = float(segment.get("start") or 0)
+    if segment.get("end") is not None:
+        return float(segment["end"])
+    return start + float(segment.get("duration") or 0)
+
+
+def auxiliary_excerpt(evidence, window_start, window_end, max_chars=20000):
+    output = {}
+    for source, video in evidence.items():
+        selected = []
+        characters = 0
+        for segment in video.get("segments", []):
+            start = float(segment.get("start") or 0)
+            if segment_end(segment) < window_start or start > window_end:
+                continue
+            text = segment.get("text", "")
+            if selected and characters + len(text) > max_chars:
+                break
+            selected.append({"text": text, "start": start, "end": segment_end(segment)})
+            characters += len(text)
+        if selected:
+            output[source] = selected
+    return output
+
+
+def make_chunks(segments, chunk_size, max_chars):
+    start = 0
+    while start < len(segments):
+        end = start
+        characters = 0
+        while end < len(segments) and end - start < chunk_size:
+            size = len(segments[end].get("text", ""))
+            if end > start and characters + size > max_chars:
+                break
+            characters += size
+            end += 1
+        yield start, end
+        start = end
+
+
+def make_prompt(video, description, hints, start, end, context, auxiliary=None):
+    segments = video["segments"]
+    context_start = max(0, start - context)
+    context_end = min(len(segments), end + context)
+    excerpt = [
+        {
+            "segmentIndex": index,
+            "text": segments[index].get("text", ""),
+            "start": segments[index].get("start"),
+            "target": start <= index < end,
+        }
+        for index in range(context_start, context_end)
+    ]
+    window_start = max(0, float(segments[context_start].get("start") or 0) - 5)
+    window_end = segment_end(segments[context_end - 1]) + 5
+    payload = {
+        "videoId": video["videoId"],
+        "title": video.get("title", ""),
+        "language": video.get("language", ""),
+        "description": description[:4000],
+        "canonicalEntityHints": hints,
+        "targetRange": {"startInclusive": start, "endExclusive": end},
+        "segments": excerpt,
+        "auxiliaryEvidence": auxiliary_excerpt(auxiliary or {}, window_start, window_end),
+    }
+    return """You are reviewing a Korean YouTube transcript produced by ASR or OCR.
+
+Return only JSON matching the supplied schema. Do not run commands, inspect
+files, or use tools.
+
+Review only segments whose target field is true. The other segments are context.
+Correct only recognition errors that are clear from the title, description,
+canonical entity hints, repetition in the transcript, and neighboring segments.
+Prioritize wrong person, place, restaurant, dish, and brand names, malformed
+Korean words, omitted syllables, and corrupted Korean/English mixtures.
+
+Rules:
+- Preserve the spoken meaning, tone, and segment boundaries.
+- Never merge, split, add, or remove segments. Do not change timestamps.
+- Do not translate or remove legitimate foreign names, English terms, units,
+  acronyms, or Korean particles attached to them.
+- Do not rewrite a sentence merely to make the speaker more formal or polished.
+- Do not correct ordinary spacing or punctuation unless it is part of a clear
+  recognition error. Prefer a flag over reconstructing speech from plausibility.
+- Audio and on-screen OCR are corroborating evidence. Prefer wording supported
+  by more than one source, but keep a flag when the sources conflict.
+- A title spelling such as `나폴리맛피아` can identify a person or brand; do not
+  globally replace an ordinary word such as `마피아` when context differs.
+- Copy originalText exactly from the input.
+- Use corrections for high- or medium-confidence fixes. Put ambiguous passages
+  in flags and leave suggestion empty when the intended wording is unknown.
+- canonicalEntity is the verified spelling involved in a correction, or an
+  empty string when the correction is not an entity.
+
+Input:
+""" + json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def run_codex(prompt, model, timeout):
+    return run_structured(
+        prompt,
+        SCHEMA_FILE,
+        model=model,
+        timeout=timeout,
+        temp_prefix="sunrei-transcript-review-",
+    )
+
+
+def validate_result(result, video, start, end):
+    segments = video["segments"]
+    accepted = []
+    flags = []
+    rejected = []
+    seen = set()
+
+    for correction in result.get("corrections", []):
+        index = correction.get("segmentIndex")
+        reason = None
+        if not isinstance(index, int) or not start <= index < end:
+            reason = "segmentIndex is outside the target range"
+        elif index in seen:
+            reason = "duplicate correction for the segment"
+        elif correction.get("originalText") != segments[index].get("text", ""):
+            reason = "originalText does not match the source segment"
+        elif not correction.get("correctedText", "").strip():
+            reason = "correctedText is empty"
+        elif correction.get("correctedText") == correction.get("originalText"):
+            reason = "correctedText is unchanged"
+        else:
+            original_length = len(correction["originalText"])
+            corrected_length = len(correction["correctedText"])
+            if corrected_length > max(original_length * 3, original_length + 80):
+                reason = "correctedText is unexpectedly long"
+
+        if reason:
+            rejected.append({"proposal": correction, "reason": reason})
+            continue
+        seen.add(index)
+        accepted.append(correction)
+
+    for flag in result.get("flags", []):
+        index = flag.get("segmentIndex")
+        if not isinstance(index, int) or not start <= index < end:
+            rejected.append({"proposal": flag, "reason": "flag is outside the target range"})
+        elif flag.get("text") != segments[index].get("text", ""):
+            rejected.append({"proposal": flag, "reason": "flag text does not match the source"})
+        else:
+            flags.append(flag)
+    return accepted, flags, rejected
+
+
+def new_review(ws, source_path, source_sha):
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "workspaceId": ws.name,
+        "source": {"file": source_path.name, "sha256": source_sha},
+        "updatedAt": utc_now(),
+        "videos": {},
+    }
+
+
+def load_review(path, ws, source_path, source_sha, restart):
+    if restart or not path.is_file():
+        return new_review(ws, source_path, source_sha)
+    review = read_json(path)
+    if review.get("schemaVersion") != SCHEMA_VERSION:
+        raise ValueError(f"{path} uses a different schema version; rerun with --restart")
+    if review.get("source", {}).get("sha256") != source_sha:
+        raise ValueError(f"{source_path} changed after the review began; rerun with --restart")
+    return review
+
+
+def update_cleaned_text(video, corrections):
+    full_text = video.get("fullText") or " ".join(
+        segment.get("text", "") for segment in video["segments"]
+    )
+    cleaned = video.get("cleanedText") or full_text
+    segment_offsets = []
+    offset = 0
+    for segment in video["segments"]:
+        segment_offsets.append(offset)
+        offset += len(segment.get("text", "")) + 1
+
+    replacements = []
+    claimed = []
+    for correction in corrections:
+        original = correction["originalText"]
+        candidates = [
+            match.start()
+            for match in re.finditer(re.escape(original), cleaned)
+            if not any(match.start() < end and match.end() > start for start, end in claimed)
+        ]
+        if not candidates:
+            correction["cleanedTextWarning"] = "original text was not found in cleanedText"
+            continue
+        expected = int(
+            segment_offsets[correction["segmentIndex"]]
+            * len(cleaned)
+            / max(len(full_text), 1)
+        )
+        position = min(candidates, key=lambda candidate: abs(candidate - expected))
+        end = position + len(original)
+        claimed.append((position, end))
+        replacements.append((position, end, correction["correctedText"]))
+        correction.pop("cleanedTextWarning", None)
+
+    for start, end, corrected in sorted(replacements, reverse=True):
+        cleaned = cleaned[:start] + corrected + cleaned[end:]
+    return cleaned
+
+
+def update_reviewed_transcript(source, review, apply_confidence):
+    reviewed = copy.deepcopy(source)
+    video_by_id = {video["videoId"]: video for video in reviewed.get("videos", [])}
+    threshold = CONFIDENCE_RANK[apply_confidence]
+
+    for video_id, video_review in review.get("videos", {}).items():
+        video = video_by_id.get(video_id)
+        if not video:
+            continue
+        applied = []
+        for correction in video_review.get("corrections", []):
+            decision = correction.setdefault("decision", "pending")
+            should_apply = decision == "accept" or (
+                decision == "pending"
+                and CONFIDENCE_RANK.get(correction.get("confidence"), 99) <= threshold
+            )
+            correction["applied"] = should_apply
+            if not should_apply:
+                continue
+            index = correction["segmentIndex"]
+            segment = video["segments"][index]
+            if segment.get("text", "") != correction["originalText"]:
+                correction["applied"] = False
+                correction["applyError"] = "source segment no longer matches"
+                continue
+            applied.append(correction)
+            correction.pop("applyError", None)
+
+        if not applied:
+            continue
+        cleaned = update_cleaned_text(video, applied)
+        for correction in applied:
+            video["segments"][correction["segmentIndex"]]["text"] = correction["correctedText"]
+        video["fullText"] = " ".join(segment.get("text", "") for segment in video["segments"])
+        video["cleanedText"] = cleaned
+    return reviewed
+
+
+def main():
+    args = parse_args()
+    if args.chunk_size < 1 or args.max_chars < 1 or args.context < 0:
+        raise ValueError("chunk-size and max-chars must be positive; context cannot be negative")
+    if not SCHEMA_FILE.is_file():
+        raise FileNotFoundError(SCHEMA_FILE)
+
+    ws = workspace(args.workspace)
+    source_path = ws / args.source
+    if not source_path.is_file():
+        raise FileNotFoundError(source_path)
+    source = read_json(source_path)
+    source_sha = sha256_file(source_path)
+    descriptions = load_descriptions(ws)
+    hints = load_hints(ws / args.hints)
+    auxiliary = load_auxiliary_evidence(ws)
+    review_path = ws / "transcript_review.json"
+    reviewed_path = ws / "transcripts.reviewed.json"
+    review = load_review(review_path, ws, source_path, source_sha, args.restart)
+
+    requested = set(args.video_ids or [])
+    videos = []
+    for video in source.get("videos", []):
+        if not video.get("segments"):
+            continue
+        if args.all or video.get("videoId") in requested:
+            videos.append(video)
+            requested.discard(video.get("videoId"))
+    if requested:
+        raise ValueError(f"video IDs not found or empty: {', '.join(sorted(requested))}")
+
+    planned = sum(1 for video in videos for _ in make_chunks(video["segments"], args.chunk_size, args.max_chars))
+    print(f"reviewing {len(videos)} videos in {planned} chunks", flush=True)
+    if args.dry_run:
+        for video in videos:
+            chunks = list(make_chunks(video["segments"], args.chunk_size, args.max_chars))
+            print(f"{video['videoId']}: {len(video['segments'])} segments -> {chunks}")
+        return
+
+    completed_now = 0
+    limit_reached = False
+    for video in videos:
+        video_id = video["videoId"]
+        entry = review["videos"].setdefault(
+            video_id,
+            {
+                "title": video.get("title", ""),
+                "segmentCount": len(video["segments"]),
+                "processedChunks": [],
+                "corrections": [],
+                "flags": [],
+                "rejected": [],
+            },
+        )
+        completed = {
+            (chunk["startInclusive"], chunk["endExclusive"])
+            for chunk in entry.get("processedChunks", [])
+        }
+        for start, end in make_chunks(video["segments"], args.chunk_size, args.max_chars):
+            if (start, end) in completed:
+                print(f"{video_id} [{start}:{end}] cached", flush=True)
+                continue
+            if args.max_new_chunks is not None and completed_now >= args.max_new_chunks:
+                limit_reached = True
+                break
+            prompt = make_prompt(
+                video,
+                descriptions.get(video_id, ""),
+                video_hints(hints, video_id),
+                start,
+                end,
+                args.context,
+                auxiliary.get(video_id, {}),
+            )
+            print(f"{video_id} [{start}:{end}] running Codex", flush=True)
+            result = run_codex(prompt, args.model, args.timeout)
+            corrections, flags, rejected = validate_result(result, video, start, end)
+            completed_at = utc_now()
+            for item in corrections:
+                item.update(
+                    {
+                        "decision": "pending",
+                        "chunkStart": start,
+                        "chunkEnd": end,
+                        "reviewedAt": completed_at,
+                    }
+                )
+            for item in flags:
+                item.update({"chunkStart": start, "chunkEnd": end, "reviewedAt": completed_at})
+            for item in rejected:
+                item.update({"chunkStart": start, "chunkEnd": end, "reviewedAt": completed_at})
+            entry["corrections"].extend(corrections)
+            entry["flags"].extend(flags)
+            entry["rejected"].extend(rejected)
+            entry["processedChunks"].append(
+                {
+                    "startInclusive": start,
+                    "endExclusive": end,
+                    "completedAt": completed_at,
+                    "promptSha256": hashlib.sha256(prompt.encode()).hexdigest(),
+                }
+            )
+            review["updatedAt"] = completed_at
+            reviewed = update_reviewed_transcript(source, review, args.apply_confidence)
+            write_json(review_path, review)
+            write_json(reviewed_path, reviewed)
+            completed_now += 1
+            print(
+                f"{video_id} [{start}:{end}] {len(corrections)} corrections, "
+                f"{len(flags)} flags, {len(rejected)} rejected",
+                flush=True,
+            )
+        if limit_reached:
+            break
+
+    reviewed = update_reviewed_transcript(source, review, args.apply_confidence)
+    write_json(review_path, review)
+    write_json(reviewed_path, reviewed)
+    correction_count = sum(len(value.get("corrections", [])) for value in review["videos"].values())
+    flag_count = sum(len(value.get("flags", [])) for value in review["videos"].values())
+    print(
+        f"done: {completed_now} new chunks, {correction_count} corrections, "
+        f"{flag_count} flags -> {reviewed_path}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (FileNotFoundError, ValueError, RuntimeError, subprocess.TimeoutExpired) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.claude/scripts/youtube/run_daily_renewal.sh
+++ b/.claude/scripts/youtube/run_daily_renewal.sh
@@ -1,0 +1,11 @@
+#!/bin/zsh
+set -eu
+
+ROOT="/Users/yongseongkim/Documents/workspace.nosync/sunrei"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+mkdir -p "$ROOT/.claude/workspace/youtube/automation/logs"
+cd "$ROOT"
+
+exec /opt/homebrew/bin/uv run python \
+  .claude/scripts/youtube/renew_playlists.py --commit --upload

--- a/.claude/scripts/youtube/sync_workspace_s3.py
+++ b/.claude/scripts/youtube/sync_workspace_s3.py
@@ -1,0 +1,587 @@
+"""Back up historical YouTube workspaces and playlist baselines to S3.
+
+The command validates every JSON document and reports the upload plan by
+default. Pass ``--commit`` to upload immutable gzip snapshots, manifests, and
+latest pointers. No raw media is accepted.
+
+Usage:
+    uv run --with boto3 python .claude/scripts/youtube/sync_workspace_s3.py
+    uv run --with boto3 python .claude/scripts/youtube/sync_workspace_s3.py --commit
+"""
+
+import argparse
+import gzip
+import hashlib
+import json
+import re
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _common import WS_ROOT, admin_token, load_google_api_key
+from renew_playlists import (
+    DEFAULT_CONFIG,
+    STATE_FILE,
+    existing_video_ids,
+    fetch_playlist,
+    fetch_video_details,
+    load_state,
+    production_video_ids,
+    read_json,
+)
+from upload_artifacts import create_client, public_url
+
+SAFE_ID = re.compile(r"^[A-Za-z0-9_-]+$")
+SECRET_PATTERNS = {
+    "AWS access key ID": re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"),
+    "Google API key": re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"),
+    "private key": re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    "Bearer token": re.compile(r"\bBearer\s+[A-Za-z0-9._~+/-]{20,}=*", re.IGNORECASE),
+}
+SECRET_KEYS = {
+    "awsaccesskeyid",
+    "awssecretaccesskey",
+    "authjwtsecret",
+    "googleapikey",
+    "youtubeapikey",
+}
+SOURCE_FILES = {
+    "audio_transcript.json",
+    "captions.json",
+    "descriptions.json",
+    "metadata.json",
+    "onscreen_text.json",
+    "transcripts_raw.json",
+    "video_info.json",
+}
+NORMALIZED_FILES = {
+    "evidence_timeline.json",
+    "resolved_links.json",
+    "staging.json",
+    "transcripts.json",
+}
+REVIEW_FILES = {
+    "location_candidates.json",
+    "transcript_review.json",
+    "transcript_review_hints.json",
+    "transcripts.reviewed.json",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--state", type=Path, default=STATE_FILE)
+    parser.add_argument("--workspace", type=Path, default=WS_ROOT)
+    parser.add_argument("--playlist", action="append", dest="playlist_ids")
+    parser.add_argument("--snapshot-id")
+    parser.add_argument("--skip-workspace-history", action="store_true")
+    parser.add_argument("--skip-playlist-snapshots", action="store_true")
+    parser.add_argument("--commit", action="store_true")
+    return parser.parse_args()
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def new_snapshot_id():
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def json_bytes(value):
+    return (json.dumps(value, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def validate_id(label, value):
+    if not SAFE_ID.fullmatch(value):
+        raise ValueError(f"Invalid {label}: {value}")
+
+
+def normalized_key(value):
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def find_secret_key(value, path="$"):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            if normalized_key(str(key)) in SECRET_KEYS and child not in (None, ""):
+                return child_path
+            found = find_secret_key(child, child_path)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found = find_secret_key(child, f"{path}[{index}]")
+            if found:
+                return found
+    return None
+
+
+def validate_json_artifact(path):
+    raw = path.read_bytes()
+    try:
+        text = raw.decode("utf-8")
+        value = json.loads(text)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"Invalid UTF-8 JSON in {path}: {error}") from error
+    secret_key = find_secret_key(value)
+    if secret_key:
+        raise ValueError(f"Sensitive key {secret_key} found in {path}")
+    for label, pattern in SECRET_PATTERNS.items():
+        if pattern.search(text):
+            raise ValueError(f"Possible {label} found in {path}")
+    return raw
+
+
+def artifact_role(path):
+    name = path.name
+    if name in SOURCE_FILES or "whisper" in path.parts:
+        return "source"
+    if name in NORMALIZED_FILES:
+        return "source_normalized"
+    if name in REVIEW_FILES:
+        return "review"
+    if name == "locations.json" or name == "locations.legacy.json" or name.endswith("_vendors.json"):
+        return "derived"
+    if name.endswith("_result.json") or name == "_create_manifest.json":
+        return "derived_intermediate"
+    return "debug_intermediate"
+
+
+def artifact_entry(file_name, role, raw, bucket, region, key):
+    compressed = gzip.compress(raw, mtime=0)
+    return {
+        "file": file_name,
+        "role": role,
+        "key": key,
+        "url": public_url(bucket, region, key),
+        "contentType": "application/json",
+        "contentEncoding": "gzip",
+        "size": len(raw),
+        "gzipSize": len(compressed),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+        "gzipSha256": hashlib.sha256(compressed).hexdigest(),
+        "body": compressed,
+    }
+
+
+def manifest_artifacts(entries):
+    return [
+        {key: value for key, value in entry.items() if key != "body"}
+        for entry in entries
+    ]
+
+
+def workspace_snapshot_plans(workspace, configured_ids, snapshot_id, bucket, region, root_prefix):
+    plans = []
+    if not workspace.is_dir():
+        return plans
+    for directory in sorted(path for path in workspace.iterdir() if path.is_dir()):
+        workspace_id = directory.name
+        if workspace_id == "automation":
+            continue
+        validate_id("workspace ID", workspace_id)
+        paths = sorted(directory.rglob("*.json"))
+        if not paths:
+            continue
+        if workspace_id in configured_ids:
+            owner_prefix = f"{root_prefix}/playlists/{workspace_id}"
+            snapshot_prefix = f"{owner_prefix}/workspace-snapshots/{snapshot_id}"
+            latest_key = f"{owner_prefix}/workspace-latest.json"
+            owner_type = "playlist"
+        else:
+            owner_prefix = f"{root_prefix}/workspaces/{workspace_id}"
+            snapshot_prefix = f"{owner_prefix}/snapshots/{snapshot_id}"
+            latest_key = f"{owner_prefix}/latest.json"
+            owner_type = "workspace"
+        entries = []
+        for path in paths:
+            relative = path.relative_to(directory)
+            raw = validate_json_artifact(path)
+            key = f"{snapshot_prefix}/files/{relative.as_posix()}.gz"
+            entries.append(
+                artifact_entry(
+                    relative.as_posix(),
+                    artifact_role(relative),
+                    raw,
+                    bucket,
+                    region,
+                    key,
+                )
+            )
+        manifest_key = f"{snapshot_prefix}/manifest.json"
+        manifest = {
+            "schemaVersion": 1,
+            "snapshotType": "workspace_history",
+            "snapshotId": snapshot_id,
+            "workspaceId": workspace_id,
+            "ownerType": owner_type,
+            "createdAt": utc_now(),
+            "bucket": bucket,
+            "prefix": snapshot_prefix,
+            "artifacts": manifest_artifacts(entries),
+        }
+        latest = {
+            "schemaVersion": 1,
+            "snapshotType": "workspace_history",
+            "snapshotId": snapshot_id,
+            "workspaceId": workspace_id,
+            "artifactCount": len(entries),
+            "manifestKey": manifest_key,
+            "manifestUrl": public_url(bucket, region, manifest_key),
+            "updatedAt": utc_now(),
+        }
+        plans.append(
+            {
+                "label": f"workspace {workspace_id}",
+                "entries": entries,
+                "manifestKey": manifest_key,
+                "manifest": manifest,
+                "latestKey": latest_key,
+                "latest": latest,
+            }
+        )
+    return plans
+
+
+def ordered_unique(*groups):
+    result = []
+    seen = set()
+    for group in groups:
+        for value in group:
+            if value and value not in seen:
+                result.append(value)
+                seen.add(value)
+    return result
+
+
+def playlist_snapshot_plan(
+    playlist_config,
+    remote,
+    details,
+    production_ids,
+    previous_state,
+    snapshot_id,
+    bucket,
+    region,
+    root_prefix,
+):
+    playlist_id = playlist_config["id"]
+    fetched_at = utc_now()
+    videos = [
+        {**video, **details.get(video["videoId"], {})}
+        for video in remote["videos"]
+    ]
+    remote_ids = [video["videoId"] for video in videos]
+    legacy_ids = existing_video_ids(playlist_id)
+    previous = previous_state.get("playlists", {}).get(playlist_id, {})
+    known_ids = ordered_unique(
+        remote_ids,
+        legacy_ids,
+        previous.get("knownVideoIds", []),
+        production_ids,
+    )
+    playlist_value = {
+        "schemaVersion": 1,
+        "snapshotId": snapshot_id,
+        "fetchedAt": fetched_at,
+        "id": playlist_id,
+        "name": playlist_config.get("name"),
+        "title": remote.get("title", ""),
+        "channelId": remote.get("channelId", ""),
+        "channelName": remote.get("channelName", ""),
+        "enabled": bool(playlist_config.get("enabled")),
+        "sunreiId": playlist_config.get("sunreiId"),
+        "locationStrategy": playlist_config.get("locationStrategy"),
+        "videos": videos,
+    }
+    state_value = {
+        "schemaVersion": 1,
+        "playlistId": playlist_id,
+        "snapshotId": snapshot_id,
+        "knownVideoIds": known_ids,
+        "videos": previous.get("videos", {}),
+        "lastCheckedAt": fetched_at,
+        "remoteVideoCount": len(remote_ids),
+        "productionVideoIds": production_ids,
+        "productionCheckedAt": fetched_at,
+        "baseline": {
+            "remoteVideoCount": len(remote_ids),
+            "legacyWorkspaceVideoCount": len(legacy_ids),
+            "productionVideoCount": len(production_ids),
+        },
+    }
+    owner_prefix = f"{root_prefix}/playlists/{playlist_id}"
+    snapshot_prefix = f"{owner_prefix}/snapshots/{snapshot_id}"
+    playlist_key = f"{snapshot_prefix}/playlist.json.gz"
+    state_key = f"{snapshot_prefix}/state.json.gz"
+    entries = [
+        artifact_entry(
+            "playlist.json",
+            "source",
+            json_bytes(playlist_value),
+            bucket,
+            region,
+            playlist_key,
+        ),
+        artifact_entry(
+            "state.json",
+            "state",
+            json_bytes(state_value),
+            bucket,
+            region,
+            state_key,
+        ),
+    ]
+    manifest_key = f"{snapshot_prefix}/manifest.json"
+    manifest = {
+        "schemaVersion": 1,
+        "snapshotType": "playlist_baseline",
+        "snapshotId": snapshot_id,
+        "playlistId": playlist_id,
+        "createdAt": utc_now(),
+        "bucket": bucket,
+        "prefix": snapshot_prefix,
+        "artifacts": manifest_artifacts(entries),
+    }
+    latest = {
+        "schemaVersion": 1,
+        "snapshotType": "playlist_baseline",
+        "snapshotId": snapshot_id,
+        "playlistId": playlist_id,
+        "remoteVideoCount": len(remote_ids),
+        "knownVideoCount": len(known_ids),
+        "playlistKey": playlist_key,
+        "playlistUrl": public_url(bucket, region, playlist_key),
+        "stateKey": state_key,
+        "stateUrl": public_url(bucket, region, state_key),
+        "manifestKey": manifest_key,
+        "manifestUrl": public_url(bucket, region, manifest_key),
+        "updatedAt": utc_now(),
+    }
+    return {
+        "label": f"playlist {playlist_id}",
+        "entries": entries,
+        "manifestKey": manifest_key,
+        "manifest": manifest,
+        "latestKey": f"{owner_prefix}/latest.json",
+        "latest": latest,
+    }
+
+
+def fetch_playlist_plans(config, selected, previous_state, snapshot_id, bucket, region, root_prefix):
+    api_key = load_google_api_key()
+    if not api_key:
+        raise RuntimeError("No YouTube API key found in application-local.conf")
+    token = admin_token()
+    if not token:
+        raise RuntimeError("Could not resolve an Admin API token for production baselines")
+    playlists = [
+        playlist
+        for playlist in config.get("playlists", [])
+        if not selected or playlist["id"] in selected
+    ]
+    missing = selected - {playlist["id"] for playlist in config.get("playlists", [])}
+    if missing:
+        raise ValueError(f"Unknown playlists: {', '.join(sorted(missing))}")
+    plans = []
+    for playlist in playlists:
+        remote = fetch_playlist(api_key, playlist["id"])
+        video_ids = [video["videoId"] for video in remote["videos"]]
+        details = fetch_video_details(api_key, video_ids)
+        production_ids = production_video_ids(playlist["sunreiId"], token)
+        plans.append(
+            playlist_snapshot_plan(
+                playlist,
+                remote,
+                details,
+                production_ids,
+                previous_state,
+                snapshot_id,
+                bucket,
+                region,
+                root_prefix,
+            )
+        )
+        print(
+            f"prepared {playlist['name']}: remote={len(video_ids)} "
+            f"details={len(details)} production={len(production_ids)}",
+            flush=True,
+        )
+    return plans
+
+
+def put_json(client, bucket, key, value, cache_control):
+    body = json_bytes(value)
+    digest = hashlib.sha256(body).hexdigest()
+    client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType="application/json",
+        CacheControl=cache_control,
+        Metadata={"sha256": digest},
+    )
+    return body, digest
+
+
+def verify_entry(client, bucket, entry):
+    head = client.head_object(Bucket=bucket, Key=entry["key"])
+    if head.get("ContentLength") != entry["gzipSize"]:
+        raise RuntimeError(f"Size mismatch for s3://{bucket}/{entry['key']}")
+    if head.get("Metadata", {}).get("sha256") != entry["sha256"]:
+        raise RuntimeError(f"Metadata hash mismatch for s3://{bucket}/{entry['key']}")
+    body = client.get_object(Bucket=bucket, Key=entry["key"])["Body"].read()
+    if hashlib.sha256(body).hexdigest() != entry["gzipSha256"]:
+        raise RuntimeError(f"Compressed hash mismatch for s3://{bucket}/{entry['key']}")
+    if hashlib.sha256(gzip.decompress(body)).hexdigest() != entry["sha256"]:
+        raise RuntimeError(f"Content hash mismatch for s3://{bucket}/{entry['key']}")
+
+
+def verify_json(client, bucket, key, expected_body, expected_digest):
+    head = client.head_object(Bucket=bucket, Key=key)
+    if head.get("ContentLength") != len(expected_body):
+        raise RuntimeError(f"Size mismatch for s3://{bucket}/{key}")
+    if head.get("Metadata", {}).get("sha256") != expected_digest:
+        raise RuntimeError(f"Metadata hash mismatch for s3://{bucket}/{key}")
+    body = client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    if body != expected_body:
+        raise RuntimeError(f"Content mismatch for s3://{bucket}/{key}")
+
+
+def verify_public_json(url, snapshot_id):
+    last_error = None
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(url, timeout=30) as response:
+                value = json.load(response)
+            if value.get("snapshotId") != snapshot_id:
+                raise RuntimeError(f"Unexpected snapshot at {url}")
+            return
+        except (OSError, ValueError, RuntimeError) as error:
+            last_error = error
+            if attempt < 2:
+                time.sleep(1)
+    raise RuntimeError(f"Public read failed for {url}: {last_error}")
+
+
+def upload_plan(client, bucket, region, plan, public):
+    for entry in plan["entries"]:
+        client.put_object(
+            Bucket=bucket,
+            Key=entry["key"],
+            Body=entry["body"],
+            ContentType=entry["contentType"],
+            ContentEncoding=entry["contentEncoding"],
+            CacheControl="public, max-age=31536000, immutable",
+            Metadata={
+                "sha256": entry["sha256"],
+                "gzipsha256": entry["gzipSha256"],
+            },
+        )
+    manifest_body, manifest_digest = put_json(
+        client,
+        bucket,
+        plan["manifestKey"],
+        plan["manifest"],
+        "public, max-age=31536000, immutable",
+    )
+    for entry in plan["entries"]:
+        verify_entry(client, bucket, entry)
+    verify_json(client, bucket, plan["manifestKey"], manifest_body, manifest_digest)
+
+    latest_body, latest_digest = put_json(
+        client,
+        bucket,
+        plan["latestKey"],
+        plan["latest"],
+        "no-cache",
+    )
+    verify_json(client, bucket, plan["latestKey"], latest_body, latest_digest)
+    if public:
+        verify_public_json(
+            public_url(bucket, region, plan["latestKey"]),
+            plan["latest"]["snapshotId"],
+        )
+
+
+def main():
+    args = parse_args()
+    if args.skip_workspace_history and args.skip_playlist_snapshots:
+        raise ValueError("Nothing to sync")
+    snapshot_id = args.snapshot_id or new_snapshot_id()
+    validate_id("snapshot ID", snapshot_id)
+    config = read_json(args.config)
+    if config.get("schemaVersion") != 1:
+        raise ValueError(f"Unsupported config schema in {args.config}")
+    store = config["artifactStore"]
+    bucket = store["bucket"]
+    region = store["region"]
+    root_prefix = store["prefix"].strip("/")
+    selected = set(args.playlist_ids or [])
+    configured_ids = {playlist["id"] for playlist in config.get("playlists", [])}
+    plans = []
+
+    if not args.skip_workspace_history:
+        plans.extend(
+            workspace_snapshot_plans(
+                args.workspace,
+                configured_ids,
+                snapshot_id,
+                bucket,
+                region,
+                root_prefix,
+            )
+        )
+    if not args.skip_playlist_snapshots:
+        previous_state = load_state(args.state)
+        plans.extend(
+            fetch_playlist_plans(
+                config,
+                selected,
+                previous_state,
+                snapshot_id,
+                bucket,
+                region,
+                root_prefix,
+            )
+        )
+    if not plans:
+        raise ValueError("No JSON snapshots found")
+
+    entry_count = sum(len(plan["entries"]) for plan in plans)
+    raw_size = sum(entry["size"] for plan in plans for entry in plan["entries"])
+    gzip_size = sum(entry["gzipSize"] for plan in plans for entry in plan["entries"])
+    mode = "commit" if args.commit else "dry-run"
+    print(
+        f"mode={mode} snapshot={snapshot_id} plans={len(plans)} "
+        f"artifacts={entry_count} rawBytes={raw_size} gzipBytes={gzip_size}"
+    )
+    for plan in plans:
+        print(
+            f"  {plan['label']}: artifacts={len(plan['entries'])} "
+            f"latest=s3://{bucket}/{plan['latestKey']}"
+        )
+    if not args.commit:
+        return
+
+    client = create_client(region)
+    for index, plan in enumerate(plans, start=1):
+        upload_plan(client, bucket, region, plan, bool(store.get("public")))
+        print(f"uploaded and verified [{index}/{len(plans)}] {plan['label']}", flush=True)
+    print(
+        f"uploaded and verified {entry_count} artifacts in {len(plans)} snapshots "
+        f"under s3://{bucket}/{root_prefix}/"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (FileNotFoundError, KeyError, ValueError, RuntimeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.claude/scripts/youtube/tests/test_automation.py
+++ b/.claude/scripts/youtube/tests/test_automation.py
@@ -10,7 +10,8 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_headless import sanitized_environment
 from _common import jwt_is_usable
-from extract_locations_headless import load_evidence, merge_results
+from evidence_timeline import build_timeline, ensure_timeline
+from extract_locations_headless import merge_results, timeline_window
 from renew_playlists import (
     discover,
     parse_json_output,
@@ -100,22 +101,54 @@ class RenewalTests(unittest.TestCase):
             self.assertFalse(video["approved"])
             self.assertEqual(video["segments"][0]["start"], 3.0)
 
-    def test_reviewed_transcript_takes_precedence_for_location_evidence(self):
+    def test_evidence_timeline_combines_and_orders_sources(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             workspace = Path(temp_dir)
-            raw = {"videoId": "abc", "segments": [{"text": "권성중", "start": 0}]}
-            reviewed = {"videos": [{"videoId": "abc", "segments": [{"text": "권성준", "start": 0}]}]}
-            (workspace / "captions.json").write_text(
-                json.dumps(raw, ensure_ascii=False), encoding="utf-8"
-            )
-            (workspace / "transcripts.reviewed.json").write_text(
-                json.dumps(reviewed, ensure_ascii=False), encoding="utf-8"
-            )
+            files = {
+                "metadata.json": {"videoId": "abc", "title": "Title"},
+                "captions.json": {
+                    "videoId": "abc",
+                    "segments": [{"text": "권성중", "start": 10, "duration": 2}],
+                },
+                "transcripts.reviewed.json": {
+                    "videos": [
+                        {
+                            "videoId": "abc",
+                            "language": "ko",
+                            "segments": [{"text": "권성준", "start": 10, "duration": 2}],
+                        }
+                    ]
+                },
+                "audio_transcript.json": {
+                    "videoId": "abc",
+                    "language": "ko",
+                    "segments": [{"text": "오디오", "start": 5, "duration": 2}],
+                },
+                "onscreen_text.json": {
+                    "videoId": "abc",
+                    "language": "ko",
+                    "segments": [{"text": "간판", "start": 7, "duration": 1}],
+                },
+            }
+            for file_name, value in files.items():
+                (workspace / file_name).write_text(
+                    json.dumps(value, ensure_ascii=False), encoding="utf-8"
+                )
 
-            evidence, paths = load_evidence(workspace, "abc")
+            timeline = build_timeline(workspace, "abc")
+            cached, output = ensure_timeline(workspace, "abc")
 
-        self.assertEqual(evidence["captions"]["segments"][0]["text"], "권성준")
-        self.assertEqual({path.name for path in paths}, {"captions.json", "transcripts.reviewed.json"})
+        self.assertEqual(
+            [(event["source"], event["text"]) for event in timeline["events"]],
+            [("whisper", "오디오"), ("ocr", "간판"), ("transcript", "권성준")],
+        )
+        self.assertEqual(timeline["sources"]["transcript"]["file"], "transcripts.reviewed.json")
+        self.assertEqual(cached["inputFingerprint"], timeline["inputFingerprint"])
+        self.assertEqual(output.name, "evidence_timeline.json")
+        self.assertEqual(
+            [event["text"] for event in timeline_window(timeline, 6, 8)],
+            ["오디오", "간판"],
+        )
 
     def test_accepted_correction_updates_missing_cleaned_text(self):
         source = {
@@ -189,6 +222,7 @@ class RenewalTests(unittest.TestCase):
             entries = artifact_entries(run_dir, "bucket", "region", "prefix")
 
         self.assertEqual([entry["file"] for entry in entries], ["metadata.json"])
+        self.assertEqual(entries[0]["role"], "source")
         self.assertEqual(entries[0]["contentEncoding"], "gzip")
         manifest = manifest_value("playlist", "abc", "run", "bucket", "region", "prefix", entries)
         self.assertNotIn("body", manifest["artifacts"][0])

--- a/.claude/scripts/youtube/tests/test_automation.py
+++ b/.claude/scripts/youtube/tests/test_automation.py
@@ -19,6 +19,7 @@ from renew_playlists import (
     youtube_video_id,
 )
 from review_transcripts import update_reviewed_transcript
+from sync_workspace_s3 import validate_json_artifact, workspace_snapshot_plans
 from upload_artifacts import artifact_entries, manifest_value
 
 
@@ -227,6 +228,47 @@ class RenewalTests(unittest.TestCase):
         manifest = manifest_value("playlist", "abc", "run", "bucket", "region", "prefix", entries)
         self.assertNotIn("body", manifest["artifacts"][0])
         self.assertEqual(manifest["reviewStatus"], "pending")
+
+    def test_workspace_snapshot_keeps_json_and_skips_automation_and_raw_media(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+            playlist = workspace / "playlist"
+            playlist.mkdir()
+            (playlist / "video_info.json").write_text(
+                '{"selectedVideos":[]}', encoding="utf-8"
+            )
+            (playlist / "video.mp4").write_bytes(b"raw")
+            automation = workspace / "automation"
+            automation.mkdir()
+            (automation / "state.json").write_text("{}", encoding="utf-8")
+
+            plans = workspace_snapshot_plans(
+                workspace,
+                {"playlist"},
+                "snapshot",
+                "bucket",
+                "region",
+                "youtube/artifacts/v1",
+            )
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]["manifest"]["snapshotType"], "workspace_history")
+        self.assertEqual(
+            [entry["file"] for entry in plans[0]["entries"]],
+            ["video_info.json"],
+        )
+        self.assertEqual(plans[0]["entries"][0]["role"], "source")
+
+    def test_workspace_snapshot_rejects_secret_fields(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "data.json"
+            path.write_text(
+                '{"aws-secret-access-key":"must-not-upload"}',
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "Sensitive key"):
+                validate_json_artifact(path)
 
     def test_codex_environment_removes_ingest_credentials(self):
         previous = dict(os.environ)

--- a/.claude/scripts/youtube/tests/test_automation.py
+++ b/.claude/scripts/youtube/tests/test_automation.py
@@ -1,0 +1,214 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_headless import sanitized_environment
+from _common import jwt_is_usable
+from extract_locations_headless import load_evidence, merge_results
+from renew_playlists import (
+    discover,
+    parse_json_output,
+    write_primary_transcript,
+    youtube_video_id,
+)
+from review_transcripts import update_reviewed_transcript
+from upload_artifacts import artifact_entries, manifest_value
+
+
+class RenewalTests(unittest.TestCase):
+    def test_expired_admin_token_is_not_reused(self):
+        import base64
+
+        payload = base64.urlsafe_b64encode(b'{"exp":1}').rstrip(b"=").decode()
+        self.assertFalse(jwt_is_usable(f"header.{payload}.signature"))
+
+    def test_discover_includes_failed_before_new(self):
+        remote = [
+            {"videoId": "known", "position": 0},
+            {"videoId": "failed", "position": 1},
+            {"videoId": "new", "position": 2},
+        ]
+        state = {
+            "knownVideoIds": ["known"],
+            "videos": {"failed": {"status": "failed"}},
+        }
+
+        self.assertEqual([item["videoId"] for item in discover(remote, state)], ["failed", "new"])
+
+    def test_discover_excludes_production_and_terminal_videos(self):
+        remote = [
+            {"videoId": "production", "position": 0},
+            {"videoId": "reviewed", "position": 1},
+            {"videoId": "new", "position": 2},
+        ]
+        state = {
+            "knownVideoIds": [],
+            "videos": {"reviewed": {"status": "review_pending"}},
+        }
+
+        self.assertEqual(
+            [item["videoId"] for item in discover(remote, state, {"production"})],
+            ["new"],
+        )
+
+    def test_youtube_video_id_supports_spot_link_formats(self):
+        expected = "aDcCeWReTG0"
+        links = [
+            f"https://www.youtube.com/watch?v={expected}&t=30",
+            f"https://youtu.be/{expected}?t=30",
+            f"https://www.youtube.com/shorts/{expected}",
+            f"https://www.youtube.com/embed/{expected}",
+            expected,
+        ]
+
+        self.assertEqual([youtube_video_id(link) for link in links], [expected] * 5)
+        self.assertIsNone(youtube_video_id("https://example.com/not-youtube"))
+
+    def test_parse_json_output_ignores_progress_logs(self):
+        value = {
+            "videoId": "abc",
+            "segments": [{"text": "last nested object", "start": 1, "duration": 2}],
+        }
+        output = "download {not json}\nprogress\n" + json.dumps(value, indent=2)
+        parsed = parse_json_output(output)
+        self.assertEqual(parsed["videoId"], "abc")
+        self.assertEqual(len(parsed["segments"]), 1)
+
+    def test_ocr_can_be_primary_transcript(self):
+        metadata = {"videoId": "abc", "title": "Title"}
+        ocr = {
+            "videoId": "abc",
+            "language": "ko",
+            "segments": [{"text": "장소 이름", "start": 3, "duration": 2}],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            value = write_primary_transcript(
+                Path(temp_dir),
+                metadata,
+                {"error": "no captions"},
+                {"error": "no audio"},
+                ocr,
+            )
+            video = value["videos"][0]
+            self.assertEqual(video["source"], "ocr_frames")
+            self.assertFalse(video["approved"])
+            self.assertEqual(video["segments"][0]["start"], 3.0)
+
+    def test_reviewed_transcript_takes_precedence_for_location_evidence(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+            raw = {"videoId": "abc", "segments": [{"text": "권성중", "start": 0}]}
+            reviewed = {"videos": [{"videoId": "abc", "segments": [{"text": "권성준", "start": 0}]}]}
+            (workspace / "captions.json").write_text(
+                json.dumps(raw, ensure_ascii=False), encoding="utf-8"
+            )
+            (workspace / "transcripts.reviewed.json").write_text(
+                json.dumps(reviewed, ensure_ascii=False), encoding="utf-8"
+            )
+
+            evidence, paths = load_evidence(workspace, "abc")
+
+        self.assertEqual(evidence["captions"]["segments"][0]["text"], "권성준")
+        self.assertEqual({path.name for path in paths}, {"captions.json", "transcripts.reviewed.json"})
+
+    def test_accepted_correction_updates_missing_cleaned_text(self):
+        source = {
+            "videos": [
+                {
+                    "videoId": "abc",
+                    "segments": [{"text": "권성중", "start": 0, "duration": 1}],
+                    "fullText": "권성중입니다",
+                }
+            ]
+        }
+        review = {
+            "videos": {
+                "abc": {
+                    "corrections": [
+                        {
+                            "segmentIndex": 0,
+                            "originalText": "권성중",
+                            "correctedText": "권성준",
+                            "confidence": "high",
+                            "decision": "accept",
+                        }
+                    ]
+                }
+            }
+        }
+
+        reviewed = update_reviewed_transcript(source, review, "none")
+
+        video = reviewed["videos"][0]
+        self.assertEqual(video["segments"][0]["text"], "권성준")
+        self.assertEqual(video["cleanedText"], "권성준입니다")
+
+    def test_location_merge_keeps_pending_decision(self):
+        metadata = {"videoId": "abc", "title": "Title"}
+        first = {
+            "concept": "Tokyo food",
+            "geographicScope": "Tokyo",
+            "locations": [
+                {
+                    "name": "가게 A",
+                    "aliases": [],
+                    "category": "restaurant",
+                    "area": "Tokyo",
+                    "evidence": [{"source": "captions", "quote": "가게 A", "startSeconds": 10}],
+                    "description": "영상에서 방문한 라멘 전문점이다.",
+                    "reason": "visited",
+                    "confidence": "medium",
+                    "needsVerification": False,
+                }
+            ],
+            "issues": [],
+            "window": {"startSeconds": 0, "endSeconds": 100},
+        }
+        second = json.loads(json.dumps(first, ensure_ascii=False))
+        second["locations"][0]["confidence"] = "high"
+        second["locations"][0]["evidence"][0]["source"] = "audio"
+
+        merged = merge_results(metadata, "sha", [first, second])
+
+        self.assertEqual(len(merged["locations"]), 1)
+        self.assertEqual(merged["locations"][0]["confidence"], "high")
+        self.assertEqual(merged["locations"][0]["decision"], "pending")
+        self.assertEqual(len(merged["locations"][0]["evidence"]), 2)
+
+    def test_artifacts_are_gzipped_and_raw_media_is_ignored(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            run_dir = Path(temp_dir)
+            (run_dir / "metadata.json").write_text('{"videoId":"abc"}', encoding="utf-8")
+            (run_dir / "audio.wav").write_bytes(b"raw")
+            entries = artifact_entries(run_dir, "bucket", "region", "prefix")
+
+        self.assertEqual([entry["file"] for entry in entries], ["metadata.json"])
+        self.assertEqual(entries[0]["contentEncoding"], "gzip")
+        manifest = manifest_value("playlist", "abc", "run", "bucket", "region", "prefix", entries)
+        self.assertNotIn("body", manifest["artifacts"][0])
+        self.assertEqual(manifest["reviewStatus"], "pending")
+
+    def test_codex_environment_removes_ingest_credentials(self):
+        previous = dict(os.environ)
+        try:
+            os.environ["AWS_ACCESS_KEY_ID"] = "secret"
+            os.environ["SUNREI_ADMIN_TOKEN"] = "secret"
+            os.environ["PATH"] = "/bin"
+            env = sanitized_environment()
+        finally:
+            os.environ.clear()
+            os.environ.update(previous)
+
+        self.assertNotIn("AWS_ACCESS_KEY_ID", env)
+        self.assertNotIn("SUNREI_ADMIN_TOKEN", env)
+        self.assertEqual(env["PATH"], "/bin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/scripts/youtube/transcript_review.schema.json
+++ b/.claude/scripts/youtube/transcript_review.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["corrections", "flags"],
+  "properties": {
+    "corrections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "segmentIndex",
+          "originalText",
+          "correctedText",
+          "reason",
+          "confidence",
+          "canonicalEntity"
+        ],
+        "properties": {
+          "segmentIndex": { "type": "integer", "minimum": 0 },
+          "originalText": { "type": "string" },
+          "correctedText": { "type": "string" },
+          "reason": { "type": "string" },
+          "confidence": { "type": "string", "enum": ["high", "medium"] },
+          "canonicalEntity": { "type": "string" }
+        }
+      }
+    },
+    "flags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["segmentIndex", "text", "issue", "suggestion"],
+        "properties": {
+          "segmentIndex": { "type": "integer", "minimum": 0 },
+          "text": { "type": "string" },
+          "issue": { "type": "string" },
+          "suggestion": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/.claude/scripts/youtube/update_sunrei_spots.py
+++ b/.claude/scripts/youtube/update_sunrei_spots.py
@@ -1,0 +1,69 @@
+"""Replace all spots on an existing Sunrei with the latest workspace locations.
+
+Preserves the Sunrei ID, source, and published status. GETs the Sunrei, builds a
+PUT that soft-deletes every current spot and adds the new ones from locations.json,
+optionally updating summary/description. Dry-run by default.
+
+Usage:
+    uv run python update_sunrei_spots.py <ID> <SUNREI_ID> [--prod] [--commit]
+        [--summary "..."] [--description "..."] [--tag-ids a,b]
+"""
+import json
+import sys
+
+from _common import admin_api, admin_token, workspace
+from create_sunrei import build_spots
+
+
+def arg(args, flag, default=None):
+    return args[args.index(flag) + 1] if flag in args else default
+
+
+def main():
+    args = sys.argv[1:]
+    ws_id, sunrei_id = args[0], args[1]
+    prod = "--prod" in args
+    commit = "--commit" in args
+    tag_ids = [t for t in arg(args, "--tag-ids", "").split(",") if t]
+    ws = workspace(ws_id)
+    token = admin_token()
+    if not token:
+        print("no admin token"); sys.exit(1)
+
+    st, body = admin_api("GET", f"/admin/sunreis/{sunrei_id}", token, prod=prod)
+    if st != 200:
+        print(f"GET failed {st}: {str(body)[:300]}"); sys.exit(1)
+    old = body.get("spots", [])
+    published = body.get("publishedAt") is not None
+
+    locs = json.load(open(ws / "locations.json"))
+    new_spots, skipped = build_spots(locs, tag_ids)
+
+    # The server auto-soft-deletes existing spots whose id is omitted from the
+    # request, so sending only the new spots (id=null) replaces the set.
+    payload = {"spots": new_spots}
+    if arg(args, "--summary"):
+        payload["summary"] = arg(args, "--summary")
+    if arg(args, "--description"):
+        payload["description"] = arg(args, "--description")
+
+    print(f"--- {'PROD' if prod else 'LOCAL'} {'COMMIT' if commit else 'DRY-RUN'} ---")
+    print(f"sunrei:  {sunrei_id} ({'published' if published else 'draft'})")
+    print(f"delete:  {len(old)} old spots")
+    print(f"add:     {len(new_spots)} new spots" + (f" (+{skipped} skipped, no coords)" if skipped else ""))
+
+    if not commit:
+        print("\nDry-run only. Re-run with --commit to replace.")
+        return
+
+    st, resp = admin_api("PUT", f"/admin/sunreis/{sunrei_id}", token, payload, prod=prod)
+    if st == 200:
+        kept = resp or body
+        nspots = len((resp or {}).get("spots", old))
+        print(f"\n✓ updated {sunrei_id}: now {nspots} spots ({'published' if (kept.get('publishedAt') or published) else 'draft'})")
+    else:
+        print(f"\n✗ update failed {st}: {str(resp)[:400]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/youtube/upload_artifacts.py
+++ b/.claude/scripts/youtube/upload_artifacts.py
@@ -1,4 +1,4 @@
-"""Upload reviewed YouTube JSON artifacts to S3 using SOPS-managed keys.
+"""Upload YouTube source and derived JSON artifacts using SOPS-managed keys.
 
 The default is a dry run. Pass ``--commit`` to decrypt the existing server AWS
 key and upload immutable gzip objects, a run manifest, and ``latest.json``.
@@ -24,17 +24,18 @@ from _common import ROOT
 
 DEFAULT_CONFIG = ROOT / ".claude" / "config" / "youtube-renewal.json"
 SECRETS_FILE = ROOT / "deploy" / "secrets" / "secrets.enc.yaml"
-ALLOWED_FILES = (
-    "metadata.json",
-    "captions.json",
-    "audio_transcript.json",
-    "onscreen_text.json",
-    "transcripts.json",
-    "transcript_review.json",
-    "transcripts.reviewed.json",
-    "location_candidates.json",
-    "run_manifest.json",
-)
+ARTIFACT_ROLES = {
+    "metadata.json": "source",
+    "captions.json": "source",
+    "audio_transcript.json": "source",
+    "onscreen_text.json": "source",
+    "transcripts.json": "source_normalized",
+    "evidence_timeline.json": "source_normalized",
+    "transcript_review.json": "review",
+    "transcripts.reviewed.json": "derived",
+    "location_candidates.json": "derived",
+}
+ALLOWED_FILES = tuple(ARTIFACT_ROLES)
 SAFE_ID = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
@@ -102,6 +103,7 @@ def artifact_entries(run_dir, bucket, region, run_prefix):
         entries.append(
             {
                 "file": file_name,
+                "role": ARTIFACT_ROLES[file_name],
                 "key": key,
                 "url": public_url(bucket, region, key),
                 "contentType": "application/json",

--- a/.claude/scripts/youtube/upload_artifacts.py
+++ b/.claude/scripts/youtube/upload_artifacts.py
@@ -1,0 +1,232 @@
+"""Upload reviewed YouTube JSON artifacts to S3 using SOPS-managed keys.
+
+The default is a dry run. Pass ``--commit`` to decrypt the existing server AWS
+key and upload immutable gzip objects, a run manifest, and ``latest.json``.
+Raw audio and video are never accepted as artifacts.
+
+Usage:
+    uv run --with boto3 python .claude/scripts/youtube/upload_artifacts.py \
+      RUN_DIR --playlist-id ID --video-id ID --run-id ID [--commit]
+"""
+
+import argparse
+import gzip
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _common import ROOT
+
+DEFAULT_CONFIG = ROOT / ".claude" / "config" / "youtube-renewal.json"
+SECRETS_FILE = ROOT / "deploy" / "secrets" / "secrets.enc.yaml"
+ALLOWED_FILES = (
+    "metadata.json",
+    "captions.json",
+    "audio_transcript.json",
+    "onscreen_text.json",
+    "transcripts.json",
+    "transcript_review.json",
+    "transcripts.reviewed.json",
+    "location_candidates.json",
+    "run_manifest.json",
+)
+SAFE_ID = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir", type=Path)
+    parser.add_argument("--playlist-id", required=True)
+    parser.add_argument("--video-id", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--commit", action="store_true")
+    return parser.parse_args()
+
+
+def read_json(path):
+    with Path(path).open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def write_json(path, value):
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as file:
+        json.dump(value, file, ensure_ascii=False, indent=2)
+        file.write("\n")
+    temporary.replace(path)
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def validate_id(label, value):
+    if not SAFE_ID.fullmatch(value):
+        raise ValueError(f"Invalid {label}: {value}")
+
+
+def load_sops_secret(key):
+    result = subprocess.run(
+        ["sops", "-d", "--extract", f'["stringData"]["{key}"]', str(SECRETS_FILE)],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Could not decrypt {key}: {result.stderr.strip()[-500:]}")
+    value = result.stdout.strip()
+    if not value:
+        raise RuntimeError(f"SOPS value {key} is empty")
+    return value
+
+
+def public_url(bucket, region, key):
+    encoded = urllib.parse.quote(key, safe="/")
+    return f"https://{bucket}.s3.{region}.amazonaws.com/{encoded}"
+
+
+def artifact_entries(run_dir, bucket, region, run_prefix):
+    entries = []
+    for file_name in ALLOWED_FILES:
+        path = run_dir / file_name
+        if not path.is_file():
+            continue
+        raw = path.read_bytes()
+        compressed = gzip.compress(raw, mtime=0)
+        key = f"{run_prefix}/{file_name}.gz"
+        entries.append(
+            {
+                "file": file_name,
+                "key": key,
+                "url": public_url(bucket, region, key),
+                "contentType": "application/json",
+                "contentEncoding": "gzip",
+                "size": len(raw),
+                "gzipSize": len(compressed),
+                "sha256": hashlib.sha256(raw).hexdigest(),
+                "gzipSha256": hashlib.sha256(compressed).hexdigest(),
+                "body": compressed,
+            }
+        )
+    return entries
+
+
+def manifest_value(playlist_id, video_id, run_id, bucket, region, run_prefix, entries):
+    return {
+        "schemaVersion": 1,
+        "playlistId": playlist_id,
+        "videoId": video_id,
+        "runId": run_id,
+        "createdAt": utc_now(),
+        "reviewStatus": "pending",
+        "bucket": bucket,
+        "prefix": run_prefix,
+        "artifacts": [
+            {key: value for key, value in entry.items() if key != "body"}
+            for entry in entries
+        ],
+    }
+
+
+def create_client(region):
+    try:
+        import boto3
+    except ImportError as error:
+        raise RuntimeError("boto3 is required for --commit; run with `uv run --with boto3`") from error
+    return boto3.client(
+        "s3",
+        region_name=region,
+        aws_access_key_id=load_sops_secret("aws-access-key-id"),
+        aws_secret_access_key=load_sops_secret("aws-secret-access-key"),
+    )
+
+
+def main():
+    args = parse_args()
+    for label, value in (
+        ("playlist ID", args.playlist_id),
+        ("video ID", args.video_id),
+        ("run ID", args.run_id),
+    ):
+        validate_id(label, value)
+    if not args.run_dir.is_dir():
+        raise FileNotFoundError(args.run_dir)
+
+    config = read_json(args.config)
+    store = config["artifactStore"]
+    bucket = store["bucket"]
+    region = store["region"]
+    root_prefix = store["prefix"].strip("/")
+    video_prefix = f"{root_prefix}/playlists/{args.playlist_id}/videos/{args.video_id}"
+    run_prefix = f"{video_prefix}/runs/{args.run_id}"
+    manifest_key = f"{run_prefix}/manifest.json"
+    latest_key = f"{video_prefix}/latest.json"
+    entries = artifact_entries(args.run_dir, bucket, region, run_prefix)
+    if not entries:
+        raise ValueError(f"No allowed JSON artifacts found in {args.run_dir}")
+    manifest = manifest_value(
+        args.playlist_id,
+        args.video_id,
+        args.run_id,
+        bucket,
+        region,
+        run_prefix,
+        entries,
+    )
+    write_json(args.run_dir / "artifact_manifest.json", manifest)
+
+    if not args.commit:
+        print(f"[dry-run] {len(entries)} artifacts -> s3://{bucket}/{run_prefix}/")
+        print(f"[dry-run] latest -> s3://{bucket}/{latest_key}")
+        return
+
+    client = create_client(region)
+    for entry in entries:
+        client.put_object(
+            Bucket=bucket,
+            Key=entry["key"],
+            Body=entry["body"],
+            ContentType=entry["contentType"],
+            ContentEncoding=entry["contentEncoding"],
+            CacheControl="public, max-age=31536000, immutable",
+            Metadata={"sha256": entry["sha256"]},
+        )
+    manifest_body = json.dumps(manifest, ensure_ascii=False, indent=2).encode()
+    client.put_object(
+        Bucket=bucket,
+        Key=manifest_key,
+        Body=manifest_body,
+        ContentType="application/json",
+        CacheControl="public, max-age=31536000, immutable",
+    )
+    latest = {
+        "schemaVersion": 1,
+        "playlistId": args.playlist_id,
+        "videoId": args.video_id,
+        "runId": args.run_id,
+        "reviewStatus": "pending",
+        "manifestKey": manifest_key,
+        "manifestUrl": public_url(bucket, region, manifest_key),
+        "updatedAt": utc_now(),
+    }
+    client.put_object(
+        Bucket=bucket,
+        Key=latest_key,
+        Body=json.dumps(latest, ensure_ascii=False, indent=2).encode(),
+        ContentType="application/json",
+        CacheControl="no-cache",
+    )
+    print(f"uploaded {len(entries)} artifacts -> s3://{bucket}/{run_prefix}/")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (FileNotFoundError, KeyError, ValueError, RuntimeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.claude/scripts/youtube/whisper_transcribe.py
+++ b/.claude/scripts/youtube/whisper_transcribe.py
@@ -62,6 +62,15 @@ def transcribe(video_url: str, model_name: str = "base"):
             "quiet": True,
             "no_warnings": True,
         }
+        # Optional auth for members-only videos:
+        #   SUNREI_YT_COOKIES=<path to Netscape cookies.txt>
+        #   SUNREI_YT_BROWSER=<chrome|firefox|brave|safari>  (logged-in profile)
+        cf = os.environ.get("SUNREI_YT_COOKIES")
+        cb = os.environ.get("SUNREI_YT_BROWSER")
+        if cf:
+            ydl_opts["cookiefile"] = cf
+        elif cb:
+            ydl_opts["cookiesfrombrowser"] = (cb,)
 
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             ydl.download([video_url])

--- a/.claude/workspace/youtube/PLDarQlAimXcFD3CqCK8TGGDLeUOGJDj6z/_create_manifest.json
+++ b/.claude/workspace/youtube/PLDarQlAimXcFD3CqCK8TGGDLeUOGJDj6z/_create_manifest.json
@@ -1,0 +1,931 @@
+{
+  "sunreiId": "SR01kyhwcyy5f1tf40nvhhxgc17x",
+  "sourceId": "SRC01kyhwcyvmh243xgb308xz76r1",
+  "spots": [
+    {
+      "spotId": "SS01kyhwcyy7cb66vv451hatdvp5",
+      "videoId": "7_1X4BiYRns",
+      "videoTitle": "일본 현대건축 여행ep27/히로오가 도쿄 최고의 부촌인 이유(feat. 일본의 압구정 현대아파트)"
+    },
+    {
+      "spotId": "SS01kyhwcyya7xma6r7wwm1nptkm",
+      "videoId": "7_1X4BiYRns",
+      "videoTitle": "일본 현대건축 여행ep27/히로오가 도쿄 최고의 부촌인 이유(feat. 일본의 압구정 현대아파트)"
+    },
+    {
+      "spotId": "SS01kyhwcyybtjv4tyqzw8zzxsvm",
+      "videoId": "7_1X4BiYRns",
+      "videoTitle": "일본 현대건축 여행ep27/히로오가 도쿄 최고의 부촌인 이유(feat. 일본의 압구정 현대아파트)"
+    },
+    {
+      "spotId": "SS01kyhwcyyd0wjtkegyrpkdtfys",
+      "videoId": "7_1X4BiYRns",
+      "videoTitle": "일본 현대건축 여행ep27/히로오가 도쿄 최고의 부촌인 이유(feat. 일본의 압구정 현대아파트)"
+    },
+    {
+      "spotId": "SS01kyhwcyyfzq59esqp4vk4egzb",
+      "videoId": "7_1X4BiYRns",
+      "videoTitle": "일본 현대건축 여행ep27/히로오가 도쿄 최고의 부촌인 이유(feat. 일본의 압구정 현대아파트)"
+    },
+    {
+      "spotId": "SS01kyhwcyyhdzea43hfh52p2dhq",
+      "videoId": "d62huiunpPQ",
+      "videoTitle": "일본 현대건축 여행ep33/아오야마는 진짜 유명한 느좋 부촌임"
+    },
+    {
+      "spotId": "SS01kyhwcyyng7pqfcnxzg2deg60",
+      "videoId": "d62huiunpPQ",
+      "videoTitle": "일본 현대건축 여행ep33/아오야마는 진짜 유명한 느좋 부촌임"
+    },
+    {
+      "spotId": "SS01kyhwcyyrk8sq1jttvhct2398",
+      "videoId": "d62huiunpPQ",
+      "videoTitle": "일본 현대건축 여행ep33/아오야마는 진짜 유명한 느좋 부촌임"
+    },
+    {
+      "spotId": "SS01kyhwcyytjyczp6xkjg7mqjze",
+      "videoId": "d62huiunpPQ",
+      "videoTitle": "일본 현대건축 여행ep33/아오야마는 진짜 유명한 느좋 부촌임"
+    },
+    {
+      "spotId": "SS01kyhwcyyydn0mktvg5cn8xwcp",
+      "videoId": "d62huiunpPQ",
+      "videoTitle": "일본 현대건축 여행ep33/아오야마는 진짜 유명한 느좋 부촌임"
+    },
+    {
+      "spotId": "SS01kyhwcyyztkb0pxjp4hnxpaah",
+      "videoId": "d62huiunpPQ",
+      "videoTitle": "일본 현대건축 여행ep33/아오야마는 진짜 유명한 느좋 부촌임"
+    },
+    {
+      "spotId": "SS01kyhwcyz1f6c2p527cw5kyxq1",
+      "videoId": "XR0MFKS8brg",
+      "videoTitle": "일본 현대건축 여행ep32/ 미대보다 감각적인 공대, 가나가와공과대학(KAIT)"
+    },
+    {
+      "spotId": "SS01kyhwcyz35zqbksvyf0eqk62c",
+      "videoId": "XR0MFKS8brg",
+      "videoTitle": "일본 현대건축 여행ep32/ 미대보다 감각적인 공대, 가나가와공과대학(KAIT)"
+    },
+    {
+      "spotId": "SS01kyhwcyz4f87dnmwp97hxxtvs",
+      "videoId": "T8rK1SZsNv4",
+      "videoTitle": "일본 현대건축 여행ep.15/도쿄 미술관 투어의 의외의 성지, 우에노, 르 코르뷔지에"
+    },
+    {
+      "spotId": "SS01kyhwcyz7ekdv6h91hhd121pb",
+      "videoId": "T8rK1SZsNv4",
+      "videoTitle": "일본 현대건축 여행ep.15/도쿄 미술관 투어의 의외의 성지, 우에노, 르 코르뷔지에"
+    },
+    {
+      "spotId": "SS01kyhwcyzc8r7yaf65szgz4zs3",
+      "videoId": "ZwbYyONOCZE",
+      "videoTitle": "일본 현대건축 여행ep.1 / 건축가들이 벌이는 패션쇼, 도쿄 오모테산도"
+    },
+    {
+      "spotId": "SS01kyhwcyze9ffrj19z6ykk393d",
+      "videoId": "ZwbYyONOCZE",
+      "videoTitle": "일본 현대건축 여행ep.1 / 건축가들이 벌이는 패션쇼, 도쿄 오모테산도"
+    },
+    {
+      "spotId": "SS01kyhwcyzg8gce8ysecmb8nnge",
+      "videoId": "ZwbYyONOCZE",
+      "videoTitle": "일본 현대건축 여행ep.1 / 건축가들이 벌이는 패션쇼, 도쿄 오모테산도"
+    },
+    {
+      "spotId": "SS01kyhwcyzjm8fhsq3k28e5x632",
+      "videoId": "ZwbYyONOCZE",
+      "videoTitle": "일본 현대건축 여행ep.1 / 건축가들이 벌이는 패션쇼, 도쿄 오모테산도"
+    },
+    {
+      "spotId": "SS01kyhwcyzmc5kmyj8276absz4n",
+      "videoId": "ZwbYyONOCZE",
+      "videoTitle": "일본 현대건축 여행ep.1 / 건축가들이 벌이는 패션쇼, 도쿄 오모테산도"
+    },
+    {
+      "spotId": "SS01kyhwcyznfn7z3yeef44qckpv",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz0mvq9a0wxgbq4qz0e3",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz0px3zvsy3p36razejq",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz0rnm9z2n8k62mphn0s",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz0v6mjg6stwdr23cjgr",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz0yywy45nwf2kshdnes",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz10zde9w2mm00114cam",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz12a3pbd4w42fxrzp28",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz14d5ppwvx1w0n63r9e",
+      "videoId": "uwuZFZXLMmQ",
+      "videoTitle": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기"
+    },
+    {
+      "spotId": "SS01kyhwcz8dgjj3hqwv20e7why5",
+      "videoId": "y5jnQELKvp4",
+      "videoTitle": "일본 현대건축 여행ep.7 / 건축가들이 만든 압도적인 스케일, 도쿄 긴자, 마루노우치"
+    },
+    {
+      "spotId": "SS01kyhwcz150617searj9q285g0",
+      "videoId": "y5jnQELKvp4",
+      "videoTitle": "일본 현대건축 여행ep.7 / 건축가들이 만든 압도적인 스케일, 도쿄 긴자, 마루노우치"
+    },
+    {
+      "spotId": "SS01kyhwcz170atknsfnqh7qmrxj",
+      "videoId": "y5jnQELKvp4",
+      "videoTitle": "일본 현대건축 여행ep.7 / 건축가들이 만든 압도적인 스케일, 도쿄 긴자, 마루노우치"
+    },
+    {
+      "spotId": "SS01kyhwcz19s2k90f34ep0f3jcv",
+      "videoId": "Bn75Zi-RidE",
+      "videoTitle": "영화 '퍼펙트데이즈'가 알려주지 않는 시부야의 이야기 #1"
+    },
+    {
+      "spotId": "SS01kyhwcz1bk8g0h97pq443243z",
+      "videoId": "xX4IXlV5i8M",
+      "videoTitle": "일본 현대건축 여행ep23/아자부다이 힐스가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz1dmbqycmq01awksvfb",
+      "videoId": "xX4IXlV5i8M",
+      "videoTitle": "일본 현대건축 여행ep23/아자부다이 힐스가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz1fwqd9b9w2q8kca0ht",
+      "videoId": "xX4IXlV5i8M",
+      "videoTitle": "일본 현대건축 여행ep23/아자부다이 힐스가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz1gk11fskef02h3m9e5",
+      "videoId": "Kk_zEgXrXeY",
+      "videoTitle": "일본 현대건축 여행ep.4 / 안도 타다오가 북치고 장구치는 곳, 도쿄 시부야"
+    },
+    {
+      "spotId": "SS01kyhwcz1j5w9389fym2kvpx9n",
+      "videoId": "Kk_zEgXrXeY",
+      "videoTitle": "일본 현대건축 여행ep.4 / 안도 타다오가 북치고 장구치는 곳, 도쿄 시부야"
+    },
+    {
+      "spotId": "SS01kyhwcz1m6pwvp37jxj7qfa51",
+      "videoId": "Kk_zEgXrXeY",
+      "videoTitle": "일본 현대건축 여행ep.4 / 안도 타다오가 북치고 장구치는 곳, 도쿄 시부야"
+    },
+    {
+      "spotId": "SS01kyhwcz1n9wr012s2qr88z8jb",
+      "videoId": "Kk_zEgXrXeY",
+      "videoTitle": "일본 현대건축 여행ep.4 / 안도 타다오가 북치고 장구치는 곳, 도쿄 시부야"
+    },
+    {
+      "spotId": "SS01kyhwcz1qpzme8j4hhn6x7hvm",
+      "videoId": "Kk_zEgXrXeY",
+      "videoTitle": "일본 현대건축 여행ep.4 / 안도 타다오가 북치고 장구치는 곳, 도쿄 시부야"
+    },
+    {
+      "spotId": "SS01kyhwcz1s9s2brzarq8z20peq",
+      "videoId": "GYjYEbTaCWE",
+      "videoTitle": "일본 현대건축 여행ep.2 /극T가 들어가도 극F가 되어 나오는 도서관, 기후 미디어 코스모스 모두의 숲"
+    },
+    {
+      "spotId": "SS01kyhwcz1z28pag8gygbh7s1qq",
+      "videoId": "GYjYEbTaCWE",
+      "videoTitle": "일본 현대건축 여행ep.2 /극T가 들어가도 극F가 되어 나오는 도서관, 기후 미디어 코스모스 모두의 숲"
+    },
+    {
+      "spotId": "SS01kyhwcz21w5hrnsp2g8axj4a4",
+      "videoId": "GYjYEbTaCWE",
+      "videoTitle": "일본 현대건축 여행ep.2 /극T가 들어가도 극F가 되어 나오는 도서관, 기후 미디어 코스모스 모두의 숲"
+    },
+    {
+      "spotId": "SS01kyhwcz23hnpw27a03hwra839",
+      "videoId": "MP33JQA586M",
+      "videoTitle": "일본 현대건축 여행 ep.3 /100년을 간직한 의외의 장소, 이케부쿠로 / 프랭크 로이드 라이트에서 쿠마 켄고까지"
+    },
+    {
+      "spotId": "SS01kyhwcz24nd5bt7xrwanjeegq",
+      "videoId": "MP33JQA586M",
+      "videoTitle": "일본 현대건축 여행 ep.3 /100년을 간직한 의외의 장소, 이케부쿠로 / 프랭크 로이드 라이트에서 쿠마 켄고까지"
+    },
+    {
+      "spotId": "SS01kyhwcz260m5yxtccjg2s4vpa",
+      "videoId": "MP33JQA586M",
+      "videoTitle": "일본 현대건축 여행 ep.3 /100년을 간직한 의외의 장소, 이케부쿠로 / 프랭크 로이드 라이트에서 쿠마 켄고까지"
+    },
+    {
+      "spotId": "SS01kyhwcz28w5mgre0rv2w8h6s0",
+      "videoId": "MP33JQA586M",
+      "videoTitle": "일본 현대건축 여행 ep.3 /100년을 간직한 의외의 장소, 이케부쿠로 / 프랭크 로이드 라이트에서 쿠마 켄고까지"
+    },
+    {
+      "spotId": "SS01kyhwcz2asbrvw464r84qzm4y",
+      "videoId": "g9PrE_JzoUw",
+      "videoTitle": "일본 현대건축 여행 ep.5 / 샤넬을 품은 뒷골목, 도쿄 하라주쿠에서 오모테산도까지"
+    },
+    {
+      "spotId": "SS01kyhwcz2brg502anww56rhwhn",
+      "videoId": "g9PrE_JzoUw",
+      "videoTitle": "일본 현대건축 여행 ep.5 / 샤넬을 품은 뒷골목, 도쿄 하라주쿠에서 오모테산도까지"
+    },
+    {
+      "spotId": "SS01kyhwcz2e4djn4ss9bax5myg3",
+      "videoId": "g9PrE_JzoUw",
+      "videoTitle": "일본 현대건축 여행 ep.5 / 샤넬을 품은 뒷골목, 도쿄 하라주쿠에서 오모테산도까지"
+    },
+    {
+      "spotId": "SS01kyhwcz2f1g09zj2f8be3yznx",
+      "videoId": "g9PrE_JzoUw",
+      "videoTitle": "일본 현대건축 여행 ep.5 / 샤넬을 품은 뒷골목, 도쿄 하라주쿠에서 오모테산도까지"
+    },
+    {
+      "spotId": "SS01kyhwcz2h9fvp0hjkqmbkzbdg",
+      "videoId": "g9PrE_JzoUw",
+      "videoTitle": "일본 현대건축 여행 ep.5 / 샤넬을 품은 뒷골목, 도쿄 하라주쿠에서 오모테산도까지"
+    },
+    {
+      "spotId": "SS01kyhwcz2kt9rh5j508psx0hhs",
+      "videoId": "g9PrE_JzoUw",
+      "videoTitle": "일본 현대건축 여행 ep.5 / 샤넬을 품은 뒷골목, 도쿄 하라주쿠에서 오모테산도까지"
+    },
+    {
+      "spotId": "SS01kyhwcz3sk194z8751ka99kby",
+      "videoId": "g9PrE_JzoUw",
+      "videoTitle": "일본 현대건축 여행 ep.5 / 샤넬을 품은 뒷골목, 도쿄 하라주쿠에서 오모테산도까지"
+    },
+    {
+      "spotId": "SS01kyhwcz3vnbwrhmhqtyp4zx9e",
+      "videoId": "HILaFQlPm3k",
+      "videoTitle": "일본 현대건축 여행ep.6/아키하바라가 뻔하다면..? 건축가들이 세운, 오타쿠를 위한 새로운 성지, 토코로자와"
+    },
+    {
+      "spotId": "SS01kyhwcz3wnt5swpk6aa4yj646",
+      "videoId": "HILaFQlPm3k",
+      "videoTitle": "일본 현대건축 여행ep.6/아키하바라가 뻔하다면..? 건축가들이 세운, 오타쿠를 위한 새로운 성지, 토코로자와"
+    },
+    {
+      "spotId": "SS01kyhwcz3yfyqmd7nsvqpzz4t9",
+      "videoId": "QQjNqjsEN0g",
+      "videoTitle": "일본 지역경제를 일으킨 어느 신사. 근데 이제 라노벨을 곁들인..도쿄 이색 건축여행, 토코로자와 신사"
+    },
+    {
+      "spotId": "SS01kyhwcz40e5yz0gtmqah27c5v",
+      "videoId": "QQjNqjsEN0g",
+      "videoTitle": "일본 지역경제를 일으킨 어느 신사. 근데 이제 라노벨을 곁들인..도쿄 이색 건축여행, 토코로자와 신사"
+    },
+    {
+      "spotId": "SS01kyhwcz415xwy5jh7v279m5m4",
+      "videoId": "zHiMkbqTHJU",
+      "videoTitle": "일본 현대건축 여행ep.8/도쿄 올드머니의 상징 긴자, 에르메스에서 로로피아나, 긴자식스까지"
+    },
+    {
+      "spotId": "SS01kyhwcz43kk889szej915s5sg",
+      "videoId": "zHiMkbqTHJU",
+      "videoTitle": "일본 현대건축 여행ep.8/도쿄 올드머니의 상징 긴자, 에르메스에서 로로피아나, 긴자식스까지"
+    },
+    {
+      "spotId": "SS01kyhwcz47vb5nppky2asapytm",
+      "videoId": "zHiMkbqTHJU",
+      "videoTitle": "일본 현대건축 여행ep.8/도쿄 올드머니의 상징 긴자, 에르메스에서 로로피아나, 긴자식스까지"
+    },
+    {
+      "spotId": "SS01kyhwcz4acn9ndqfwj08w6sg9",
+      "videoId": "zHiMkbqTHJU",
+      "videoTitle": "일본 현대건축 여행ep.8/도쿄 올드머니의 상징 긴자, 에르메스에서 로로피아나, 긴자식스까지"
+    },
+    {
+      "spotId": "SS01kyhwcz4cs1xevk4q8n3fap2s",
+      "videoId": "zHiMkbqTHJU",
+      "videoTitle": "일본 현대건축 여행ep.8/도쿄 올드머니의 상징 긴자, 에르메스에서 로로피아나, 긴자식스까지"
+    },
+    {
+      "spotId": "SS01kyhwcz4grdmz5djwfwdg3gt4",
+      "videoId": "zHiMkbqTHJU",
+      "videoTitle": "일본 현대건축 여행ep.8/도쿄 올드머니의 상징 긴자, 에르메스에서 로로피아나, 긴자식스까지"
+    },
+    {
+      "spotId": "SS01kyhwcz4jzsz5gfd48pv6whfj",
+      "videoId": "oK0Htyl1-VQ",
+      "videoTitle": "일본 현대건축 여행ep.9/긴자에서 만나는 건축과 지구의 미래"
+    },
+    {
+      "spotId": "SS01kyhwcz4mrqcphf8qbj3k023j",
+      "videoId": "oK0Htyl1-VQ",
+      "videoTitle": "일본 현대건축 여행ep.9/긴자에서 만나는 건축과 지구의 미래"
+    },
+    {
+      "spotId": "SS01kyhwcz4pntkkz1gy26qtz83f",
+      "videoId": "ks9z5MwLHXY",
+      "videoTitle": "일본 현대건축 여행ep.10/쿠마몬 말고 안도 타다오...구마모토 여행에서 꼭 봐야하는 건축물"
+    },
+    {
+      "spotId": "SS01kyhwcz4thb8860m56y6e183y",
+      "videoId": "ks9z5MwLHXY",
+      "videoTitle": "일본 현대건축 여행ep.10/쿠마몬 말고 안도 타다오...구마모토 여행에서 꼭 봐야하는 건축물"
+    },
+    {
+      "spotId": "SS01kyhwcz54abasccqfrj567qcp",
+      "videoId": "ks9z5MwLHXY",
+      "videoTitle": "일본 현대건축 여행ep.10/쿠마몬 말고 안도 타다오...구마모토 여행에서 꼭 봐야하는 건축물"
+    },
+    {
+      "spotId": "SS01kyhwcz5500gxmptfnn9r0vz9",
+      "videoId": "BgF6rLnyoGs",
+      "videoTitle": "일본 현대건축 여행ep.11/구마모토와 천재 건축가들의 만남, 구마모토 아트폴리스"
+    },
+    {
+      "spotId": "SS01kyhwcz57syp6rwe4mpck8ff9",
+      "videoId": "BgF6rLnyoGs",
+      "videoTitle": "일본 현대건축 여행ep.11/구마모토와 천재 건축가들의 만남, 구마모토 아트폴리스"
+    },
+    {
+      "spotId": "SS01kyhwcz592kz2jmj0mtw5fs6h",
+      "videoId": "J8FcWsEif-k",
+      "videoTitle": "일본 현대건축 여행ep.12/후쿠오카 여행을 더욱 재미있게 부수는 방법, 후쿠오카 주요 관광지의 건축물 구경하기"
+    },
+    {
+      "spotId": "SS01kyhwcz5ade0wsxq7x2h0kte9",
+      "videoId": "J8FcWsEif-k",
+      "videoTitle": "일본 현대건축 여행ep.12/후쿠오카 여행을 더욱 재미있게 부수는 방법, 후쿠오카 주요 관광지의 건축물 구경하기"
+    },
+    {
+      "spotId": "SS01kyhwcz5cmphpbtmqmnsmb2sn",
+      "videoId": "J8FcWsEif-k",
+      "videoTitle": "일본 현대건축 여행ep.12/후쿠오카 여행을 더욱 재미있게 부수는 방법, 후쿠오카 주요 관광지의 건축물 구경하기"
+    },
+    {
+      "spotId": "SS01kyhwcz5d1wabbyemrxp3x62x",
+      "videoId": "J8FcWsEif-k",
+      "videoTitle": "일본 현대건축 여행ep.12/후쿠오카 여행을 더욱 재미있게 부수는 방법, 후쿠오카 주요 관광지의 건축물 구경하기"
+    },
+    {
+      "spotId": "SS01kyhwcz5fscd11fw642dtgfxb",
+      "videoId": "J8FcWsEif-k",
+      "videoTitle": "일본 현대건축 여행ep.12/후쿠오카 여행을 더욱 재미있게 부수는 방법, 후쿠오카 주요 관광지의 건축물 구경하기"
+    },
+    {
+      "spotId": "SS01kyhwcz5hfc5av65gtyftgnvg",
+      "videoId": "J8FcWsEif-k",
+      "videoTitle": "일본 현대건축 여행ep.12/후쿠오카 여행을 더욱 재미있게 부수는 방법, 후쿠오카 주요 관광지의 건축물 구경하기"
+    },
+    {
+      "spotId": "SS01kyhwcz5j6qjbk3588ej8fnmp",
+      "videoId": "J8FcWsEif-k",
+      "videoTitle": "일본 현대건축 여행ep.12/후쿠오카 여행을 더욱 재미있게 부수는 방법, 후쿠오카 주요 관광지의 건축물 구경하기"
+    },
+    {
+      "spotId": "SS01kyhwcz5m5bj9yy2seb3xs4e0",
+      "videoId": "g7J0tViEQ1o",
+      "videoTitle": "일본 현대건축 여행ep.13/무라카미 하루키와 나츠메 소세키의 서재, 도쿄 와세다"
+    },
+    {
+      "spotId": "SS01kyhwcz5n6316k54nrs01qm69",
+      "videoId": "g7J0tViEQ1o",
+      "videoTitle": "일본 현대건축 여행ep.13/무라카미 하루키와 나츠메 소세키의 서재, 도쿄 와세다"
+    },
+    {
+      "spotId": "SS01kyhwcz5q86fk28yqcyztg3ac",
+      "videoId": "g7J0tViEQ1o",
+      "videoTitle": "일본 현대건축 여행ep.13/무라카미 하루키와 나츠메 소세키의 서재, 도쿄 와세다"
+    },
+    {
+      "spotId": "SS01kyhwcz5rjdaajz4x969axv77",
+      "videoId": "fXAtHT096Vc",
+      "videoTitle": "일본 현대건축 여행ep.16/신주쿠 여행시 알아두면 더욱 재미있는 건축물TMI"
+    },
+    {
+      "spotId": "SS01kyhwcz6wem6bwxyn0q0j8kv5",
+      "videoId": "fXAtHT096Vc",
+      "videoTitle": "일본 현대건축 여행ep.16/신주쿠 여행시 알아두면 더욱 재미있는 건축물TMI"
+    },
+    {
+      "spotId": "SS01kyhwcz6yj4y8b3tnbqzq7awf",
+      "videoId": "fXAtHT096Vc",
+      "videoTitle": "일본 현대건축 여행ep.16/신주쿠 여행시 알아두면 더욱 재미있는 건축물TMI"
+    },
+    {
+      "spotId": "SS01kyhwcz6zvagr80e2xg2wefdx",
+      "videoId": "fXAtHT096Vc",
+      "videoTitle": "일본 현대건축 여행ep.16/신주쿠 여행시 알아두면 더욱 재미있는 건축물TMI"
+    },
+    {
+      "spotId": "SS01kyhwcz71fzw97h96vwxk3kzb",
+      "videoId": "9Y38r0HGjCs",
+      "videoTitle": "일본 현대건축 여행ep.17/도쿄 최고의 미술관에는 소장품이 단 하나도 없다? 롯본기 국립신미술관"
+    },
+    {
+      "spotId": "SS01kyhwcz737d60nwpm4qrpp9jr",
+      "videoId": "XUNlP214vXU",
+      "videoTitle": "도쿄대 캠퍼스 투어 / 최고의 건축가들이 지켜낸 최고의 대학교"
+    },
+    {
+      "spotId": "SS01kyhwcz74tcdjp83wes8bqh3b",
+      "videoId": "XUNlP214vXU",
+      "videoTitle": "도쿄대 캠퍼스 투어 / 최고의 건축가들이 지켜낸 최고의 대학교"
+    },
+    {
+      "spotId": "SS01kyhwcz76pq2stwm2mr39mmwn",
+      "videoId": "XUNlP214vXU",
+      "videoTitle": "도쿄대 캠퍼스 투어 / 최고의 건축가들이 지켜낸 최고의 대학교"
+    },
+    {
+      "spotId": "SS01kyhwcz7ev86gd84y577shb4w",
+      "videoId": "XUNlP214vXU",
+      "videoTitle": "도쿄대 캠퍼스 투어 / 최고의 건축가들이 지켜낸 최고의 대학교"
+    },
+    {
+      "spotId": "SS01kyhwcz7hb9sbt92y1zvj85gm",
+      "videoId": "XUNlP214vXU",
+      "videoTitle": "도쿄대 캠퍼스 투어 / 최고의 건축가들이 지켜낸 최고의 대학교"
+    },
+    {
+      "spotId": "SS01kyhwcz7kqza9ctmhk8yrwefs",
+      "videoId": "XUNlP214vXU",
+      "videoTitle": "도쿄대 캠퍼스 투어 / 최고의 건축가들이 지켜낸 최고의 대학교"
+    },
+    {
+      "spotId": "SS01kyhwcz7mg05rr6yrw68e7te7",
+      "videoId": "XUNlP214vXU",
+      "videoTitle": "도쿄대 캠퍼스 투어 / 최고의 건축가들이 지켜낸 최고의 대학교"
+    },
+    {
+      "spotId": "SS01kyhwcz7p1n3t50t4s3e30tvs",
+      "videoId": "STp0ugXlXfY",
+      "videoTitle": "일본 현대건축 여행ep19/누가 아사쿠사를 묻거든, 고개를 들어 지붕을 보게 하라"
+    },
+    {
+      "spotId": "SS01kyhwcz7q8fa3vnm5mx99xcpc",
+      "videoId": "STp0ugXlXfY",
+      "videoTitle": "일본 현대건축 여행ep19/누가 아사쿠사를 묻거든, 고개를 들어 지붕을 보게 하라"
+    },
+    {
+      "spotId": "SS01kyhwcz7s7rzd22nccwkd0zy0",
+      "videoId": "STp0ugXlXfY",
+      "videoTitle": "일본 현대건축 여행ep19/누가 아사쿠사를 묻거든, 고개를 들어 지붕을 보게 하라"
+    },
+    {
+      "spotId": "SS01kyhwcz7tepfejw2r0ypgt20v",
+      "videoId": "STp0ugXlXfY",
+      "videoTitle": "일본 현대건축 여행ep19/누가 아사쿠사를 묻거든, 고개를 들어 지붕을 보게 하라"
+    },
+    {
+      "spotId": "SS01kyhwcz7whn70rdf8gmd7zjq7",
+      "videoId": "STp0ugXlXfY",
+      "videoTitle": "일본 현대건축 여행ep19/누가 아사쿠사를 묻거든, 고개를 들어 지붕을 보게 하라"
+    },
+    {
+      "spotId": "SS01kyhwcz7xz8tk3p4s02p1g8tx",
+      "videoId": "STp0ugXlXfY",
+      "videoTitle": "일본 현대건축 여행ep19/누가 아사쿠사를 묻거든, 고개를 들어 지붕을 보게 하라"
+    },
+    {
+      "spotId": "SS01kyhwcz7z7t2ys1a3vnkc5qev",
+      "videoId": "JZoN83wn5dA",
+      "videoTitle": "일본 현대건축 여행ep20/다이칸야마가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz808sy8a0j99ydfyver",
+      "videoId": "JZoN83wn5dA",
+      "videoTitle": "일본 현대건축 여행ep20/다이칸야마가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz88xwjp4f9mc273gqhw",
+      "videoId": "JZoN83wn5dA",
+      "videoTitle": "일본 현대건축 여행ep20/다이칸야마가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz89mzsjx9p4fx4w2419",
+      "videoId": "JZoN83wn5dA",
+      "videoTitle": "일본 현대건축 여행ep20/다이칸야마가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz8bpgjynt6x7tewthtp",
+      "videoId": "JZoN83wn5dA",
+      "videoTitle": "일본 현대건축 여행ep20/다이칸야마가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz8earj52gmtzrvtnc1x",
+      "videoId": "JZoN83wn5dA",
+      "videoTitle": "일본 현대건축 여행ep20/다이칸야마가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz8gy5wapz21pa7aqf06",
+      "videoId": "JZoN83wn5dA",
+      "videoTitle": "일본 현대건축 여행ep20/다이칸야마가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwcz8jpyrwa7f4e5c60jn3",
+      "videoId": "ib1dbfCDn8o",
+      "videoTitle": "일본 현대건축 여행ep21/나카메구로 카페 투어. 근데 이제 건축을 곁들인"
+    },
+    {
+      "spotId": "SS01kyhwcz8k9szx9amdvnxfhghq",
+      "videoId": "ib1dbfCDn8o",
+      "videoTitle": "일본 현대건축 여행ep21/나카메구로 카페 투어. 근데 이제 건축을 곁들인"
+    },
+    {
+      "spotId": "SS01kyhwcza09vbdkbfws27zcfvj",
+      "videoId": "ib1dbfCDn8o",
+      "videoTitle": "일본 현대건축 여행ep21/나카메구로 카페 투어. 근데 이제 건축을 곁들인"
+    },
+    {
+      "spotId": "SS01kyhwcza2c1kvc8w5wd7p4jdt",
+      "videoId": "ib1dbfCDn8o",
+      "videoTitle": "일본 현대건축 여행ep21/나카메구로 카페 투어. 근데 이제 건축을 곁들인"
+    },
+    {
+      "spotId": "SS01kyhwcza34zmc9qrzg3b6hgvq",
+      "videoId": "ib1dbfCDn8o",
+      "videoTitle": "일본 현대건축 여행ep21/나카메구로 카페 투어. 근데 이제 건축을 곁들인"
+    },
+    {
+      "spotId": "SS01kyhwcza51mp96ejm2yy5b8yv",
+      "videoId": "ib1dbfCDn8o",
+      "videoTitle": "일본 현대건축 여행ep21/나카메구로 카페 투어. 근데 이제 건축을 곁들인"
+    },
+    {
+      "spotId": "SS01kyhwcza7c124wxqcgkp3nzde",
+      "videoId": "ib1dbfCDn8o",
+      "videoTitle": "일본 현대건축 여행ep21/나카메구로 카페 투어. 근데 이제 건축을 곁들인"
+    },
+    {
+      "spotId": "SS01kyhwcza8gdjjksa3mvt29e8m",
+      "videoId": "pLseKjqPvkc",
+      "videoTitle": "일본 현대건축 여행ep22/건축가,디자이너가 저출산을 해결하려 하면 벌어지는 일"
+    },
+    {
+      "spotId": "SS01kyhwczaad3c4czdfv3dgbj6p",
+      "videoId": "ohtvVIl-rF4",
+      "videoTitle": "일본 현대건축 여행ep.24/후쿠오카 넥서스 월드. 버블경제가 상상한 미래도시의 모습은?"
+    },
+    {
+      "spotId": "SS01kyhwczac30fmmcrkv2g2zb9a",
+      "videoId": "ohtvVIl-rF4",
+      "videoTitle": "일본 현대건축 여행ep.24/후쿠오카 넥서스 월드. 버블경제가 상상한 미래도시의 모습은?"
+    },
+    {
+      "spotId": "SS01kyhwczadfemdejqxwzfsp471",
+      "videoId": "tx8CGpVPmAs",
+      "videoTitle": "일본 현대건축 여행ep25/시로카네다이가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczafer3sbr7580hwgq12",
+      "videoId": "tx8CGpVPmAs",
+      "videoTitle": "일본 현대건축 여행ep25/시로카네다이가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczag2bqy92z9jwmv8b22",
+      "videoId": "tx8CGpVPmAs",
+      "videoTitle": "일본 현대건축 여행ep25/시로카네다이가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczajcvwe1wdwny79s67d",
+      "videoId": "tx8CGpVPmAs",
+      "videoTitle": "일본 현대건축 여행ep25/시로카네다이가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczakkzc65ajdga139qvc",
+      "videoId": "tx8CGpVPmAs",
+      "videoTitle": "일본 현대건축 여행ep25/시로카네다이가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczamf9q0etvfhey841fz",
+      "videoId": "tx8CGpVPmAs",
+      "videoTitle": "일본 현대건축 여행ep25/시로카네다이가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczappqjcybzmwc6xm8ev",
+      "videoId": "g5uvDtMPgys",
+      "videoTitle": "영화 '퍼펙트데이즈'가 알려주지 않는 시부야의 이야기 #2"
+    },
+    {
+      "spotId": "SS01kyhwczaqx2zyaeaqem44ee6t",
+      "videoId": "g5uvDtMPgys",
+      "videoTitle": "영화 '퍼펙트데이즈'가 알려주지 않는 시부야의 이야기 #2"
+    },
+    {
+      "spotId": "SS01kyhwczasrhvdg3tda5d31w4n",
+      "videoId": "svLNosI6E2Q",
+      "videoTitle": "일본 현대건축 여행ep26/오타니의 고향이 알려주는 지방(?)의 익힘 정도, 이와테 시와초"
+    },
+    {
+      "spotId": "SS01kyhwczat678ntjasbknv6yyv",
+      "videoId": "svLNosI6E2Q",
+      "videoTitle": "일본 현대건축 여행ep26/오타니의 고향이 알려주는 지방(?)의 익힘 정도, 이와테 시와초"
+    },
+    {
+      "spotId": "SS01kyhwczawn1ww5vpzqndmfbmt",
+      "videoId": "D6RL3kQ0pWc",
+      "videoTitle": "일본 현대건축 여행ep28/도쿄여행을 더욱 깊이있게 다녀오는 방법"
+    },
+    {
+      "spotId": "SS01kyhwczay1pr3p6w0ywx24vgr",
+      "videoId": "D6RL3kQ0pWc",
+      "videoTitle": "일본 현대건축 여행ep28/도쿄여행을 더욱 깊이있게 다녀오는 방법"
+    },
+    {
+      "spotId": "SS01kyhwczaza91jty3c5njrm0bg",
+      "videoId": "D6RL3kQ0pWc",
+      "videoTitle": "일본 현대건축 여행ep28/도쿄여행을 더욱 깊이있게 다녀오는 방법"
+    },
+    {
+      "spotId": "SS01kyhwczb15dejara3asd4r1zh",
+      "videoId": "D6RL3kQ0pWc",
+      "videoTitle": "일본 현대건축 여행ep28/도쿄여행을 더욱 깊이있게 다녀오는 방법"
+    },
+    {
+      "spotId": "SS01kyhwczb30tdvdfedzyrfja0a",
+      "videoId": "Zb4GyroZoVc",
+      "videoTitle": "일본 현대건축 여행ep29/스타벅스가 도쿄 소도시에 만든 특별한 매장, 스타벅스 사이닝 스토어"
+    },
+    {
+      "spotId": "SS01kyhwczb4rsmd0z1tdnb3e63v",
+      "videoId": "J8sDgpgvtt0",
+      "videoTitle": "일본 현대건축 여행ep30/투박하지만 독보적 감성을 품은 곳, 나고야"
+    },
+    {
+      "spotId": "SS01kyhwczb6zsc4sbbwseeakk89",
+      "videoId": "J8sDgpgvtt0",
+      "videoTitle": "일본 현대건축 여행ep30/투박하지만 독보적 감성을 품은 곳, 나고야"
+    },
+    {
+      "spotId": "SS01kyhwczb7s5yesvj66acdw8ww",
+      "videoId": "J8sDgpgvtt0",
+      "videoTitle": "일본 현대건축 여행ep30/투박하지만 독보적 감성을 품은 곳, 나고야"
+    },
+    {
+      "spotId": "SS01kyhwczbcfcnedfz4rdpfvt7q",
+      "videoId": "J8sDgpgvtt0",
+      "videoTitle": "일본 현대건축 여행ep30/투박하지만 독보적 감성을 품은 곳, 나고야"
+    },
+    {
+      "spotId": "SS01kyhwczbe19v0qvxzqq8kf9a0",
+      "videoId": "J8sDgpgvtt0",
+      "videoTitle": "일본 현대건축 여행ep30/투박하지만 독보적 감성을 품은 곳, 나고야"
+    },
+    {
+      "spotId": "SS01kyhwczbftqt1ygaw1ctbwv7k",
+      "videoId": "J8sDgpgvtt0",
+      "videoTitle": "일본 현대건축 여행ep30/투박하지만 독보적 감성을 품은 곳, 나고야"
+    },
+    {
+      "spotId": "SS01kyhwczbh3788pnhsver6zm77",
+      "videoId": "mw8gbfXM06Y",
+      "videoTitle": "일본 현대건축 여행ep31/거장이 설계한 대학 캠퍼스 뒤에 숨겨진 불편한 진실"
+    },
+    {
+      "spotId": "SS01kyhwczbj2gvcsqvajp5j3c95",
+      "videoId": "vI_3a0SsxpE",
+      "videoTitle": "일본 건축여행ep34/시모키타자와, 빈티(?)와 빈티지 사이의 외줄타기"
+    },
+    {
+      "spotId": "SS01kyhwczbmn4x2mbkbyt83bj62",
+      "videoId": "vI_3a0SsxpE",
+      "videoTitle": "일본 건축여행ep34/시모키타자와, 빈티(?)와 빈티지 사이의 외줄타기"
+    },
+    {
+      "spotId": "SS01kyhwczbn6nw83zn27z5xv1bh",
+      "videoId": "vI_3a0SsxpE",
+      "videoTitle": "일본 건축여행ep34/시모키타자와, 빈티(?)와 빈티지 사이의 외줄타기"
+    },
+    {
+      "spotId": "SS01kyhwczbqxktw32kqqmzbcgs4",
+      "videoId": "vI_3a0SsxpE",
+      "videoTitle": "일본 건축여행ep34/시모키타자와, 빈티(?)와 빈티지 사이의 외줄타기"
+    },
+    {
+      "spotId": "SS01kyhwczbrj20pdt4nz6dhdyyw",
+      "videoId": "vI_3a0SsxpE",
+      "videoTitle": "일본 건축여행ep34/시모키타자와, 빈티(?)와 빈티지 사이의 외줄타기"
+    },
+    {
+      "spotId": "SS01kyhwczbt8bybvpzkbk25ndh4",
+      "videoId": "vI_3a0SsxpE",
+      "videoTitle": "일본 건축여행ep34/시모키타자와, 빈티(?)와 빈티지 사이의 외줄타기"
+    },
+    {
+      "spotId": "SS01kyhwczbvsm8bkhr0w6m0hgdv",
+      "videoId": "hVWm_ElNTWQ",
+      "videoTitle": "일본 건축여행ep35/지방도시에 공공도서관 건립은 세금낭비일까?"
+    },
+    {
+      "spotId": "SS01kyhwczd5rncdbs3maa3p6s6f",
+      "videoId": "hVWm_ElNTWQ",
+      "videoTitle": "일본 건축여행ep35/지방도시에 공공도서관 건립은 세금낭비일까?"
+    },
+    {
+      "spotId": "SS01kyhwczd648vv62p7bsf8ch6d",
+      "videoId": "REvGuvL5Mhs",
+      "videoTitle": "도쿄 필수코스 또 생겼네...조감도 뚫고 나온 아시아 최대급 신상 티파니"
+    },
+    {
+      "spotId": "SS01kyhwczd7e6qpkyvmzdv658wr",
+      "videoId": "REvGuvL5Mhs",
+      "videoTitle": "도쿄 필수코스 또 생겼네...조감도 뚫고 나온 아시아 최대급 신상 티파니"
+    },
+    {
+      "spotId": "SS01kyhwczd9pqtfef07sh9nnvb8",
+      "videoId": "REvGuvL5Mhs",
+      "videoTitle": "도쿄 필수코스 또 생겼네...조감도 뚫고 나온 아시아 최대급 신상 티파니"
+    },
+    {
+      "spotId": "SS01kyhwczdap05mfttts09j63gb",
+      "videoId": "REvGuvL5Mhs",
+      "videoTitle": "도쿄 필수코스 또 생겼네...조감도 뚫고 나온 아시아 최대급 신상 티파니"
+    },
+    {
+      "spotId": "SS01kyhwczdcdx5gyk1x8q403nk8",
+      "videoId": "xs22pKzUwiQ",
+      "videoTitle": "특이점이 온 도쿄의 도시공원 퀄리티"
+    },
+    {
+      "spotId": "SS01kyhwczddpwxkntp0hh5fc3dn",
+      "videoId": "xs22pKzUwiQ",
+      "videoTitle": "특이점이 온 도쿄의 도시공원 퀄리티"
+    },
+    {
+      "spotId": "SS01kyhwczdegm32gw36epj5zckg",
+      "videoId": "xs22pKzUwiQ",
+      "videoTitle": "특이점이 온 도쿄의 도시공원 퀄리티"
+    },
+    {
+      "spotId": "SS01kyhwczdfbfgtcc40apth9sbw",
+      "videoId": "Sq5B9MVF7Vs",
+      "videoTitle": "일본 건축여행ep38/도쿄 MZ들이 가장 많이 찾는 공간, 가메아리 아트 센터 by DAIKEI MILLS"
+    },
+    {
+      "spotId": "SS01kyhwczdhhh1edkxh4bcbhw0q",
+      "videoId": "Sq5B9MVF7Vs",
+      "videoTitle": "일본 건축여행ep38/도쿄 MZ들이 가장 많이 찾는 공간, 가메아리 아트 센터 by DAIKEI MILLS"
+    },
+    {
+      "spotId": "SS01kyhwczdjajdvvzny44y9v5be",
+      "videoId": "Sq5B9MVF7Vs",
+      "videoTitle": "일본 건축여행ep38/도쿄 MZ들이 가장 많이 찾는 공간, 가메아리 아트 센터 by DAIKEI MILLS"
+    },
+    {
+      "spotId": "SS01kyhwczdkdecm12rvvrmmp63n",
+      "videoId": "PbGdaHPlhJ8",
+      "videoTitle": "일본 건축여행ep39/도쿄에서 에렌 예거 체험하기, 메구로 천공정원"
+    },
+    {
+      "spotId": "SS01kyhwczdn61tj4kdpcx176jw0",
+      "videoId": "PbGdaHPlhJ8",
+      "videoTitle": "일본 건축여행ep39/도쿄에서 에렌 예거 체험하기, 메구로 천공정원"
+    },
+    {
+      "spotId": "SS01kyhwczdppq7v734b1a24ztpz",
+      "videoId": "PbGdaHPlhJ8",
+      "videoTitle": "일본 건축여행ep39/도쿄에서 에렌 예거 체험하기, 메구로 천공정원"
+    },
+    {
+      "spotId": "SS01kyhwczdr88s2msf0x7h87k7x",
+      "videoId": "PbGdaHPlhJ8",
+      "videoTitle": "일본 건축여행ep39/도쿄에서 에렌 예거 체험하기, 메구로 천공정원"
+    },
+    {
+      "spotId": "SS01kyhwczdsscpb06aa1rr148vx",
+      "videoId": "Y_wbeg8GBQg",
+      "videoTitle": "일본 건축여행ep40/토라노몬 힐즈가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczdtkn6q1byjba5fahbw",
+      "videoId": "Y_wbeg8GBQg",
+      "videoTitle": "일본 건축여행ep40/토라노몬 힐즈가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczdw79ss5heb6f89tx1m",
+      "videoId": "Y_wbeg8GBQg",
+      "videoTitle": "일본 건축여행ep40/토라노몬 힐즈가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczdxfxr35sch5tkx2td3",
+      "videoId": "Y_wbeg8GBQg",
+      "videoTitle": "일본 건축여행ep40/토라노몬 힐즈가 도쿄 최고의 부촌인 이유"
+    },
+    {
+      "spotId": "SS01kyhwczdzc783txybtqkb9021",
+      "videoId": "LP8zWRrT8C0",
+      "videoTitle": "오사카 건축여행ep1/시장통이 일본 제 2의 도시가 될 수 있었던 건에 관하여"
+    },
+    {
+      "spotId": "SS01kyhwcze0b57m5489w8h2rn2g",
+      "videoId": "LP8zWRrT8C0",
+      "videoTitle": "오사카 건축여행ep1/시장통이 일본 제 2의 도시가 될 수 있었던 건에 관하여"
+    },
+    {
+      "spotId": "SS01kyhwcze1pgwsaby7dd0t57mm",
+      "videoId": "LP8zWRrT8C0",
+      "videoTitle": "오사카 건축여행ep1/시장통이 일본 제 2의 도시가 될 수 있었던 건에 관하여"
+    },
+    {
+      "spotId": "SS01kyhwcze5pxn6pzp7qajetgrf",
+      "videoId": "LP8zWRrT8C0",
+      "videoTitle": "오사카 건축여행ep1/시장통이 일본 제 2의 도시가 될 수 있었던 건에 관하여"
+    },
+    {
+      "spotId": "SS01kyhwczege0p50d52qtfqa2en",
+      "videoId": "LP8zWRrT8C0",
+      "videoTitle": "오사카 건축여행ep1/시장통이 일본 제 2의 도시가 될 수 있었던 건에 관하여"
+    },
+    {
+      "spotId": "SS01kyhwczejnmyd8y89379s52xp",
+      "videoId": "LP8zWRrT8C0",
+      "videoTitle": "오사카 건축여행ep1/시장통이 일본 제 2의 도시가 될 수 있었던 건에 관하여"
+    },
+    {
+      "spotId": "SS01kyhwczemmw0wz2cvbv80askq",
+      "videoId": "1W8nkiSRaBs",
+      "videoTitle": "서울은 철거, 오사카는 보존? 비슷한 두 건축물의 엇갈린 운명 l 오사카 건축여행ep2. 세운상가와 센바센터빌딩"
+    },
+    {
+      "spotId": "SS01kyhwczeny11dfzwjfzh6v896",
+      "videoId": "1xg7PqZuoGU",
+      "videoTitle": "일본 건축여행ep43/ 아파트만 짓는다고 살기 좋은 곳이 될까? 도쿄 근교에서 찾은 해답, MUFG PARK LIBRARY"
+    },
+    {
+      "spotId": "SS01kyhwczeqebk9qdn3503r51h1",
+      "videoId": "skhNkILNIec",
+      "videoTitle": "일본 건축여행ep.44/우에노가 도쿄 문화예술의 중심지가 된 이유, 우에노 도쿄도미술관"
+    },
+    {
+      "spotId": "SS01kyhwczetqx0yywtrbwhpdkkk",
+      "videoId": "skhNkILNIec",
+      "videoTitle": "일본 건축여행ep.44/우에노가 도쿄 문화예술의 중심지가 된 이유, 우에노 도쿄도미술관"
+    },
+    {
+      "spotId": "SS01kyhwczew1qhhp54ctq61wv9t",
+      "videoId": "WB6sz4NVzgs",
+      "videoTitle": "일본 건축여행ep.45/일본 미니멀리즘의 끝판왕, 우에노 호류지 보물관"
+    },
+    {
+      "spotId": "SS01kyhwczexzhmz9cfresw96r2z",
+      "videoId": "WB6sz4NVzgs",
+      "videoTitle": "일본 건축여행ep.45/일본 미니멀리즘의 끝판왕, 우에노 호류지 보물관"
+    },
+    {
+      "spotId": "SS01kyhwczeyyynzfc3xt3v9wn34",
+      "videoId": "4xBYEVitri4",
+      "videoTitle": "일본은 어떻게 세계 건축 강국이 되었을까? / 우에노 국립서양미술관"
+    },
+    {
+      "spotId": "SS01kyhwczezka0e2408kpew8vdf",
+      "videoId": "4xBYEVitri4",
+      "videoTitle": "일본은 어떻게 세계 건축 강국이 되었을까? / 우에노 국립서양미술관"
+    },
+    {
+      "spotId": "SS01kyhwczf1ckbxvk73009rzggj",
+      "videoId": "4xBYEVitri4",
+      "videoTitle": "일본은 어떻게 세계 건축 강국이 되었을까? / 우에노 국립서양미술관"
+    },
+    {
+      "spotId": "SS01kyhwczf299g943j6yxz45bqa",
+      "videoId": "4xBYEVitri4",
+      "videoTitle": "일본은 어떻게 세계 건축 강국이 되었을까? / 우에노 국립서양미술관"
+    },
+    {
+      "spotId": "SS01kyhwczg81zswwzgw6mfcedj0",
+      "videoId": "4xBYEVitri4",
+      "videoTitle": "일본은 어떻게 세계 건축 강국이 되었을까? / 우에노 국립서양미술관"
+    },
+    {
+      "spotId": "SS01kyhwczga8qxn7a5zcz8qcy7n",
+      "videoId": "XC848GyKaKk",
+      "videoTitle": "일본 건축여행ep.47/ 취향이 미술관이 되는 도쿄 최고의 부촌 '쇼토'"
+    },
+    {
+      "spotId": "SS01kyhwczgcbjrrx3fxjwxm4qr7",
+      "videoId": "XC848GyKaKk",
+      "videoTitle": "일본 건축여행ep.47/ 취향이 미술관이 되는 도쿄 최고의 부촌 '쇼토'"
+    },
+    {
+      "spotId": "SS01kyhwczge43a1m9y3f0nmkt0b",
+      "videoId": "XC848GyKaKk",
+      "videoTitle": "일본 건축여행ep.47/ 취향이 미술관이 되는 도쿄 최고의 부촌 '쇼토'"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLDarQlAimXcFD3CqCK8TGGDLeUOGJDj6z/video_info.json
+++ b/.claude/workspace/youtube/PLDarQlAimXcFD3CqCK8TGGDLeUOGJDj6z/video_info.json
@@ -1,0 +1,431 @@
+{
+  "type": "playlist",
+  "id": "PLDarQlAimXcFD3CqCK8TGGDLeUOGJDj6z",
+  "title": "X=일본 건축여행",
+  "description": "",
+  "url": "https://www.youtube.com/playlist?list=PLDarQlAimXcFD3CqCK8TGGDLeUOGJDj6z",
+  "channelName": "풀어봤어X",
+  "channel": {
+    "id": "UCCRbWnjemxbvSnAhXUDek-g",
+    "title": "풀어봤어X",
+    "handle": "@wabixabi",
+    "url": "https://www.youtube.com/@wabixabi",
+    "description": "도쿄에서 가구와 건축을 덕질합니다\n📷 : https://www.instagram.com/wabixabi.jp/\n✉️ :Chaew8k@gmail.com",
+    "thumbnailUrl": "https://yt3.ggpht.com/8nFzCWG2MI7pSytRo0kcTlhe5mmNgM-U4VEhBwvUKtsTs6xY-R98LG9cnGXebG3vKo5M7f02Vw=s800-c-k-c0x00ffffff-no-rj"
+  },
+  "selectedVideos": [
+    {
+      "videoId": "7_1X4BiYRns",
+      "title": "일본 현대건축 여행ep27/히로오가 도쿄 최고의 부촌인 이유(feat. 일본의 압구정 현대아파트)",
+      "channelName": "풀어봤어X",
+      "position": 0,
+      "url": "https://www.youtube.com/watch?v=7_1X4BiYRns"
+    },
+    {
+      "videoId": "d62huiunpPQ",
+      "title": "일본 현대건축 여행ep33/아오야마는 진짜 유명한 느좋 부촌임",
+      "channelName": "풀어봤어X",
+      "position": 1,
+      "url": "https://www.youtube.com/watch?v=d62huiunpPQ"
+    },
+    {
+      "videoId": "XR0MFKS8brg",
+      "title": "일본 현대건축 여행ep32/ 미대보다 감각적인 공대, 가나가와공과대학(KAIT)",
+      "channelName": "풀어봤어X",
+      "position": 2,
+      "url": "https://www.youtube.com/watch?v=XR0MFKS8brg"
+    },
+    {
+      "videoId": "T8rK1SZsNv4",
+      "title": "일본 현대건축 여행ep.15/도쿄 미술관 투어의 의외의 성지, 우에노, 르 코르뷔지에",
+      "channelName": "풀어봤어X",
+      "position": 3,
+      "url": "https://www.youtube.com/watch?v=T8rK1SZsNv4"
+    },
+    {
+      "videoId": "ZwbYyONOCZE",
+      "title": "일본 현대건축 여행ep.1 / 건축가들이 벌이는 패션쇼, 도쿄 오모테산도",
+      "channelName": "풀어봤어X",
+      "position": 4,
+      "url": "https://www.youtube.com/watch?v=ZwbYyONOCZE"
+    },
+    {
+      "videoId": "uwuZFZXLMmQ",
+      "title": "일본 현대건축 여행ep.14/도쿄에 숨겨진 작은 교토, 작은 파리, 카구라자카의 유명 건축물 둘러보기",
+      "channelName": "풀어봤어X",
+      "position": 5,
+      "url": "https://www.youtube.com/watch?v=uwuZFZXLMmQ"
+    },
+    {
+      "videoId": "y5jnQELKvp4",
+      "title": "일본 현대건축 여행ep.7 / 건축가들이 만든 압도적인 스케일, 도쿄 긴자, 마루노우치",
+      "channelName": "풀어봤어X",
+      "position": 6,
+      "url": "https://www.youtube.com/watch?v=y5jnQELKvp4"
+    },
+    {
+      "videoId": "Bn75Zi-RidE",
+      "title": "영화 '퍼펙트데이즈'가 알려주지 않는 시부야의 이야기 #1",
+      "channelName": "풀어봤어X",
+      "position": 7,
+      "url": "https://www.youtube.com/watch?v=Bn75Zi-RidE"
+    },
+    {
+      "videoId": "xX4IXlV5i8M",
+      "title": "일본 현대건축 여행ep23/아자부다이 힐스가 도쿄 최고의 부촌인 이유",
+      "channelName": "풀어봤어X",
+      "position": 8,
+      "url": "https://www.youtube.com/watch?v=xX4IXlV5i8M"
+    },
+    {
+      "videoId": "Kk_zEgXrXeY",
+      "title": "일본 현대건축 여행ep.4 / 안도 타다오가 북치고 장구치는 곳, 도쿄 시부야",
+      "channelName": "풀어봤어X",
+      "position": 9,
+      "url": "https://www.youtube.com/watch?v=Kk_zEgXrXeY"
+    },
+    {
+      "videoId": "GYjYEbTaCWE",
+      "title": "일본 현대건축 여행ep.2 /극T가 들어가도 극F가 되어 나오는 도서관, 기후 미디어 코스모스 모두의 숲",
+      "channelName": "풀어봤어X",
+      "position": 10,
+      "url": "https://www.youtube.com/watch?v=GYjYEbTaCWE"
+    },
+    {
+      "videoId": "MP33JQA586M",
+      "title": "일본 현대건축 여행 ep.3 /100년을 간직한 의외의 장소, 이케부쿠로 / 프랭크 로이드 라이트에서 쿠마 켄고까지",
+      "channelName": "풀어봤어X",
+      "position": 11,
+      "url": "https://www.youtube.com/watch?v=MP33JQA586M"
+    },
+    {
+      "videoId": "g9PrE_JzoUw",
+      "title": "일본 현대건축 여행 ep.5 / 샤넬을 품은 뒷골목, 도쿄 하라주쿠에서 오모테산도까지",
+      "channelName": "풀어봤어X",
+      "position": 12,
+      "url": "https://www.youtube.com/watch?v=g9PrE_JzoUw"
+    },
+    {
+      "videoId": "HILaFQlPm3k",
+      "title": "일본 현대건축 여행ep.6/아키하바라가 뻔하다면..? 건축가들이 세운, 오타쿠를 위한 새로운 성지, 토코로자와",
+      "channelName": "풀어봤어X",
+      "position": 13,
+      "url": "https://www.youtube.com/watch?v=HILaFQlPm3k"
+    },
+    {
+      "videoId": "QQjNqjsEN0g",
+      "title": "일본 지역경제를 일으킨 어느 신사. 근데 이제 라노벨을 곁들인..도쿄 이색 건축여행, 토코로자와 신사",
+      "channelName": "풀어봤어X",
+      "position": 14,
+      "url": "https://www.youtube.com/watch?v=QQjNqjsEN0g"
+    },
+    {
+      "videoId": "zHiMkbqTHJU",
+      "title": "일본 현대건축 여행ep.8/도쿄 올드머니의 상징 긴자, 에르메스에서 로로피아나, 긴자식스까지",
+      "channelName": "풀어봤어X",
+      "position": 15,
+      "url": "https://www.youtube.com/watch?v=zHiMkbqTHJU"
+    },
+    {
+      "videoId": "oK0Htyl1-VQ",
+      "title": "일본 현대건축 여행ep.9/긴자에서 만나는 건축과 지구의 미래",
+      "channelName": "풀어봤어X",
+      "position": 16,
+      "url": "https://www.youtube.com/watch?v=oK0Htyl1-VQ"
+    },
+    {
+      "videoId": "ks9z5MwLHXY",
+      "title": "일본 현대건축 여행ep.10/쿠마몬 말고 안도 타다오...구마모토 여행에서 꼭 봐야하는 건축물",
+      "channelName": "풀어봤어X",
+      "position": 17,
+      "url": "https://www.youtube.com/watch?v=ks9z5MwLHXY"
+    },
+    {
+      "videoId": "BgF6rLnyoGs",
+      "title": "일본 현대건축 여행ep.11/구마모토와 천재 건축가들의 만남, 구마모토 아트폴리스",
+      "channelName": "풀어봤어X",
+      "position": 18,
+      "url": "https://www.youtube.com/watch?v=BgF6rLnyoGs"
+    },
+    {
+      "videoId": "J8FcWsEif-k",
+      "title": "일본 현대건축 여행ep.12/후쿠오카 여행을 더욱 재미있게 부수는 방법, 후쿠오카 주요 관광지의 건축물 구경하기",
+      "channelName": "풀어봤어X",
+      "position": 19,
+      "url": "https://www.youtube.com/watch?v=J8FcWsEif-k"
+    },
+    {
+      "videoId": "g7J0tViEQ1o",
+      "title": "일본 현대건축 여행ep.13/무라카미 하루키와 나츠메 소세키의 서재, 도쿄 와세다",
+      "channelName": "풀어봤어X",
+      "position": 20,
+      "url": "https://www.youtube.com/watch?v=g7J0tViEQ1o"
+    },
+    {
+      "videoId": "fXAtHT096Vc",
+      "title": "일본 현대건축 여행ep.16/신주쿠 여행시 알아두면 더욱 재미있는 건축물TMI",
+      "channelName": "풀어봤어X",
+      "position": 21,
+      "url": "https://www.youtube.com/watch?v=fXAtHT096Vc"
+    },
+    {
+      "videoId": "9Y38r0HGjCs",
+      "title": "일본 현대건축 여행ep.17/도쿄 최고의 미술관에는 소장품이 단 하나도 없다? 롯본기 국립신미술관",
+      "channelName": "풀어봤어X",
+      "position": 22,
+      "url": "https://www.youtube.com/watch?v=9Y38r0HGjCs"
+    },
+    {
+      "videoId": "XUNlP214vXU",
+      "title": "도쿄대 캠퍼스 투어 / 최고의 건축가들이 지켜낸 최고의 대학교",
+      "channelName": "풀어봤어X",
+      "position": 23,
+      "url": "https://www.youtube.com/watch?v=XUNlP214vXU"
+    },
+    {
+      "videoId": "STp0ugXlXfY",
+      "title": "일본 현대건축 여행ep19/누가 아사쿠사를 묻거든, 고개를 들어 지붕을 보게 하라",
+      "channelName": "풀어봤어X",
+      "position": 24,
+      "url": "https://www.youtube.com/watch?v=STp0ugXlXfY"
+    },
+    {
+      "videoId": "JZoN83wn5dA",
+      "title": "일본 현대건축 여행ep20/다이칸야마가 도쿄 최고의 부촌인 이유",
+      "channelName": "풀어봤어X",
+      "position": 25,
+      "url": "https://www.youtube.com/watch?v=JZoN83wn5dA"
+    },
+    {
+      "videoId": "ib1dbfCDn8o",
+      "title": "일본 현대건축 여행ep21/나카메구로 카페 투어. 근데 이제 건축을 곁들인",
+      "channelName": "풀어봤어X",
+      "position": 26,
+      "url": "https://www.youtube.com/watch?v=ib1dbfCDn8o"
+    },
+    {
+      "videoId": "pLseKjqPvkc",
+      "title": "일본 현대건축 여행ep22/건축가,디자이너가 저출산을 해결하려 하면 벌어지는 일",
+      "channelName": "풀어봤어X",
+      "position": 27,
+      "url": "https://www.youtube.com/watch?v=pLseKjqPvkc"
+    },
+    {
+      "videoId": "ohtvVIl-rF4",
+      "title": "일본 현대건축 여행ep.24/후쿠오카 넥서스 월드. 버블경제가 상상한 미래도시의 모습은?",
+      "channelName": "풀어봤어X",
+      "position": 28,
+      "url": "https://www.youtube.com/watch?v=ohtvVIl-rF4"
+    },
+    {
+      "videoId": "tx8CGpVPmAs",
+      "title": "일본 현대건축 여행ep25/시로카네다이가 도쿄 최고의 부촌인 이유",
+      "channelName": "풀어봤어X",
+      "position": 29,
+      "url": "https://www.youtube.com/watch?v=tx8CGpVPmAs"
+    },
+    {
+      "videoId": "g5uvDtMPgys",
+      "title": "영화 '퍼펙트데이즈'가 알려주지 않는 시부야의 이야기 #2",
+      "channelName": "풀어봤어X",
+      "position": 30,
+      "url": "https://www.youtube.com/watch?v=g5uvDtMPgys"
+    },
+    {
+      "videoId": "svLNosI6E2Q",
+      "title": "일본 현대건축 여행ep26/오타니의 고향이 알려주는 지방(?)의 익힘 정도, 이와테 시와초",
+      "channelName": "풀어봤어X",
+      "position": 31,
+      "url": "https://www.youtube.com/watch?v=svLNosI6E2Q"
+    },
+    {
+      "videoId": "D6RL3kQ0pWc",
+      "title": "일본 현대건축 여행ep28/도쿄여행을 더욱 깊이있게 다녀오는 방법",
+      "channelName": "풀어봤어X",
+      "position": 32,
+      "url": "https://www.youtube.com/watch?v=D6RL3kQ0pWc"
+    },
+    {
+      "videoId": "Zb4GyroZoVc",
+      "title": "일본 현대건축 여행ep29/스타벅스가 도쿄 소도시에 만든 특별한 매장, 스타벅스 사이닝 스토어",
+      "channelName": "풀어봤어X",
+      "position": 33,
+      "url": "https://www.youtube.com/watch?v=Zb4GyroZoVc"
+    },
+    {
+      "videoId": "J8sDgpgvtt0",
+      "title": "일본 현대건축 여행ep30/투박하지만 독보적 감성을 품은 곳, 나고야",
+      "channelName": "풀어봤어X",
+      "position": 34,
+      "url": "https://www.youtube.com/watch?v=J8sDgpgvtt0"
+    },
+    {
+      "videoId": "mw8gbfXM06Y",
+      "title": "일본 현대건축 여행ep31/거장이 설계한 대학 캠퍼스 뒤에 숨겨진 불편한 진실",
+      "channelName": "풀어봤어X",
+      "position": 35,
+      "url": "https://www.youtube.com/watch?v=mw8gbfXM06Y"
+    },
+    {
+      "videoId": "vI_3a0SsxpE",
+      "title": "일본 건축여행ep34/시모키타자와, 빈티(?)와 빈티지 사이의 외줄타기",
+      "channelName": "풀어봤어X",
+      "position": 36,
+      "url": "https://www.youtube.com/watch?v=vI_3a0SsxpE"
+    },
+    {
+      "videoId": "hVWm_ElNTWQ",
+      "title": "일본 건축여행ep35/지방도시에 공공도서관 건립은 세금낭비일까?",
+      "channelName": "풀어봤어X",
+      "position": 37,
+      "url": "https://www.youtube.com/watch?v=hVWm_ElNTWQ"
+    },
+    {
+      "videoId": "REvGuvL5Mhs",
+      "title": "도쿄 필수코스 또 생겼네...조감도 뚫고 나온 아시아 최대급 신상 티파니",
+      "channelName": "풀어봤어X",
+      "position": 38,
+      "url": "https://www.youtube.com/watch?v=REvGuvL5Mhs"
+    },
+    {
+      "videoId": "xs22pKzUwiQ",
+      "title": "특이점이 온 도쿄의 도시공원 퀄리티",
+      "channelName": "풀어봤어X",
+      "position": 39,
+      "url": "https://www.youtube.com/watch?v=xs22pKzUwiQ"
+    },
+    {
+      "videoId": "Sq5B9MVF7Vs",
+      "title": "일본 건축여행ep38/도쿄 MZ들이 가장 많이 찾는 공간, 가메아리 아트 센터 by DAIKEI MILLS",
+      "channelName": "풀어봤어X",
+      "position": 40,
+      "url": "https://www.youtube.com/watch?v=Sq5B9MVF7Vs"
+    },
+    {
+      "videoId": "PbGdaHPlhJ8",
+      "title": "일본 건축여행ep39/도쿄에서 에렌 예거 체험하기, 메구로 천공정원",
+      "channelName": "풀어봤어X",
+      "position": 41,
+      "url": "https://www.youtube.com/watch?v=PbGdaHPlhJ8"
+    },
+    {
+      "videoId": "Y_wbeg8GBQg",
+      "title": "일본 건축여행ep40/토라노몬 힐즈가 도쿄 최고의 부촌인 이유",
+      "channelName": "풀어봤어X",
+      "position": 42,
+      "url": "https://www.youtube.com/watch?v=Y_wbeg8GBQg"
+    },
+    {
+      "videoId": "LP8zWRrT8C0",
+      "title": "오사카 건축여행ep1/시장통이 일본 제 2의 도시가 될 수 있었던 건에 관하여",
+      "channelName": "풀어봤어X",
+      "position": 43,
+      "url": "https://www.youtube.com/watch?v=LP8zWRrT8C0"
+    },
+    {
+      "videoId": "1W8nkiSRaBs",
+      "title": "서울은 철거, 오사카는 보존? 비슷한 두 건축물의 엇갈린 운명 l 오사카 건축여행ep2. 세운상가와 센바센터빌딩",
+      "channelName": "풀어봤어X",
+      "position": 44,
+      "url": "https://www.youtube.com/watch?v=1W8nkiSRaBs"
+    },
+    {
+      "videoId": "1xg7PqZuoGU",
+      "title": "일본 건축여행ep43/ 아파트만 짓는다고 살기 좋은 곳이 될까? 도쿄 근교에서 찾은 해답, MUFG PARK LIBRARY",
+      "channelName": "풀어봤어X",
+      "position": 45,
+      "url": "https://www.youtube.com/watch?v=1xg7PqZuoGU"
+    },
+    {
+      "videoId": "skhNkILNIec",
+      "title": "일본 건축여행ep.44/우에노가 도쿄 문화예술의 중심지가 된 이유, 우에노 도쿄도미술관",
+      "channelName": "풀어봤어X",
+      "position": 46,
+      "url": "https://www.youtube.com/watch?v=skhNkILNIec"
+    },
+    {
+      "videoId": "WB6sz4NVzgs",
+      "title": "일본 건축여행ep.45/일본 미니멀리즘의 끝판왕, 우에노 호류지 보물관",
+      "channelName": "풀어봤어X",
+      "position": 47,
+      "url": "https://www.youtube.com/watch?v=WB6sz4NVzgs"
+    },
+    {
+      "videoId": "4xBYEVitri4",
+      "title": "일본은 어떻게 세계 건축 강국이 되었을까? / 우에노 국립서양미술관",
+      "channelName": "풀어봤어X",
+      "position": 48,
+      "url": "https://www.youtube.com/watch?v=4xBYEVitri4"
+    },
+    {
+      "videoId": "XC848GyKaKk",
+      "title": "일본 건축여행ep.47/ 취향이 미술관이 되는 도쿄 최고의 부촌 '쇼토'",
+      "channelName": "풀어봤어X",
+      "position": 49,
+      "url": "https://www.youtube.com/watch?v=XC848GyKaKk"
+    },
+    {
+      "videoId": "MUs4gzAuvNg",
+      "title": "일본 건축여행ep.48/ 자본이 아닌 자연으로 살아남은 온천마을 '유후인'",
+      "channelName": "풀어봤어X",
+      "position": 50,
+      "url": "https://www.youtube.com/watch?v=MUs4gzAuvNg"
+    },
+    {
+      "videoId": "TlPvXYvPoBM",
+      "title": "세계적인 건축가 쿠마 켄고가 설계한 온천, 코미코 아트 하우스 유후인(COMICO ART HOUSE YUFUIN)",
+      "channelName": "풀어봤어X",
+      "position": 51,
+      "url": "https://www.youtube.com/watch?v=TlPvXYvPoBM"
+    },
+    {
+      "videoId": "Rcg9IapAtk8",
+      "title": "일본 건축이 차원이 다른 궁극적인 이유/ 일본 건축여행 ep.50",
+      "channelName": "풀어봤어X",
+      "position": 52,
+      "url": "https://www.youtube.com/watch?v=Rcg9IapAtk8"
+    },
+    {
+      "videoId": "2UYKbTnKDEo",
+      "title": "철도회사가 도심재개발에 손대면 벌어지는 일, 다카나와 게이트웨이 시티 / 일본 건축여행ep51",
+      "channelName": "풀어봤어X",
+      "position": 53,
+      "url": "https://www.youtube.com/watch?v=2UYKbTnKDEo"
+    },
+    {
+      "videoId": "EsSN2jH4t-c",
+      "title": "구도심에 스타벅스는 위기일까 기회일까 / 일본 건축여행ep52",
+      "channelName": "풀어봤어X",
+      "position": 54,
+      "url": "https://www.youtube.com/watch?v=EsSN2jH4t-c"
+    },
+    {
+      "videoId": "IeCvS7YSoa4",
+      "title": "건축오타쿠의 아키하바라 감도 외줄타기 l 일본 건축여행ep.53",
+      "channelName": "풀어봤어X",
+      "position": 55,
+      "url": "https://www.youtube.com/watch?v=IeCvS7YSoa4"
+    },
+    {
+      "videoId": "LXqF08KvKdw",
+      "title": "일본 건축여행ep54/사장님들이 아카사카,롯본기를 선택하는 이유",
+      "channelName": "풀어봤어X",
+      "position": 56,
+      "url": "https://www.youtube.com/watch?v=LXqF08KvKdw"
+    },
+    {
+      "videoId": "g3MTFHH8bWc",
+      "title": "일본 최고의 디자이너가 미술관 대신 만든 곳, 21_21Design Sight",
+      "channelName": "풀어봤어X",
+      "position": 57,
+      "url": "https://www.youtube.com/watch?v=g3MTFHH8bWc"
+    },
+    {
+      "videoId": "MuOJQVKClw4",
+      "title": "잘한다 하니 점점 선넘는 일본 편의점 근황",
+      "channelName": "풀어봤어X",
+      "position": 58,
+      "url": "https://www.youtube.com/watch?v=MuOJQVKClw4"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2/_create_manifest.json
+++ b/.claude/workspace/youtube/PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2/_create_manifest.json
@@ -1,0 +1,671 @@
+{
+  "sunreiId": "SR01kyhxp3f4201e3v8k5h1tg47v",
+  "sourceId": "SRC01kyhxp2ezjzark6h2yjy5f8dt",
+  "spots": [
+    {
+      "spotId": "SS01kyhxp3f5wy14ggzcasafsz0c",
+      "videoId": "vTG6PxKuOCQ",
+      "videoTitle": "푸드 무비의 선구자, 백종원과 제작진이 돌아왔다! 스트리트푸드파이터2"
+    },
+    {
+      "spotId": "SS01kyhxp3f6zkd550k4sf84rn2v",
+      "videoId": "RVZo-Yd4r08",
+      "videoTitle": "이스탄불 케밥 : 소고기와 양고기를 알맞은 비율로 차곡차곡 쌓아 올린, 백종원 숨겨진 케밥 단골집"
+    },
+    {
+      "spotId": "SS01kyhxp3f7956p20rbr7h93yk2",
+      "videoId": "sCctPC96hHo",
+      "videoTitle": "이스켄데르 케밥 : 버터의 축복."
+    },
+    {
+      "spotId": "SS01kyhxp3f8n640y4zy448rkp73",
+      "videoId": "CKzUY2xcSdQ",
+      "videoTitle": "타북 필라프 : 닭백숙 국물로 지은 밥 느낌?!?!?! 볶음밥으로 착각할 정도로 밥알이 따로놉니다. 먹어봐야 압니다."
+    },
+    {
+      "spotId": "SS01kyhxp3f93ac5s517y6vkcej6",
+      "videoId": "UwY5Pqn8r3Y",
+      "videoTitle": "아이란 : 터키의 국민 음료. 요구르트가 들어갔지만 밥 먹으면서 먹는 냉국 같은 존재?!?!!?"
+    },
+    {
+      "spotId": "SS01kyhxp3faxd220jgykyv1p84r",
+      "videoId": "1mVFAbxMJeA",
+      "videoTitle": "시미트 : 전통 화덕 기이이이잎은 곳에서 굽는 갓 구운 빵의 미친 매력."
+    },
+    {
+      "spotId": "SS01kyhxp3fak8k68f90r8mq8sva",
+      "videoId": "zftY4Fs5wuU",
+      "videoTitle": "카이막 : 터키에 왔다면 꼭 한번은 먹어봐야 할 천상의 맛"
+    },
+    {
+      "spotId": "SS01kyhxp3fbnt3djdr0jhwzzncv",
+      "videoId": "DHmqyWPqpv4",
+      "videoTitle": "카이막 : 우유 10kg으로 만들어지는 양 400g?"
+    },
+    {
+      "spotId": "SS01kyhxp3fc6h9crcpy5yfzyswk",
+      "videoId": "66mJhvl4klk",
+      "videoTitle": "미디예 돌마 : 홍합과 양파의 만남. 그 자리에서 10개는 뚝딱!?!?!"
+    },
+    {
+      "spotId": "SS01kyhxp3fd7bytmz2851v07yc0",
+      "videoId": "hEkt2Q5EQa4",
+      "videoTitle": "돈두르마 카다이프 : 쫀~독한 아이스크림 돈두르마와 소면을 튀긴 것 같은 식감의 카다이프의 만남."
+    },
+    {
+      "spotId": "SS01kyhxp3fd77zaw296b45af4t3",
+      "videoId": "6m6gRtQwgV0",
+      "videoTitle": "탄투니: 단순하게 고기를 잘게잘게 썰어가지고 거기에 소금을 뿌려서 지금 특별한 양념을 안 한 것 같은 맛이에요"
+    },
+    {
+      "spotId": "SS01kyhxp3fe274h0y1b5kxmj04q",
+      "videoId": "mJkgEzykeF8",
+      "videoTitle": "괴프테 : 완자나 떡갈비 느낌의 미트볼?!?!?? 근데 이제 식감이 쫄깃한."
+    },
+    {
+      "spotId": "SS01kyhxp3ffw05e2z6mpjvqjrrz",
+      "videoId": "FSAG7CgaqCk",
+      "videoTitle": "치이 쾨프테 : 길거리에서 파는 게 찐?! 고기가 하나도 없지만 너무 맛있는 진정한 비건 푸드!!!"
+    },
+    {
+      "spotId": "SS01kyhxp3fgdje07qnng7rfez5f",
+      "videoId": "8apWu4OotMU",
+      "videoTitle": "이시켐베 초르바스 : 내장을 거의 다지듯이 썰어서 제대로 올라오는 쿰쿰한 이 맛. 소주 좀 가져다 주세요!!!"
+    },
+    {
+      "spotId": "SS01kyhxp3fjgn20y8tt8btwbjxj",
+      "videoId": "kve9C7k3kXc",
+      "videoTitle": "쏘이 쎄오 : 아주 단순한 750원 짜리 아침. 하지만 맛은 따봉"
+    },
+    {
+      "spotId": "SS01kyhxp3fk3g2bhj6sec6rr493",
+      "videoId": "-7l5KUi_pZI",
+      "videoTitle": "분 더우 맘 똠 : 분짜의 상위버전 한 번 중독되면 잘못하다간 못끊어요"
+    },
+    {
+      "spotId": "SS01kyhxp3fm84h26anw9s3c97tw",
+      "videoId": "mT8bVAmO3LY",
+      "videoTitle": "맘 똠 : 곰삭은 황석어젓 같은 냄새?!?!? 안에 튀김이 들어가 있어서 섞으면 카푸치노같이 거품이나요"
+    },
+    {
+      "spotId": "SS01kyhxp3fnm796v2wh5jzqjt57",
+      "videoId": "OEegrwmnppg",
+      "videoTitle": "닭구이 : 닭발을 바로 구우면 콜라겐이 살아있어요 그래서 엄청 쫀독쫀독해"
+    },
+    {
+      "spotId": "SS01kyhxp3frz3wy9k26ve0wv5na",
+      "videoId": "Tw_Ep-iEuo8",
+      "videoTitle": "반 미 느엉 : 기름하고 꿀하고 발라서 구운 반미와 닭구이의 조합은? 맛 없을 수 없음"
+    },
+    {
+      "spotId": "SS01kyhxp3ftbzjcxe9fm1pp14qf",
+      "videoId": "mKPfmrQvZgg",
+      "videoTitle": "꿔이 : 이 매력은 하노이에서만 느낄 수 있습니다 호치민가서 쌀국수 먹을 때 이거 안준다고 뭐라하면 안됩니다!!!"
+    },
+    {
+      "spotId": "SS01kyhxp3fv5kf5kttjfp22ps5q",
+      "videoId": "_TmYAydLkUE",
+      "videoTitle": "반 똠 : 찍어먹는 느억맘 소스가 진짜 꿀맛. 먹다보면 나도 모르게 마셔벌임ㅇㅇ.."
+    },
+    {
+      "spotId": "SS01kyhxp3fv32s90v68b2qvdhxk",
+      "videoId": "imzbIa81KaI",
+      "videoTitle": "반 꾸온 꼬 년 : 하노이 사람들은 차암 행복하겠다 간식을 이렇게 먹으니"
+    },
+    {
+      "spotId": "SS01kyhxp3fw3jfgbfxd9cdzexd1",
+      "videoId": "7FvuOGJZUuE",
+      "videoTitle": "거위고기 : 씹다보면 껍데기에서 기름이 쭉쭉 나오니까 고소해요 닭똥집 맛?!?!?!"
+    },
+    {
+      "spotId": "SS01kyhxp3fxqg44db4perqfw60x",
+      "videoId": "hbxTavxKk9U",
+      "videoTitle": "반 쯩 : 새콤달콤하게 절인 거랑 같이 먹으면 더 꿀맛 부렵죠? 750원으로 이런 아침을 먹을 수 있다는 게ㅎㅎ"
+    },
+    {
+      "spotId": "SS01kyhxp3fyfq35hk15bs8s2xzt",
+      "videoId": "wf5r-GUh0mU",
+      "videoTitle": "짜오 롱 : 죽입니다 죽인데 순대, 내장, 선지가 들어가 있어요 아, 한잔해야하는데…"
+    },
+    {
+      "spotId": "SS01kyhxp3fz69y19k217kfq5mxt",
+      "videoId": "7PcfURXJlPc",
+      "videoTitle": "분 옥 : 새코옴한데 시워언한, 상상도 하지 못한 재료들의 조합!!! 그 맛은?"
+    },
+    {
+      "spotId": "SS01kyhxp3g0y0gpysqf7qtbmgc1",
+      "videoId": "kyP2aE5Js60",
+      "videoTitle": "반 미 & 솟 방 : 딱 보시면 스튜입니다. 단, 다른건 고수가 듬뿍 들어간… 바사삭 소리가 환.상."
+    },
+    {
+      "spotId": "SS01kyhxp3g16j34t57rcq05txe1",
+      "videoId": "3dKte6rpx7s",
+      "videoTitle": "피자 : 백종원의 찐 뉴요커 따라잡기ㅋㅋㅋㅋ"
+    },
+    {
+      "spotId": "SS01kyhxp3g2e409td7t8rbmnjd5",
+      "videoId": "A1IYJjST2js",
+      "videoTitle": "피자2 : 석탄 화덕에서 만든 피자에서만 느낄 수 있는 바삭바삭한 이 가게 피자🍕"
+    },
+    {
+      "spotId": "SS01kyhxp3g3bkfxxztfe6c370gb",
+      "videoId": "ba--mjuBUFw",
+      "videoTitle": "포터하우스 스테이크 : 온 비법이 다들어간 육즙. 이 집 스테이크는 맛이 계속 올라갑니다 예술이에요🥩"
+    },
+    {
+      "spotId": "SS01kyhxp3g4k83e1rd6t22ghzf7",
+      "videoId": "Zbj3YLVLoj4",
+      "videoTitle": "포터하우스 스테이크2 : 침 고이는 선홍빛 마블링 백선생님을 감동시킨 스테이크"
+    },
+    {
+      "spotId": "SS01kyhxp3g548y4f0jcm7b8fnz7",
+      "videoId": "5I2NFZ65jCc",
+      "videoTitle": "럼버잭 : 아침엔 살 걱정 안해도 되쥬~"
+    },
+    {
+      "spotId": "SS01kyhxp3g6tyett2ntknn3brns",
+      "videoId": "vdCn0I-_7QQ",
+      "videoTitle": "뉴욕 햄버거 : 햄버거는 먹으면서 다음 먹을 걸 찾을 수 있어유ㅎㅎ"
+    },
+    {
+      "spotId": "SS01kyhxp3g74yhvg156jv8ctxye",
+      "videoId": "Cmc4BtUJ4Ck",
+      "videoTitle": "뉴욕 치즈케이크 : 그냥 치즈케이크가 아닙니다. 앞에 뉴욕이 붙어야해요 이쁘죠?"
+    },
+    {
+      "spotId": "SS01kyhxp3g8e9xqd3f5fyq9h36f",
+      "videoId": "XTtidLKK96k",
+      "videoTitle": "버펄로 윙 : 여기서 버팔로 윙 안 먹어 봤으면 먹어봤다 말하면 안 됨🍻"
+    },
+    {
+      "spotId": "SS01kyhxp3g9x1y5gbh8kqfywczy",
+      "videoId": "eJTvH49yTSk",
+      "videoTitle": "베이글 : 보기만해도 마음이 므흣해지는 크림치즈 + 베이글"
+    },
+    {
+      "spotId": "SS01kyhxp3gavh5j1y36g9adyspq",
+      "videoId": "BjMizteUE2A",
+      "videoTitle": "콘 브레드 : 꽁짠데 갓 만들어서 따끈하고 맛을 보자하는 빵. 하지만 이제 칼로리는 보장 못 하는."
+    },
+    {
+      "spotId": "SS01kyhxp3gb9p3p42pcpej4vekf",
+      "videoId": "x60mZ-nIODw",
+      "videoTitle": "프라이드치킨 : 닭다리, 닭날개가 먹다 남은 부위라고?!?! 아프리카계 미국인들의 소울푸드"
+    },
+    {
+      "spotId": "SS01kyhxp3gb53znzyv97swtmpsb",
+      "videoId": "p0T5WnrKEYA",
+      "videoTitle": "굴 : 미국 동부, 전혀 안비리고 달달한 굴이 있다??!?!?"
+    },
+    {
+      "spotId": "SS01kyhxp3gdg382mdxnbv3h07jf",
+      "videoId": "s8QeRTIEK_k",
+      "videoTitle": "스쯔모 : 맥반석 돌로 굽는 중국식 와플 느낌? 고소한 간식으로 딱!!"
+    },
+    {
+      "spotId": "SS01kyhxp3gdfdeh1wz4qm05ad76",
+      "videoId": "BbxgWO02X2I",
+      "videoTitle": "유차마화 : 자극적이진 않은데, 무의식중에 계속 먹게 되는 맛?!"
+    },
+    {
+      "spotId": "SS01kyhxp3gerb8aw90bxkrapvan",
+      "videoId": "0iAaHNN9vtw",
+      "videoTitle": "유포면 : 들어가는게 별거 없는데 너~~무 맛있는 이 요리🥢"
+    },
+    {
+      "spotId": "SS01kyhxp3gfgc7csetx8ft2m30h",
+      "videoId": "2zSwxWEQV58",
+      "videoTitle": "서봉주 : 비교적 저렴하지만 시안의 명주라고 불리는 술🍶"
+    },
+    {
+      "spotId": "SS01kyhxp3gr5y6c9rqwh02pxmcr",
+      "videoId": "MiLdS5ikyq8",
+      "videoTitle": "후루터우 샤오차오 : 한국의 대창볶음이 있다면 중국엔 이 요리가 있다!! 서봉주랑 먹으면~크👍"
+    },
+    {
+      "spotId": "SS01kyhxp3gsg97bzq1tjmy9r5h3",
+      "videoId": "U-XPZHLjJWw",
+      "videoTitle": "후라탕 : 요즘 유행하는 마라와 후추의 조합?!? 완자까지 들어있으니 JMT!!"
+    },
+    {
+      "spotId": "SS01kyhxp3j45d55p5qwsqcaa45f",
+      "videoId": "VkfKGpRDCcY",
+      "videoTitle": "쩡가오 : 이게 다~ 대추입니다 대추 향이 풍부한 약밥의 느낌?!?!?"
+    },
+    {
+      "spotId": "SS01kyhxp3j5k2jm54jrsy6m96md",
+      "videoId": "2YLjkhY5NZg",
+      "videoTitle": "샤오쯔몐 : 얇은 국수 면에 싸악 배어 있는 새~코옴한 국물 중독되는 그 맛🥢"
+    },
+    {
+      "spotId": "SS01kyhxp3j65mmkqmpsw2j4ajma",
+      "videoId": "tjwAXEpLw1Y",
+      "videoTitle": "삼진세트 : 매콤한 떡볶이 소스에 튀김을 찍어 먹으면 조화가 되듯 완벽한 조화로우움"
+    },
+    {
+      "spotId": "SS01kyhxp3j779245cexaeyjdm09",
+      "videoId": "rC0_gbd8eu8",
+      "videoTitle": "양 내장탕 : 중국 왔으면 이건 제대로 한 번 먹어봐야죠 쿰쿰한 맛을 좋아하는 분 무조건 좋아합니다!!"
+    },
+    {
+      "spotId": "SS01kyhxp3j8pcha2tmsh1z3rwf7",
+      "videoId": "INcgtsw-lYA",
+      "videoTitle": "펀정러우 : 갈비찜을 빵 안에 넣어 먹는 맛?!? 하얀 소 내장 기름을 꼭 넣어서 드세유"
+    },
+    {
+      "spotId": "SS01kyhxp3j9q2cvpnfvk5gx99m4",
+      "videoId": "v7vKA5vT8nY",
+      "videoTitle": "따꼬 : 따꼬는 어떤 음식을 싸 먹는 방법을 말하는 겁니다 몰랐쥬?"
+    },
+    {
+      "spotId": "SS01kyhxp3ja738r8yh3zn22ng1e",
+      "videoId": "ABkWkgC9_WA",
+      "videoTitle": "살사 소스 :  따꼬 가게마다 비법이 들어간 특별 소스를 만듭니다 그만큼 중요하다는 거죠"
+    },
+    {
+      "spotId": "SS01kyhxp3jajr291b566majhwt1",
+      "videoId": "CScfmK4RhoE",
+      "videoTitle": "바르바꼬아 : 어? 맛있다. 양고기를 깊은 구덩이에서 오래 구워요 그래서 되게 부드러워요🍖"
+    },
+    {
+      "spotId": "SS01kyhxp3jb8172kz0vbzn3xrw5",
+      "videoId": "mqwtd4QEm6c",
+      "videoTitle": "석회수 : 옥수수 속의 섬유질을 소화 가능하게 만들어주는 이 물의 정체"
+    },
+    {
+      "spotId": "SS01kyhxp3jcpefz7p2w42tjy57x",
+      "videoId": "lMZWUGLxo30",
+      "videoTitle": "반데라 : 시고 짭짜름하다?! 멕시코의 밤을 즐겁게 만드는 방법🥃"
+    },
+    {
+      "spotId": "SS01kyhxp3jdndnanc29t8w8za1k",
+      "videoId": "kfjlQsTRR2Q",
+      "videoTitle": "판시따 : 멕시코에서 해장국을 먹고 싶다면? 환-상"
+    },
+    {
+      "spotId": "SS01kyhxp3jf56v3rj02pptkndb0",
+      "videoId": "4i_QSyhZA90",
+      "videoTitle": "판시따 : 족발, 천엽, 양고기 등 소 내장을 끓인 스프?! 또띠아에 싸 먹으면 바로 해장 뚝딱"
+    },
+    {
+      "spotId": "SS01kyhxp3jfq09fakj98xk1qqdk",
+      "videoId": "3KowjCYp4hU",
+      "videoTitle": "케사디야 : 돼기고기 튀김 + 돼지껍데기 튀김 + 치즈 무적의 삼위일체👍"
+    },
+    {
+      "spotId": "SS01kyhxp3jj73g5q0mn80yx4xkj",
+      "videoId": "Ql3oIX1BdCk",
+      "videoTitle": "엘로떼 : 옥수수 싫어하는 사람람의 입맛도 영원히 바꿔줄 마약 옥수수"
+    },
+    {
+      "spotId": "SS01kyhxp3jkw86n39wxn7jnzkp9",
+      "videoId": "vLlhtvdwsQg",
+      "videoTitle": "몰레 콘 포요 : 카레에 초콜릿을 넣어봤는가 초콜릿으로 만든 천국의 맛"
+    },
+    {
+      "spotId": "SS01kyhxp3jm8m854sy4wctt7sze",
+      "videoId": "Vc7kC6taeK0",
+      "videoTitle": "따말&아똘레 : 옥수수 반죽에 닭고기가 쏘옥?! 2000원의 행복"
+    },
+    {
+      "spotId": "SS01kyhxp3jnd02fc5pdzcyw31rf",
+      "videoId": "lLskv19Vfoc",
+      "videoTitle": "칠라킬레스 : 대한민국 어디에서도 찾을 수 없는 맛! 촤르륵 흘러 내리는 노른자를 느껴봐"
+    },
+    {
+      "spotId": "SS01kyhxp3jpp0gfskxaq8xcdnqr",
+      "videoId": "sNt2MLnuiNQ",
+      "videoTitle": "포솔레 : 한국 국밥 vs 멕시코 국밥 과연 백종원의 선택은?!"
+    },
+    {
+      "spotId": "SS01kyhxp3jry29kddz1y3ppg32s",
+      "videoId": "kQ_hBSIlc5Y",
+      "videoTitle": "또스따다스+크레마 : 국밥에 또띠야를 넣어서 먹는다면?!"
+    },
+    {
+      "spotId": "SS01kyhxp3jtqt6w34x69eng16yk",
+      "videoId": "LRhiA0BX4rw",
+      "videoTitle": "러우저우&홍사오러우 : 백쌤이 이상한 신음소리를 내기 시작했습니다."
+    },
+    {
+      "spotId": "SS01kyhxp3jvngk6n66bb0zmjte1",
+      "videoId": "8CyOd9Rr7lY",
+      "videoTitle": "족발국수 : 국수에 삶은 족발이 풍덩!! 이거 먹으면 합격한다?!"
+    },
+    {
+      "spotId": "SS01kyhxp3jw95qa27zfdbb2x5mt",
+      "videoId": "LPGZq4MIg0k",
+      "videoTitle": "깨 끙 : 닭고기 없는 닭고기 말이 튀김!?"
+    },
+    {
+      "spotId": "SS01kyhxp3jxyr0vq4v07z4kr24m",
+      "videoId": "W6ZirHCGDec",
+      "videoTitle": "전주나이차 : 동글동글 검은색 진주들이 잔뜩 들어간 대만 대표 음료수🥤"
+    },
+    {
+      "spotId": "SS01kyhxp3jzfpsq554kg6czkdhz",
+      "videoId": "5GcK2-mbkqQ",
+      "videoTitle": "굴전 : 이 비주얼은 못 참지. 우리 다이어트는,, 잠시 쉬기로 해요."
+    },
+    {
+      "spotId": "SS01kyhxp3jz86ae3hkayjbm9j4v",
+      "videoId": "LXSorJ47htc",
+      "videoTitle": "루 러우 판 : 이른 아침 졸린 눈이 번쩍?!👀 떠지게 만드는 맛!!"
+    },
+    {
+      "spotId": "SS01kyhxp3k09gba15ewdqjk8jwj",
+      "videoId": "bwrnQCeuvv8",
+      "videoTitle": "타이완식 소시지 : 고기와 비계가 씹히는 소시지에 마늘을 같이 먹으면?"
+    },
+    {
+      "spotId": "SS01kyhxp3k12qq7c8vbt0j85zqb",
+      "videoId": "EwYcFwk-VFw",
+      "videoTitle": "대창굴국수 : 굴 있쥬 돼지 대창 있쥬 안 어울릴 것 같쥬? 무지하게 잘 어울려유☺️"
+    },
+    {
+      "spotId": "SS01kyhxp3k2dr79qc273vnqdvqd",
+      "videoId": "S1Zdt8ya7Ec",
+      "videoTitle": "우육면 : 고기가 실종되었습니다. 입 안에서."
+    },
+    {
+      "spotId": "SS01kyhxp3k3x8rm7rjrygr7p3rx",
+      "videoId": "hCF9rgFmymA",
+      "videoTitle": "스무위 덮밥 : 이게 장어야 푸딩이야? ㅇㅅㅇ 입 안에서 장어가 살살 녹아유"
+    },
+    {
+      "spotId": "SS01kyhxp3k4m6bp52w160ehw05g",
+      "videoId": "1913r9IXCiw",
+      "videoTitle": "쓰선탕 : 더위 먹은 사람들도 이것만 먹으면 벌떡! 일어난다는 이 음식!"
+    },
+    {
+      "spotId": "SS01kyhxp3k5rt6680mxce41zb1k",
+      "videoId": "06MUNiVH6DM",
+      "videoTitle": "펑리수 : 대만의 대표 간식 쫀독한 파인애플 필링이 가~득차서 새콤달콤 맛있다!"
+    },
+    {
+      "spotId": "SS01kyhxp3k64zanmad2nn3hpjck",
+      "videoId": "469R33ZNL_c",
+      "videoTitle": "브리오쉬에 젤라토 : 빵과 젤라또? 이건 근본이다."
+    },
+    {
+      "spotId": "SS01kyhxp3k7vrswcb7z1zap07km",
+      "videoId": "YBHxVbYQh8A",
+      "videoTitle": "빠넬레&까질리 : 해변가에서 병맥 하나 들고 따악 앉아서 먹으면 이게 행복..🍻"
+    },
+    {
+      "spotId": "SS01kyhxp3k8dm4dj9vjc1mszwh4",
+      "videoId": "BpHUAnZftxs",
+      "videoTitle": "카포나타 : 사과가 없어요. 근데 미친 사과라 불립니다."
+    },
+    {
+      "spotId": "SS01kyhxp3k9p94nzrs8hqrgs4sb",
+      "videoId": "iCwiJQF_ul8",
+      "videoTitle": "알라 노르마 : 고기 빠진 파스타. 노맛? ㄴㄴ 존맛탱"
+    },
+    {
+      "spotId": "SS01kyhxp3kaq3yxpxt8tsbvr8y3",
+      "videoId": "Kh8iWZj0irs",
+      "videoTitle": "스티키올라 : 한국 곱창 맛. 한 입 먹는 순간 소주가 술술술"
+    },
+    {
+      "spotId": "SS01kyhxp3kb3j7024ch18531h7a",
+      "videoId": "TM6H2OeRLUs",
+      "videoTitle": "아란치니 : 맛있는 주먹밥을 기름에 풍덩? 말해 뭐해♥"
+    },
+    {
+      "spotId": "SS01kyhxp3kcx2v3qtkqns2pcr8s",
+      "videoId": "fkYwpbJtOtw",
+      "videoTitle": "파니 카 메우사 : 내장 좋아하는 사람 모여라🙋🏻‍♀️"
+    },
+    {
+      "spotId": "SS01kyhxp3kc0spp35925s28xz6g",
+      "videoId": "wdpfXQXS2Kg",
+      "videoTitle": "탈리에레 : 소금에 절인 생 햄과 와인의 환상적 콜라보🍷"
+    },
+    {
+      "spotId": "SS01kyhxp3kd9b7xb39b0pmm579s",
+      "videoId": "q39FCOMEK2Y",
+      "videoTitle": "에트나 로쏘 : 에트나산 포도로 만든 와인이 가져다주는 천상의 맛(황홀)"
+    },
+    {
+      "spotId": "SS01kyhxp3ke91fqpjqfm0a42h1y",
+      "videoId": "4DKJYHkjvk8",
+      "videoTitle": "쿠스쿠스 : 이게 무슨 파스타야? 먹어 보면 압니다."
+    },
+    {
+      "spotId": "SS01kyhxp3kfrxpteavtq03c2ra7",
+      "videoId": "z6U2KvCWBbI",
+      "videoTitle": "사르데 아 베카피코 : 생선과 완자의 상상 불가능한 만남"
+    },
+    {
+      "spotId": "SS01kyhxp3kgmt479v5s65rqhe4j",
+      "videoId": "jLrBp1jOD2M",
+      "videoTitle": "스핀치오네 : 스펀지 피자?! 이탈리아의 엔초비가 들어간 독특한 맛과 식감"
+    },
+    {
+      "spotId": "SS01kyhxp3khx0m39mhjkcftc0v4",
+      "videoId": "RXipqsF1-2o",
+      "videoTitle": "요우먼따샤 : 가재를 둘러싼 마한 맛의 강렬한 양념 은은~한 고추기름의 매콤함까지"
+    },
+    {
+      "spotId": "SS01kyhxp3kjrjed13vnv7yx7ye5",
+      "videoId": "4Z3JHGYSALw",
+      "videoTitle": "러깐몐 : 중국 10대 면요리🍜"
+    },
+    {
+      "spotId": "SS01kyhxp3kmdksv0st65jasdfdr",
+      "videoId": "MwjSh0SlMKg",
+      "videoTitle": "몐양싼정: 3단 찜 요리 이게 고기야? 솜사탕이야? 각양각색의 요리에 신난 백종원"
+    },
+    {
+      "spotId": "SS01kyhxp3krqgekegywk6ytw9jf",
+      "videoId": "Y6py3x0x2t8",
+      "videoTitle": "어우펀 : 사과 맛이 나는데 단팥에 대추가 들어가 있다? 묘한 식감의 요리"
+    },
+    {
+      "spotId": "SS01kyhxp3ksc7mdz7gm8j4saphy",
+      "videoId": "dZr9FPLIfRU",
+      "videoTitle": "연근 갈비탕 : 뜨-끈한 갈비탕에 연근이 퐁-당🍲"
+    },
+    {
+      "spotId": "SS01kyhxp3kthtjq2jqhtr8c8t3m",
+      "videoId": "t3G6ar27DiA",
+      "videoTitle": "몐워 & 눠미지 : 백쌤이 분식집에 알려줬던 쌀도넛의 원조 애피타이저로 먹으면 딱!"
+    },
+    {
+      "spotId": "SS01kyhxp3kvnq0fp3eqbdrpanqv",
+      "videoId": "C0IsGA_MvoI",
+      "videoTitle": "후탕펀 & 요우티아오 : 생선 국물 베이스로 한 걸-쭉한 쌀국수! 후추가 후추후추 들어가 하나도 안비림."
+    },
+    {
+      "spotId": "SS01kyhxp3kv4qsyzeq8hbzdbang",
+      "videoId": "HQi0peG8QW4",
+      "videoTitle": "위터우파오판 : 백종원의 합격을 받은 생선 조림 고소~합니다😋"
+    },
+    {
+      "spotId": "SS01kyhxp3kw7p9qcx5x0z5sgg58",
+      "videoId": "FT_X7hvwSTc",
+      "videoTitle": "자자 : 재료를 직접 고르고 소스도 직접! 재료가 살아 있는 튀김 요리😛"
+    },
+    {
+      "spotId": "SS01kyhxp3kxn2pkvwgzt3ekc5fy",
+      "videoId": "-xXkQyEI-BQ",
+      "videoTitle": "고구마 몐워 : 고구마 + 기름 = 끝 아는 맛의 무서움🍠"
+    },
+    {
+      "spotId": "SS01kyhxp3kytf6qqg7shnpbp01j",
+      "videoId": "J2ag1Qm62Bk",
+      "videoTitle": "뉴자훠궈 : 흰 쌀밥이나 면추가를 부르는 미친 국물의 마라맛 내장 요리"
+    },
+    {
+      "spotId": "SS01kyhxp3kzvpc5cfw6tt71nbwx",
+      "videoId": "yEuOEYLSJVk",
+      "videoTitle": "싼셴또우피 : 우한의 대표 아침 겉은 바삭한데 속은 쫀득한 찹쌀이 거기다 각종 재료들이?!?! 환.상"
+    },
+    {
+      "spotId": "SS01kyhxp3m0wssw4p7s3ts27w30",
+      "videoId": "HL5y5q1hZV4",
+      "videoTitle": "요우빙빠오샤오마이 : 탄수화물 + 탄수화물 + 탄수화물 = 환상🍴"
+    },
+    {
+      "spotId": "SS01kyhxp3m11cjdm2z5v4wcd5qc",
+      "videoId": "gWeIaVY0xvw",
+      "videoTitle": "나시 르막 : 흰 쌀밥에 삶은 달걀 그리고 삼발 소스. 게임 끝입니다."
+    },
+    {
+      "spotId": "SS01kyhxp3m2ejdm3qmv447wmnv3",
+      "videoId": "9ExZ0jOfv4g",
+      "videoTitle": "뿔룻 타이타이 : 코코넛 맛 나는 짭조름한 찹쌀밥이에요 근데 여기에 이제 카야 잼을 더하면?"
+    },
+    {
+      "spotId": "SS01kyhxp3n8wrpj4kajngwsypp7",
+      "videoId": "toO-7luxcGk",
+      "videoTitle": "바꾸떼 : 기운이 불뚝불뚝 솟는 찌인한 고기 국물"
+    },
+    {
+      "spotId": "SS01kyhxp3n9mamsfy3b036vh6ve",
+      "videoId": "CpCz2NB8Zbg",
+      "videoTitle": "록록 : 직접 꼬치를 골라서 데쳐 먹는데 매콤한 소스가 조화롭게 챱챱~🍢"
+    },
+    {
+      "spotId": "SS01kyhxp3na83zzw7byymsc90q4",
+      "videoId": "F4Rx68S4tjM",
+      "videoTitle": "아팜 발릭 : 코코넛향이 확 올라오는 팬케이크🥞 + 바나나🍌"
+    },
+    {
+      "spotId": "SS01kyhxp3ndc5qk0w81svwwv3xe",
+      "videoId": "1cJieTHfAx0",
+      "videoTitle": "로작 : 신박한 오징어 샐러드🥗 역시 미식의 천국, 길거리 음식의 천국 인정"
+    },
+    {
+      "spotId": "SS01kyhxp3nezjcvwyj657618ejt",
+      "videoId": "eV7KoQnTLuo",
+      "videoTitle": "로띠 & 떼 따릭 : 기름이나 버터, 마가린으로 반죽해서 숙성해서 페스츄리처럼 찢어집니다 커리에 찍어 먹으면 끝."
+    },
+    {
+      "spotId": "SS01kyhxp3nf0wh80ss8wvwvx51y",
+      "videoId": "ej6KEpmngWg",
+      "videoTitle": "아쌈 락사 : 낯선 재료로 맛보는 익숙한 맛😛"
+    },
+    {
+      "spotId": "SS01kyhxp3ng3mdbdj4b17eck1sv",
+      "videoId": "2ibGprMylzs",
+      "videoTitle": "첸돌 : 향과 식감을 동시에 즐겨야하는 페낭의 빙수👍"
+    },
+    {
+      "spotId": "SS01kyhxp3ngsmw4rzdv5wy5x41a",
+      "videoId": "Najxa4O5QKg",
+      "videoTitle": "나시 칸다르 : 이것저것 반찬 많이 놓고 먹는 밥보다 괜히 하나에 집중하는 밥이 더 좋을 때가 있죠 그게 이거입니다"
+    },
+    {
+      "spotId": "SS01kyhxp3nh7tf9w6ybgzg79k9r",
+      "videoId": "5l-VCKO4Fmg",
+      "videoTitle": "차 퀘이 칵 : 돼지고기 기름 + 간장으로 만든 고소~한 팟타이"
+    },
+    {
+      "spotId": "SS01kyhxp3nj3w4acx0f0st6a8b9",
+      "videoId": "oP9n78Z8MZ4",
+      "videoTitle": "카야 토스트 : 고소함에. 고소함을 더하다."
+    },
+    {
+      "spotId": "SS01kyhxp3nkjgr2hpyrjs99earj",
+      "videoId": "dc-zbt6mAH8",
+      "videoTitle": "초두부 : 물을 덜어내면서 먹어야할 정도로 물이 많아 수두부라고도 불리는 촉촉한 두부😋"
+    },
+    {
+      "spotId": "SS01kyhxp3nm075mvjt3qaeypy68",
+      "videoId": "VFbsnMLTvto",
+      "videoTitle": "연길냉면 : 굉장히 자극적이고 새콤달콤해서 오이냉면 같은 맛입니다. 온 가게가 다 이래요 ㅇㅅㅇ"
+    },
+    {
+      "spotId": "SS01kyhxp3nnej72sye2v3pz37zf",
+      "videoId": "9X1EDyXUJ0s",
+      "videoTitle": "꿔바로우 : 냉면에 넣어 먹는 꿔바로우. 그 맛과 식감은??😗"
+    },
+    {
+      "spotId": "SS01kyhxp3nnyftwfb6mfb9x5b34",
+      "videoId": "vFYcBu-DGpU",
+      "videoTitle": "연변 양꼬치 : 살코기 다음 기름 다음 살코기 다음 기름"
+    },
+    {
+      "spotId": "SS01kyhxp3npbqyd1rcxj40rxah4",
+      "videoId": "ihOMzVl_oYM",
+      "videoTitle": "피주궈 : 양꼬치가 남았다면? 맥주와 함께 부어주세요🍺"
+    },
+    {
+      "spotId": "SS01kyhxp3nq1dt1mb9g7eezghf4",
+      "videoId": "ke0gEJ3_uqU",
+      "videoTitle": "찰떡 : 연변의 이른 아침 들려오는 방아 찧는 소리.."
+    },
+    {
+      "spotId": "SS01kyhxp3nrd9zpm8j83rfkcnxc",
+      "videoId": "d8hTyhkvjgQ",
+      "videoTitle": "소탕 : 소즙과 부추꽃장만 있다면 어디든 갈 수 있어.."
+    },
+    {
+      "spotId": "SS01kyhxp3ns5hpxqh7chtjx5jbv",
+      "videoId": "gRRTQsijx3c",
+      "videoTitle": "찹쌀 순대 : 백종원 픽, 여태까지 찹쌀 들어간 순대 먹어본 것 중에서는 거의 일등 같은데요?🥇"
+    },
+    {
+      "spotId": "SS01kyhxp3ntz381bx8cb28ab9x3",
+      "videoId": "CdGDd2yxWxg",
+      "videoTitle": "짝태구이 : 백종원 픽 짝태구이 소스 '라면수프 + 맥주(?)'"
+    },
+    {
+      "spotId": "SS01kyhxp3nt73pgd0yat73h8pej",
+      "videoId": "r1wYibhsegg",
+      "videoTitle": "짝태 볶음 : 연변에 오면 꼭 먹어야해유. 맵습니다. 그치만 JMT😋"
+    },
+    {
+      "spotId": "SS01kyhxp3nvvd84cvn8yn841htz",
+      "videoId": "6drvL2-Iuk0",
+      "videoTitle": "장국 : 100% 성공 조합. 된장찌개 + 돼지고기"
+    },
+    {
+      "spotId": "SS01kyhxp3nw5kw0mzvj0qm17w6z",
+      "videoId": "ucVT3KdQxRc",
+      "videoTitle": "옥수수면 : 백종원이 젓가락 쪽쪽 빨게 만든 그 음식!!🥢"
+    },
+    {
+      "spotId": "SS01kyhxp3nxvh9hajdf6ts903t8",
+      "videoId": "U-6jbotyWw4",
+      "videoTitle": "가지 돌솥밥 : 가지밥은 볶음밥을 눌려 먹는 것처럼 나중에 누룽지로 먹는 게 맛있습니다👍"
+    },
+    {
+      "spotId": "SS01kyhxp3nya25kvrgb2td2jsbw",
+      "videoId": "Yt4CzyLBOxw",
+      "videoTitle": "차이 : 백종원이 알려주는 차이 마시는 법🍵"
+    },
+    {
+      "spotId": "SS01kyhxp3nzk5d359grc0bstzqe",
+      "videoId": "Mo7XERLbhe0",
+      "videoTitle": "만트 : 만두 위에 요구르트(?), 고추기름을 올려요 그리고 고춧가루 너무 신기하죠😗"
+    },
+    {
+      "spotId": "SS01kyhxp3nzv7dy6bz6zvhjnprp",
+      "videoId": "R9oN2nNcs5o",
+      "videoTitle": "랍스타 롤 : 버터에 구운 식빵에 랍스타를 싸악- 고급진 간식 완-성"
+    },
+    {
+      "spotId": "SS01kyhxp3p091z4ms55c55ghhzv",
+      "videoId": "sT9wwi5g2Ww",
+      "videoTitle": "'바구니'따꼬 : 길거리에 서서 먹어줘야 또 맛있는거 먼지알지?😘"
+    },
+    {
+      "spotId": "SS01kyhxp3p1egetz1p70qv697nb",
+      "videoId": "azwXa-4QqnA",
+      "videoTitle": "칠레 엔 노가다 : 멕시코에서도 딱 4개월만 먹을 수 있다는 이것!"
+    },
+    {
+      "spotId": "SS01kyhxp3p1evne7rszezjyf430",
+      "videoId": "l-onc_c2lrM",
+      "videoTitle": "이 조합이 단돈 2,000원?!! 백종원도 놀라버린 가격ㄷㄷ🔥 베트남식 고급스러운 소고기 스튜에 바삭하고 고소한 반미를 찍어 먹으면 끝이쥬-! | 스트리트푸드파이터2"
+    },
+    {
+      "spotId": "SS01kyhxp3p2fpz3x9mske7avcfn",
+      "videoId": "gxeOvylKFq4",
+      "videoTitle": "백종원이 방문한 쑤안 할머니 식당🎊 이름 들어가면 다 맛집이라던데...👍 수제비를 얇게 썰어놓은 야들야들한 피에 볶은 돼지고기를 넣은 한국식 만두 먹방! | 스트리트푸드파이터2"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2/locations.json
+++ b/.claude/workspace/youtube/PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2/locations.json
@@ -1,0 +1,2265 @@
+{
+  "videos": [
+    {
+      "videoId": "vTG6PxKuOCQ",
+      "title": "푸드 무비의 선구자, 백종원과 제작진이 돌아왔다! 스트리트푸드파이터2",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 푸드 무비의 선구자, 백종원과 제작진이 돌아왔다! 스트리트푸드파이터2",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vTG6PxKuOCQ"
+        }
+      ]
+    },
+    {
+      "videoId": "RVZo-Yd4r08",
+      "title": "이스탄불 케밥 : 소고기와 양고기를 알맞은 비율로 차곡차곡 쌓아 올린, 백종원 숨겨진 케밥 단골집",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 이스탄불 케밥 : 소고기와 양고기를 알맞은 비율로 차곡차곡 쌓아 올린, 백종원 숨겨진 케밥 단골집",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=RVZo-Yd4r08"
+        }
+      ]
+    },
+    {
+      "videoId": "sCctPC96hHo",
+      "title": "이스켄데르 케밥 : 버터의 축복.",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 이스켄데르 케밥 : 버터의 축복.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sCctPC96hHo"
+        }
+      ]
+    },
+    {
+      "videoId": "CKzUY2xcSdQ",
+      "title": "타북 필라프 : 닭백숙 국물로 지은 밥 느낌?!?!?! 볶음밥으로 착각할 정도로 밥알이 따로놉니다. 먹어봐야 압니다.",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 타북 필라프 : 닭백숙 국물로 지은 밥 느낌?!?!?! 볶음밥으로 착각할 정도로 밥알이 따로놉니다. 먹어봐야 압니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CKzUY2xcSdQ"
+        }
+      ]
+    },
+    {
+      "videoId": "UwY5Pqn8r3Y",
+      "title": "아이란 : 터키의 국민 음료. 요구르트가 들어갔지만 밥 먹으면서 먹는 냉국 같은 존재?!?!!?",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 아이란 : 터키의 국민 음료. 요구르트가 들어갔지만 밥 먹으면서 먹는 냉국 같은 존재?!?!!?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=UwY5Pqn8r3Y"
+        }
+      ]
+    },
+    {
+      "videoId": "1mVFAbxMJeA",
+      "title": "시미트 : 전통 화덕 기이이이잎은 곳에서 굽는 갓 구운 빵의 미친 매력.",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 시미트 : 전통 화덕 기이이이잎은 곳에서 굽는 갓 구운 빵의 미친 매력.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1mVFAbxMJeA"
+        }
+      ]
+    },
+    {
+      "videoId": "zftY4Fs5wuU",
+      "title": "카이막 : 터키에 왔다면 꼭 한번은 먹어봐야 할 천상의 맛",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 카이막 : 터키에 왔다면 꼭 한번은 먹어봐야 할 천상의 맛",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zftY4Fs5wuU"
+        }
+      ]
+    },
+    {
+      "videoId": "DHmqyWPqpv4",
+      "title": "카이막 : 우유 10kg으로 만들어지는 양 400g?",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 카이막 : 우유 10kg으로 만들어지는 양 400g?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DHmqyWPqpv4"
+        }
+      ]
+    },
+    {
+      "videoId": "66mJhvl4klk",
+      "title": "미디예 돌마 : 홍합과 양파의 만남. 그 자리에서 10개는 뚝딱!?!?!",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 미디예 돌마 : 홍합과 양파의 만남. 그 자리에서 10개는 뚝딱!?!?!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=66mJhvl4klk"
+        }
+      ]
+    },
+    {
+      "videoId": "hEkt2Q5EQa4",
+      "title": "돈두르마 카다이프 : 쫀~독한 아이스크림 돈두르마와 소면을 튀긴 것 같은 식감의 카다이프의 만남.",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 돈두르마 카다이프 : 쫀~독한 아이스크림 돈두르마와 소면을 튀긴 것 같은 식감의 카다이프의 만남.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=hEkt2Q5EQa4"
+        }
+      ]
+    },
+    {
+      "videoId": "6m6gRtQwgV0",
+      "title": "탄투니: 단순하게 고기를 잘게잘게 썰어가지고 거기에 소금을 뿌려서 지금 특별한 양념을 안 한 것 같은 맛이에요",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 탄투니: 단순하게 고기를 잘게잘게 썰어가지고 거기에 소금을 뿌려서 지금 특별한 양념을 안 한 것 같은 맛이에요",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6m6gRtQwgV0"
+        }
+      ]
+    },
+    {
+      "videoId": "mJkgEzykeF8",
+      "title": "괴프테 : 완자나 떡갈비 느낌의 미트볼?!?!?? 근데 이제 식감이 쫄깃한.",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 괴프테 : 완자나 떡갈비 느낌의 미트볼?!?!?? 근데 이제 식감이 쫄깃한.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=mJkgEzykeF8"
+        }
+      ]
+    },
+    {
+      "videoId": "FSAG7CgaqCk",
+      "title": "치이 쾨프테 : 길거리에서 파는 게 찐?! 고기가 하나도 없지만 너무 맛있는 진정한 비건 푸드!!!",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 치이 쾨프테 : 길거리에서 파는 게 찐?! 고기가 하나도 없지만 너무 맛있는 진정한 비건 푸드!!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=FSAG7CgaqCk"
+        }
+      ]
+    },
+    {
+      "videoId": "8apWu4OotMU",
+      "title": "이시켐베 초르바스 : 내장을 거의 다지듯이 썰어서 제대로 올라오는 쿰쿰한 이 맛. 소주 좀 가져다 주세요!!!",
+      "concept": "터키 이스탄불",
+      "locations": [
+        {
+          "name": "에미뇌뉘",
+          "address": "튀르키예 이스탄불 주 파티흐 Rüstem Paşa, 에미뇌뉘",
+          "latitude": 41.014935799999996,
+          "longitude": 28.9659767,
+          "googleMapsId": "ChIJNXFYneu5yhQRt__WHWu7oIo",
+          "googleMapsUri": "https://maps.google.com/?cid=9989190042244284343&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 터키 이스탄불 편. 이시켐베 초르바스 : 내장을 거의 다지듯이 썰어서 제대로 올라오는 쿰쿰한 이 맛. 소주 좀 가져다 주세요!!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=8apWu4OotMU"
+        }
+      ]
+    },
+    {
+      "videoId": "kve9C7k3kXc",
+      "title": "쏘이 쎄오 : 아주 단순한 750원 짜리 아침. 하지만 맛은 따봉",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 쏘이 쎄오 : 아주 단순한 750원 짜리 아침. 하지만 맛은 따봉",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kve9C7k3kXc"
+        }
+      ]
+    },
+    {
+      "videoId": "-7l5KUi_pZI",
+      "title": "분 더우 맘 똠 : 분짜의 상위버전 한 번 중독되면 잘못하다간 못끊어요",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 분 더우 맘 똠 : 분짜의 상위버전 한 번 중독되면 잘못하다간 못끊어요",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-7l5KUi_pZI"
+        }
+      ]
+    },
+    {
+      "videoId": "mT8bVAmO3LY",
+      "title": "맘 똠 : 곰삭은 황석어젓 같은 냄새?!?!? 안에 튀김이 들어가 있어서 섞으면 카푸치노같이 거품이나요",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 맘 똠 : 곰삭은 황석어젓 같은 냄새?!?!? 안에 튀김이 들어가 있어서 섞으면 카푸치노같이 거품이나요",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=mT8bVAmO3LY"
+        }
+      ]
+    },
+    {
+      "videoId": "OEegrwmnppg",
+      "title": "닭구이 : 닭발을 바로 구우면 콜라겐이 살아있어요 그래서 엄청 쫀독쫀독해",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 닭구이 : 닭발을 바로 구우면 콜라겐이 살아있어요 그래서 엄청 쫀독쫀독해",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=OEegrwmnppg"
+        }
+      ]
+    },
+    {
+      "videoId": "Tw_Ep-iEuo8",
+      "title": "반 미 느엉 : 기름하고 꿀하고 발라서 구운 반미와 닭구이의 조합은? 맛 없을 수 없음",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 반 미 느엉 : 기름하고 꿀하고 발라서 구운 반미와 닭구이의 조합은? 맛 없을 수 없음",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Tw_Ep-iEuo8"
+        }
+      ]
+    },
+    {
+      "videoId": "mKPfmrQvZgg",
+      "title": "꿔이 : 이 매력은 하노이에서만 느낄 수 있습니다 호치민가서 쌀국수 먹을 때 이거 안준다고 뭐라하면 안됩니다!!!",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 꿔이 : 이 매력은 하노이에서만 느낄 수 있습니다 호치민가서 쌀국수 먹을 때 이거 안준다고 뭐라하면 안됩니다!!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=mKPfmrQvZgg"
+        }
+      ]
+    },
+    {
+      "videoId": "_TmYAydLkUE",
+      "title": "반 똠 : 찍어먹는 느억맘 소스가 진짜 꿀맛. 먹다보면 나도 모르게 마셔벌임ㅇㅇ..",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 반 똠 : 찍어먹는 느억맘 소스가 진짜 꿀맛. 먹다보면 나도 모르게 마셔벌임ㅇㅇ..",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=_TmYAydLkUE"
+        }
+      ]
+    },
+    {
+      "videoId": "imzbIa81KaI",
+      "title": "반 꾸온 꼬 년 : 하노이 사람들은 차암 행복하겠다 간식을 이렇게 먹으니",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 반 꾸온 꼬 년 : 하노이 사람들은 차암 행복하겠다 간식을 이렇게 먹으니",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=imzbIa81KaI"
+        }
+      ]
+    },
+    {
+      "videoId": "7FvuOGJZUuE",
+      "title": "거위고기 : 씹다보면 껍데기에서 기름이 쭉쭉 나오니까 고소해요 닭똥집 맛?!?!?!",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 거위고기 : 씹다보면 껍데기에서 기름이 쭉쭉 나오니까 고소해요 닭똥집 맛?!?!?!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=7FvuOGJZUuE"
+        }
+      ]
+    },
+    {
+      "videoId": "hbxTavxKk9U",
+      "title": "반 쯩 : 새콤달콤하게 절인 거랑 같이 먹으면 더 꿀맛 부렵죠? 750원으로 이런 아침을 먹을 수 있다는 게ㅎㅎ",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 반 쯩 : 새콤달콤하게 절인 거랑 같이 먹으면 더 꿀맛 부렵죠? 750원으로 이런 아침을 먹을 수 있다는 게ㅎㅎ",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=hbxTavxKk9U"
+        }
+      ]
+    },
+    {
+      "videoId": "wf5r-GUh0mU",
+      "title": "짜오 롱 : 죽입니다 죽인데 순대, 내장, 선지가 들어가 있어요 아, 한잔해야하는데…",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 짜오 롱 : 죽입니다 죽인데 순대, 내장, 선지가 들어가 있어요 아, 한잔해야하는데…",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=wf5r-GUh0mU"
+        }
+      ]
+    },
+    {
+      "videoId": "7PcfURXJlPc",
+      "title": "분 옥 : 새코옴한데 시워언한, 상상도 하지 못한 재료들의 조합!!! 그 맛은?",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 분 옥 : 새코옴한데 시워언한, 상상도 하지 못한 재료들의 조합!!! 그 맛은?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=7PcfURXJlPc"
+        }
+      ]
+    },
+    {
+      "videoId": "kyP2aE5Js60",
+      "title": "반 미 & 솟 방 : 딱 보시면 스튜입니다. 단, 다른건 고수가 듬뿍 들어간… 바사삭 소리가 환.상.",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 반 미 & 솟 방 : 딱 보시면 스튜입니다. 단, 다른건 고수가 듬뿍 들어간… 바사삭 소리가 환.상.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kyP2aE5Js60"
+        }
+      ]
+    },
+    {
+      "videoId": "3dKte6rpx7s",
+      "title": "피자 : 백종원의 찐 뉴요커 따라잡기ㅋㅋㅋㅋ",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 피자 : 백종원의 찐 뉴요커 따라잡기ㅋㅋㅋㅋ",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=3dKte6rpx7s"
+        }
+      ]
+    },
+    {
+      "videoId": "A1IYJjST2js",
+      "title": "피자2 : 석탄 화덕에서 만든 피자에서만 느낄 수 있는 바삭바삭한 이 가게 피자🍕",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 피자2 : 석탄 화덕에서 만든 피자에서만 느낄 수 있는 바삭바삭한 이 가게 피자🍕",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=A1IYJjST2js"
+        }
+      ]
+    },
+    {
+      "videoId": "ba--mjuBUFw",
+      "title": "포터하우스 스테이크 : 온 비법이 다들어간 육즙. 이 집 스테이크는 맛이 계속 올라갑니다 예술이에요🥩",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 포터하우스 스테이크 : 온 비법이 다들어간 육즙. 이 집 스테이크는 맛이 계속 올라갑니다 예술이에요🥩",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ba--mjuBUFw"
+        }
+      ]
+    },
+    {
+      "videoId": "Zbj3YLVLoj4",
+      "title": "포터하우스 스테이크2 : 침 고이는 선홍빛 마블링 백선생님을 감동시킨 스테이크",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 포터하우스 스테이크2 : 침 고이는 선홍빛 마블링 백선생님을 감동시킨 스테이크",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Zbj3YLVLoj4"
+        }
+      ]
+    },
+    {
+      "videoId": "5I2NFZ65jCc",
+      "title": "럼버잭 : 아침엔 살 걱정 안해도 되쥬~",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 럼버잭 : 아침엔 살 걱정 안해도 되쥬~",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5I2NFZ65jCc"
+        }
+      ]
+    },
+    {
+      "videoId": "vdCn0I-_7QQ",
+      "title": "뉴욕 햄버거 : 햄버거는 먹으면서 다음 먹을 걸 찾을 수 있어유ㅎㅎ",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 뉴욕 햄버거 : 햄버거는 먹으면서 다음 먹을 걸 찾을 수 있어유ㅎㅎ",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vdCn0I-_7QQ"
+        }
+      ]
+    },
+    {
+      "videoId": "Cmc4BtUJ4Ck",
+      "title": "뉴욕 치즈케이크 : 그냥 치즈케이크가 아닙니다. 앞에 뉴욕이 붙어야해요 이쁘죠?",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 뉴욕 치즈케이크 : 그냥 치즈케이크가 아닙니다. 앞에 뉴욕이 붙어야해요 이쁘죠?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Cmc4BtUJ4Ck"
+        }
+      ]
+    },
+    {
+      "videoId": "XTtidLKK96k",
+      "title": "버펄로 윙 : 여기서 버팔로 윙 안 먹어 봤으면 먹어봤다 말하면 안 됨🍻",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 버펄로 윙 : 여기서 버팔로 윙 안 먹어 봤으면 먹어봤다 말하면 안 됨🍻",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XTtidLKK96k"
+        }
+      ]
+    },
+    {
+      "videoId": "eJTvH49yTSk",
+      "title": "베이글 : 보기만해도 마음이 므흣해지는 크림치즈 + 베이글",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 베이글 : 보기만해도 마음이 므흣해지는 크림치즈 + 베이글",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=eJTvH49yTSk"
+        }
+      ]
+    },
+    {
+      "videoId": "BjMizteUE2A",
+      "title": "콘 브레드 : 꽁짠데 갓 만들어서 따끈하고 맛을 보자하는 빵. 하지만 이제 칼로리는 보장 못 하는.",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 콘 브레드 : 꽁짠데 갓 만들어서 따끈하고 맛을 보자하는 빵. 하지만 이제 칼로리는 보장 못 하는.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BjMizteUE2A"
+        }
+      ]
+    },
+    {
+      "videoId": "x60mZ-nIODw",
+      "title": "프라이드치킨 : 닭다리, 닭날개가 먹다 남은 부위라고?!?! 아프리카계 미국인들의 소울푸드",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 프라이드치킨 : 닭다리, 닭날개가 먹다 남은 부위라고?!?! 아프리카계 미국인들의 소울푸드",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=x60mZ-nIODw"
+        }
+      ]
+    },
+    {
+      "videoId": "p0T5WnrKEYA",
+      "title": "굴 : 미국 동부, 전혀 안비리고 달달한 굴이 있다??!?!?",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 굴 : 미국 동부, 전혀 안비리고 달달한 굴이 있다??!?!?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=p0T5WnrKEYA"
+        }
+      ]
+    },
+    {
+      "videoId": "s8QeRTIEK_k",
+      "title": "스쯔모 : 맥반석 돌로 굽는 중국식 와플 느낌? 고소한 간식으로 딱!!",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 스쯔모 : 맥반석 돌로 굽는 중국식 와플 느낌? 고소한 간식으로 딱!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=s8QeRTIEK_k"
+        }
+      ]
+    },
+    {
+      "videoId": "BbxgWO02X2I",
+      "title": "유차마화 : 자극적이진 않은데, 무의식중에 계속 먹게 되는 맛?!",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 유차마화 : 자극적이진 않은데, 무의식중에 계속 먹게 되는 맛?!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BbxgWO02X2I"
+        }
+      ]
+    },
+    {
+      "videoId": "0iAaHNN9vtw",
+      "title": "유포면 : 들어가는게 별거 없는데 너~~무 맛있는 이 요리🥢",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 유포면 : 들어가는게 별거 없는데 너~~무 맛있는 이 요리🥢",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0iAaHNN9vtw"
+        }
+      ]
+    },
+    {
+      "videoId": "2zSwxWEQV58",
+      "title": "서봉주 : 비교적 저렴하지만 시안의 명주라고 불리는 술🍶",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 서봉주 : 비교적 저렴하지만 시안의 명주라고 불리는 술🍶",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=2zSwxWEQV58"
+        }
+      ]
+    },
+    {
+      "videoId": "MiLdS5ikyq8",
+      "title": "후루터우 샤오차오 : 한국의 대창볶음이 있다면 중국엔 이 요리가 있다!! 서봉주랑 먹으면~크👍",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 후루터우 샤오차오 : 한국의 대창볶음이 있다면 중국엔 이 요리가 있다!! 서봉주랑 먹으면~크👍",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=MiLdS5ikyq8"
+        }
+      ]
+    },
+    {
+      "videoId": "U-XPZHLjJWw",
+      "title": "후라탕 : 요즘 유행하는 마라와 후추의 조합?!? 완자까지 들어있으니 JMT!!",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 후라탕 : 요즘 유행하는 마라와 후추의 조합?!? 완자까지 들어있으니 JMT!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=U-XPZHLjJWw"
+        }
+      ]
+    },
+    {
+      "videoId": "VkfKGpRDCcY",
+      "title": "쩡가오 : 이게 다~ 대추입니다 대추 향이 풍부한 약밥의 느낌?!?!?",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 쩡가오 : 이게 다~ 대추입니다 대추 향이 풍부한 약밥의 느낌?!?!?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=VkfKGpRDCcY"
+        }
+      ]
+    },
+    {
+      "videoId": "2YLjkhY5NZg",
+      "title": "샤오쯔몐 : 얇은 국수 면에 싸악 배어 있는 새~코옴한 국물 중독되는 그 맛🥢",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 샤오쯔몐 : 얇은 국수 면에 싸악 배어 있는 새~코옴한 국물 중독되는 그 맛🥢",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=2YLjkhY5NZg"
+        }
+      ]
+    },
+    {
+      "videoId": "tjwAXEpLw1Y",
+      "title": "삼진세트 : 매콤한 떡볶이 소스에 튀김을 찍어 먹으면 조화가 되듯 완벽한 조화로우움",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 삼진세트 : 매콤한 떡볶이 소스에 튀김을 찍어 먹으면 조화가 되듯 완벽한 조화로우움",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tjwAXEpLw1Y"
+        }
+      ]
+    },
+    {
+      "videoId": "rC0_gbd8eu8",
+      "title": "양 내장탕 : 중국 왔으면 이건 제대로 한 번 먹어봐야죠 쿰쿰한 맛을 좋아하는 분 무조건 좋아합니다!!",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 양 내장탕 : 중국 왔으면 이건 제대로 한 번 먹어봐야죠 쿰쿰한 맛을 좋아하는 분 무조건 좋아합니다!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=rC0_gbd8eu8"
+        }
+      ]
+    },
+    {
+      "videoId": "INcgtsw-lYA",
+      "title": "펀정러우 : 갈비찜을 빵 안에 넣어 먹는 맛?!? 하얀 소 내장 기름을 꼭 넣어서 드세유",
+      "concept": "중국 시안",
+      "locations": [
+        {
+          "name": "Xi'an Muslim Dasi Residential Quarter",
+          "address": "90 Bei Guang Ji Jie, 钟楼商圈 Lian Hu Qu, Xi An Shi, Shan Xi Sheng, 중국 710008",
+          "latitude": 34.261497999999996,
+          "longitude": 108.938791,
+          "googleMapsId": "ChIJ7UHGLGZ6YzYRahR4zEvkDBs",
+          "googleMapsUri": "https://maps.google.com/?cid=1949183752948683882&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 시안 편. 펀정러우 : 갈비찜을 빵 안에 넣어 먹는 맛?!? 하얀 소 내장 기름을 꼭 넣어서 드세유",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=INcgtsw-lYA"
+        }
+      ]
+    },
+    {
+      "videoId": "v7vKA5vT8nY",
+      "title": "따꼬 : 따꼬는 어떤 음식을 싸 먹는 방법을 말하는 겁니다 몰랐쥬?",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 따꼬 : 따꼬는 어떤 음식을 싸 먹는 방법을 말하는 겁니다 몰랐쥬?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=v7vKA5vT8nY"
+        }
+      ]
+    },
+    {
+      "videoId": "ABkWkgC9_WA",
+      "title": "살사 소스 :  따꼬 가게마다 비법이 들어간 특별 소스를 만듭니다 그만큼 중요하다는 거죠",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 살사 소스 :  따꼬 가게마다 비법이 들어간 특별 소스를 만듭니다 그만큼 중요하다는 거죠",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ABkWkgC9_WA"
+        }
+      ]
+    },
+    {
+      "videoId": "CScfmK4RhoE",
+      "title": "바르바꼬아 : 어? 맛있다. 양고기를 깊은 구덩이에서 오래 구워요 그래서 되게 부드러워요🍖",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 바르바꼬아 : 어? 맛있다. 양고기를 깊은 구덩이에서 오래 구워요 그래서 되게 부드러워요🍖",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CScfmK4RhoE"
+        }
+      ]
+    },
+    {
+      "videoId": "mqwtd4QEm6c",
+      "title": "석회수 : 옥수수 속의 섬유질을 소화 가능하게 만들어주는 이 물의 정체",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 석회수 : 옥수수 속의 섬유질을 소화 가능하게 만들어주는 이 물의 정체",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=mqwtd4QEm6c"
+        }
+      ]
+    },
+    {
+      "videoId": "lMZWUGLxo30",
+      "title": "반데라 : 시고 짭짜름하다?! 멕시코의 밤을 즐겁게 만드는 방법🥃",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 반데라 : 시고 짭짜름하다?! 멕시코의 밤을 즐겁게 만드는 방법🥃",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=lMZWUGLxo30"
+        }
+      ]
+    },
+    {
+      "videoId": "kfjlQsTRR2Q",
+      "title": "판시따 : 멕시코에서 해장국을 먹고 싶다면? 환-상",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 판시따 : 멕시코에서 해장국을 먹고 싶다면? 환-상",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kfjlQsTRR2Q"
+        }
+      ]
+    },
+    {
+      "videoId": "4i_QSyhZA90",
+      "title": "판시따 : 족발, 천엽, 양고기 등 소 내장을 끓인 스프?! 또띠아에 싸 먹으면 바로 해장 뚝딱",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 판시따 : 족발, 천엽, 양고기 등 소 내장을 끓인 스프?! 또띠아에 싸 먹으면 바로 해장 뚝딱",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=4i_QSyhZA90"
+        }
+      ]
+    },
+    {
+      "videoId": "3KowjCYp4hU",
+      "title": "케사디야 : 돼기고기 튀김 + 돼지껍데기 튀김 + 치즈 무적의 삼위일체👍",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 케사디야 : 돼기고기 튀김 + 돼지껍데기 튀김 + 치즈 무적의 삼위일체👍",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=3KowjCYp4hU"
+        }
+      ]
+    },
+    {
+      "videoId": "Ql3oIX1BdCk",
+      "title": "엘로떼 : 옥수수 싫어하는 사람람의 입맛도 영원히 바꿔줄 마약 옥수수",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 엘로떼 : 옥수수 싫어하는 사람람의 입맛도 영원히 바꿔줄 마약 옥수수",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Ql3oIX1BdCk"
+        }
+      ]
+    },
+    {
+      "videoId": "vLlhtvdwsQg",
+      "title": "몰레 콘 포요 : 카레에 초콜릿을 넣어봤는가 초콜릿으로 만든 천국의 맛",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 몰레 콘 포요 : 카레에 초콜릿을 넣어봤는가 초콜릿으로 만든 천국의 맛",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vLlhtvdwsQg"
+        }
+      ]
+    },
+    {
+      "videoId": "Vc7kC6taeK0",
+      "title": "따말&아똘레 : 옥수수 반죽에 닭고기가 쏘옥?! 2000원의 행복",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 따말&아똘레 : 옥수수 반죽에 닭고기가 쏘옥?! 2000원의 행복",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Vc7kC6taeK0"
+        }
+      ]
+    },
+    {
+      "videoId": "lLskv19Vfoc",
+      "title": "칠라킬레스 : 대한민국 어디에서도 찾을 수 없는 맛! 촤르륵 흘러 내리는 노른자를 느껴봐",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 칠라킬레스 : 대한민국 어디에서도 찾을 수 없는 맛! 촤르륵 흘러 내리는 노른자를 느껴봐",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=lLskv19Vfoc"
+        }
+      ]
+    },
+    {
+      "videoId": "sNt2MLnuiNQ",
+      "title": "포솔레 : 한국 국밥 vs 멕시코 국밥 과연 백종원의 선택은?!",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 포솔레 : 한국 국밥 vs 멕시코 국밥 과연 백종원의 선택은?!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sNt2MLnuiNQ"
+        }
+      ]
+    },
+    {
+      "videoId": "kQ_hBSIlc5Y",
+      "title": "또스따다스+크레마 : 국밥에 또띠야를 넣어서 먹는다면?!",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 또스따다스+크레마 : 국밥에 또띠야를 넣어서 먹는다면?!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kQ_hBSIlc5Y"
+        }
+      ]
+    },
+    {
+      "videoId": "LRhiA0BX4rw",
+      "title": "러우저우&홍사오러우 : 백쌤이 이상한 신음소리를 내기 시작했습니다.",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 러우저우&홍사오러우 : 백쌤이 이상한 신음소리를 내기 시작했습니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=LRhiA0BX4rw"
+        }
+      ]
+    },
+    {
+      "videoId": "8CyOd9Rr7lY",
+      "title": "족발국수 : 국수에 삶은 족발이 풍덩!! 이거 먹으면 합격한다?!",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 족발국수 : 국수에 삶은 족발이 풍덩!! 이거 먹으면 합격한다?!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=8CyOd9Rr7lY"
+        }
+      ]
+    },
+    {
+      "videoId": "LPGZq4MIg0k",
+      "title": "깨 끙 : 닭고기 없는 닭고기 말이 튀김!?",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 깨 끙 : 닭고기 없는 닭고기 말이 튀김!?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=LPGZq4MIg0k"
+        }
+      ]
+    },
+    {
+      "videoId": "W6ZirHCGDec",
+      "title": "전주나이차 : 동글동글 검은색 진주들이 잔뜩 들어간 대만 대표 음료수🥤",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 전주나이차 : 동글동글 검은색 진주들이 잔뜩 들어간 대만 대표 음료수🥤",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=W6ZirHCGDec"
+        }
+      ]
+    },
+    {
+      "videoId": "5GcK2-mbkqQ",
+      "title": "굴전 : 이 비주얼은 못 참지. 우리 다이어트는,, 잠시 쉬기로 해요.",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 굴전 : 이 비주얼은 못 참지. 우리 다이어트는,, 잠시 쉬기로 해요.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5GcK2-mbkqQ"
+        }
+      ]
+    },
+    {
+      "videoId": "LXSorJ47htc",
+      "title": "루 러우 판 : 이른 아침 졸린 눈이 번쩍?!👀 떠지게 만드는 맛!!",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 루 러우 판 : 이른 아침 졸린 눈이 번쩍?!👀 떠지게 만드는 맛!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=LXSorJ47htc"
+        }
+      ]
+    },
+    {
+      "videoId": "bwrnQCeuvv8",
+      "title": "타이완식 소시지 : 고기와 비계가 씹히는 소시지에 마늘을 같이 먹으면?",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 타이완식 소시지 : 고기와 비계가 씹히는 소시지에 마늘을 같이 먹으면?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bwrnQCeuvv8"
+        }
+      ]
+    },
+    {
+      "videoId": "EwYcFwk-VFw",
+      "title": "대창굴국수 : 굴 있쥬 돼지 대창 있쥬 안 어울릴 것 같쥬? 무지하게 잘 어울려유☺️",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 대창굴국수 : 굴 있쥬 돼지 대창 있쥬 안 어울릴 것 같쥬? 무지하게 잘 어울려유☺️",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=EwYcFwk-VFw"
+        }
+      ]
+    },
+    {
+      "videoId": "S1Zdt8ya7Ec",
+      "title": "우육면 : 고기가 실종되었습니다. 입 안에서.",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 우육면 : 고기가 실종되었습니다. 입 안에서.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=S1Zdt8ya7Ec"
+        }
+      ]
+    },
+    {
+      "videoId": "hCF9rgFmymA",
+      "title": "스무위 덮밥 : 이게 장어야 푸딩이야? ㅇㅅㅇ 입 안에서 장어가 살살 녹아유",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 스무위 덮밥 : 이게 장어야 푸딩이야? ㅇㅅㅇ 입 안에서 장어가 살살 녹아유",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=hCF9rgFmymA"
+        }
+      ]
+    },
+    {
+      "videoId": "1913r9IXCiw",
+      "title": "쓰선탕 : 더위 먹은 사람들도 이것만 먹으면 벌떡! 일어난다는 이 음식!",
+      "concept": "대만 타이베이",
+      "locations": [
+        {
+          "name": "닝샤 야시장",
+          "address": "Ningxia Rd, Xingming Village, Datong District, Taipei City, 대만 103",
+          "latitude": 25.0566808,
+          "longitude": 121.51536410000001,
+          "googleMapsId": "ChIJxUXPVmupQjQRtBB6oj-S5qI",
+          "googleMapsUri": "https://maps.google.com/?cid=11738230280794280116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 대만 타이베이 편. 쓰선탕 : 더위 먹은 사람들도 이것만 먹으면 벌떡! 일어난다는 이 음식!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1913r9IXCiw"
+        }
+      ]
+    },
+    {
+      "videoId": "06MUNiVH6DM",
+      "title": "펑리수 : 대만의 대표 간식 쫀독한 파인애플 필링이 가~득차서 새콤달콤 맛있다!",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 펑리수 : 대만의 대표 간식 쫀독한 파인애플 필링이 가~득차서 새콤달콤 맛있다!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=06MUNiVH6DM"
+        }
+      ]
+    },
+    {
+      "videoId": "469R33ZNL_c",
+      "title": "브리오쉬에 젤라토 : 빵과 젤라또? 이건 근본이다.",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 브리오쉬에 젤라토 : 빵과 젤라또? 이건 근본이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=469R33ZNL_c"
+        }
+      ]
+    },
+    {
+      "videoId": "YBHxVbYQh8A",
+      "title": "빠넬레&까질리 : 해변가에서 병맥 하나 들고 따악 앉아서 먹으면 이게 행복..🍻",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 빠넬레&까질리 : 해변가에서 병맥 하나 들고 따악 앉아서 먹으면 이게 행복..🍻",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YBHxVbYQh8A"
+        }
+      ]
+    },
+    {
+      "videoId": "BpHUAnZftxs",
+      "title": "카포나타 : 사과가 없어요. 근데 미친 사과라 불립니다.",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 카포나타 : 사과가 없어요. 근데 미친 사과라 불립니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BpHUAnZftxs"
+        }
+      ]
+    },
+    {
+      "videoId": "iCwiJQF_ul8",
+      "title": "알라 노르마 : 고기 빠진 파스타. 노맛? ㄴㄴ 존맛탱",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 알라 노르마 : 고기 빠진 파스타. 노맛? ㄴㄴ 존맛탱",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=iCwiJQF_ul8"
+        }
+      ]
+    },
+    {
+      "videoId": "Kh8iWZj0irs",
+      "title": "스티키올라 : 한국 곱창 맛. 한 입 먹는 순간 소주가 술술술",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 스티키올라 : 한국 곱창 맛. 한 입 먹는 순간 소주가 술술술",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Kh8iWZj0irs"
+        }
+      ]
+    },
+    {
+      "videoId": "TM6H2OeRLUs",
+      "title": "아란치니 : 맛있는 주먹밥을 기름에 풍덩? 말해 뭐해♥",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 아란치니 : 맛있는 주먹밥을 기름에 풍덩? 말해 뭐해♥",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=TM6H2OeRLUs"
+        }
+      ]
+    },
+    {
+      "videoId": "fkYwpbJtOtw",
+      "title": "파니 카 메우사 : 내장 좋아하는 사람 모여라🙋🏻‍♀️",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 파니 카 메우사 : 내장 좋아하는 사람 모여라🙋🏻‍♀️",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=fkYwpbJtOtw"
+        }
+      ]
+    },
+    {
+      "videoId": "wdpfXQXS2Kg",
+      "title": "탈리에레 : 소금에 절인 생 햄과 와인의 환상적 콜라보🍷",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 탈리에레 : 소금에 절인 생 햄과 와인의 환상적 콜라보🍷",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=wdpfXQXS2Kg"
+        }
+      ]
+    },
+    {
+      "videoId": "q39FCOMEK2Y",
+      "title": "에트나 로쏘 : 에트나산 포도로 만든 와인이 가져다주는 천상의 맛(황홀)",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 에트나 로쏘 : 에트나산 포도로 만든 와인이 가져다주는 천상의 맛(황홀)",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=q39FCOMEK2Y"
+        }
+      ]
+    },
+    {
+      "videoId": "4DKJYHkjvk8",
+      "title": "쿠스쿠스 : 이게 무슨 파스타야? 먹어 보면 압니다.",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 쿠스쿠스 : 이게 무슨 파스타야? 먹어 보면 압니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=4DKJYHkjvk8"
+        }
+      ]
+    },
+    {
+      "videoId": "z6U2KvCWBbI",
+      "title": "사르데 아 베카피코 : 생선과 완자의 상상 불가능한 만남",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 사르데 아 베카피코 : 생선과 완자의 상상 불가능한 만남",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=z6U2KvCWBbI"
+        }
+      ]
+    },
+    {
+      "videoId": "jLrBp1jOD2M",
+      "title": "스핀치오네 : 스펀지 피자?! 이탈리아의 엔초비가 들어간 독특한 맛과 식감",
+      "concept": "이탈리아 시칠리아 팔레르모",
+      "locations": [
+        {
+          "name": "Mercato Ballarò",
+          "address": "Via Chiappara Al Carmine, 23, 90134 Palermo PA, 이탈리아",
+          "latitude": 38.110614399999996,
+          "longitude": 13.3636751,
+          "googleMapsId": "ChIJG10YKgDlGRMRgvss8tSK0oc",
+          "googleMapsUri": "https://maps.google.com/?cid=9787037587430243202&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 이탈리아 시칠리아 팔레르모 편. 스핀치오네 : 스펀지 피자?! 이탈리아의 엔초비가 들어간 독특한 맛과 식감",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=jLrBp1jOD2M"
+        }
+      ]
+    },
+    {
+      "videoId": "RXipqsF1-2o",
+      "title": "요우먼따샤 : 가재를 둘러싼 마한 맛의 강렬한 양념 은은~한 고추기름의 매콤함까지",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 요우먼따샤 : 가재를 둘러싼 마한 맛의 강렬한 양념 은은~한 고추기름의 매콤함까지",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=RXipqsF1-2o"
+        }
+      ]
+    },
+    {
+      "videoId": "4Z3JHGYSALw",
+      "title": "러깐몐 : 중국 10대 면요리🍜",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 러깐몐 : 중국 10대 면요리🍜",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=4Z3JHGYSALw"
+        }
+      ]
+    },
+    {
+      "videoId": "MwjSh0SlMKg",
+      "title": "몐양싼정: 3단 찜 요리 이게 고기야? 솜사탕이야? 각양각색의 요리에 신난 백종원",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 몐양싼정: 3단 찜 요리 이게 고기야? 솜사탕이야? 각양각색의 요리에 신난 백종원",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=MwjSh0SlMKg"
+        }
+      ]
+    },
+    {
+      "videoId": "Y6py3x0x2t8",
+      "title": "어우펀 : 사과 맛이 나는데 단팥에 대추가 들어가 있다? 묘한 식감의 요리",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 어우펀 : 사과 맛이 나는데 단팥에 대추가 들어가 있다? 묘한 식감의 요리",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Y6py3x0x2t8"
+        }
+      ]
+    },
+    {
+      "videoId": "dZr9FPLIfRU",
+      "title": "연근 갈비탕 : 뜨-끈한 갈비탕에 연근이 퐁-당🍲",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 연근 갈비탕 : 뜨-끈한 갈비탕에 연근이 퐁-당🍲",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=dZr9FPLIfRU"
+        }
+      ]
+    },
+    {
+      "videoId": "t3G6ar27DiA",
+      "title": "몐워 & 눠미지 : 백쌤이 분식집에 알려줬던 쌀도넛의 원조 애피타이저로 먹으면 딱!",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 몐워 & 눠미지 : 백쌤이 분식집에 알려줬던 쌀도넛의 원조 애피타이저로 먹으면 딱!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=t3G6ar27DiA"
+        }
+      ]
+    },
+    {
+      "videoId": "C0IsGA_MvoI",
+      "title": "후탕펀 & 요우티아오 : 생선 국물 베이스로 한 걸-쭉한 쌀국수! 후추가 후추후추 들어가 하나도 안비림.",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 후탕펀 & 요우티아오 : 생선 국물 베이스로 한 걸-쭉한 쌀국수! 후추가 후추후추 들어가 하나도 안비림.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=C0IsGA_MvoI"
+        }
+      ]
+    },
+    {
+      "videoId": "HQi0peG8QW4",
+      "title": "위터우파오판 : 백종원의 합격을 받은 생선 조림 고소~합니다😋",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 위터우파오판 : 백종원의 합격을 받은 생선 조림 고소~합니다😋",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=HQi0peG8QW4"
+        }
+      ]
+    },
+    {
+      "videoId": "FT_X7hvwSTc",
+      "title": "자자 : 재료를 직접 고르고 소스도 직접! 재료가 살아 있는 튀김 요리😛",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 자자 : 재료를 직접 고르고 소스도 직접! 재료가 살아 있는 튀김 요리😛",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=FT_X7hvwSTc"
+        }
+      ]
+    },
+    {
+      "videoId": "-xXkQyEI-BQ",
+      "title": "고구마 몐워 : 고구마 + 기름 = 끝 아는 맛의 무서움🍠",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 고구마 몐워 : 고구마 + 기름 = 끝 아는 맛의 무서움🍠",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-xXkQyEI-BQ"
+        }
+      ]
+    },
+    {
+      "videoId": "J2ag1Qm62Bk",
+      "title": "뉴자훠궈 : 흰 쌀밥이나 면추가를 부르는 미친 국물의 마라맛 내장 요리",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 뉴자훠궈 : 흰 쌀밥이나 면추가를 부르는 미친 국물의 마라맛 내장 요리",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=J2ag1Qm62Bk"
+        }
+      ]
+    },
+    {
+      "videoId": "yEuOEYLSJVk",
+      "title": "싼셴또우피 : 우한의 대표 아침 겉은 바삭한데 속은 쫀득한 찹쌀이 거기다 각종 재료들이?!?! 환.상",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 싼셴또우피 : 우한의 대표 아침 겉은 바삭한데 속은 쫀득한 찹쌀이 거기다 각종 재료들이?!?! 환.상",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=yEuOEYLSJVk"
+        }
+      ]
+    },
+    {
+      "videoId": "HL5y5q1hZV4",
+      "title": "요우빙빠오샤오마이 : 탄수화물 + 탄수화물 + 탄수화물 = 환상🍴",
+      "concept": "중국 우한",
+      "locations": [
+        {
+          "name": "Hubu Alley",
+          "address": "G7WX+P46, Min Zhu Lu, 户部巷 Wu Chang Qu, Wu Han Shi, Hu Bei Sheng, 중국 430060",
+          "latitude": 30.54679,
+          "longitude": 114.297759,
+          "googleMapsId": "ChIJn6Vqz7mvLjQRIsc4ieYz0oM",
+          "googleMapsUri": "https://maps.google.com/?cid=9498711629315491618&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 우한 편. 요우빙빠오샤오마이 : 탄수화물 + 탄수화물 + 탄수화물 = 환상🍴",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=HL5y5q1hZV4"
+        }
+      ]
+    },
+    {
+      "videoId": "gWeIaVY0xvw",
+      "title": "나시 르막 : 흰 쌀밥에 삶은 달걀 그리고 삼발 소스. 게임 끝입니다.",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 나시 르막 : 흰 쌀밥에 삶은 달걀 그리고 삼발 소스. 게임 끝입니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=gWeIaVY0xvw"
+        }
+      ]
+    },
+    {
+      "videoId": "9ExZ0jOfv4g",
+      "title": "뿔룻 타이타이 : 코코넛 맛 나는 짭조름한 찹쌀밥이에요 근데 여기에 이제 카야 잼을 더하면?",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 뿔룻 타이타이 : 코코넛 맛 나는 짭조름한 찹쌀밥이에요 근데 여기에 이제 카야 잼을 더하면?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=9ExZ0jOfv4g"
+        }
+      ]
+    },
+    {
+      "videoId": "toO-7luxcGk",
+      "title": "바꾸떼 : 기운이 불뚝불뚝 솟는 찌인한 고기 국물",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 바꾸떼 : 기운이 불뚝불뚝 솟는 찌인한 고기 국물",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=toO-7luxcGk"
+        }
+      ]
+    },
+    {
+      "videoId": "CpCz2NB8Zbg",
+      "title": "록록 : 직접 꼬치를 골라서 데쳐 먹는데 매콤한 소스가 조화롭게 챱챱~🍢",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 록록 : 직접 꼬치를 골라서 데쳐 먹는데 매콤한 소스가 조화롭게 챱챱~🍢",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CpCz2NB8Zbg"
+        }
+      ]
+    },
+    {
+      "videoId": "F4Rx68S4tjM",
+      "title": "아팜 발릭 : 코코넛향이 확 올라오는 팬케이크🥞 + 바나나🍌",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 아팜 발릭 : 코코넛향이 확 올라오는 팬케이크🥞 + 바나나🍌",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=F4Rx68S4tjM"
+        }
+      ]
+    },
+    {
+      "videoId": "1cJieTHfAx0",
+      "title": "로작 : 신박한 오징어 샐러드🥗 역시 미식의 천국, 길거리 음식의 천국 인정",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 로작 : 신박한 오징어 샐러드🥗 역시 미식의 천국, 길거리 음식의 천국 인정",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1cJieTHfAx0"
+        }
+      ]
+    },
+    {
+      "videoId": "eV7KoQnTLuo",
+      "title": "로띠 & 떼 따릭 : 기름이나 버터, 마가린으로 반죽해서 숙성해서 페스츄리처럼 찢어집니다 커리에 찍어 먹으면 끝.",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 로띠 & 떼 따릭 : 기름이나 버터, 마가린으로 반죽해서 숙성해서 페스츄리처럼 찢어집니다 커리에 찍어 먹으면 끝.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=eV7KoQnTLuo"
+        }
+      ]
+    },
+    {
+      "videoId": "ej6KEpmngWg",
+      "title": "아쌈 락사 : 낯선 재료로 맛보는 익숙한 맛😛",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 아쌈 락사 : 낯선 재료로 맛보는 익숙한 맛😛",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ej6KEpmngWg"
+        }
+      ]
+    },
+    {
+      "videoId": "2ibGprMylzs",
+      "title": "첸돌 : 향과 식감을 동시에 즐겨야하는 페낭의 빙수👍",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 첸돌 : 향과 식감을 동시에 즐겨야하는 페낭의 빙수👍",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=2ibGprMylzs"
+        }
+      ]
+    },
+    {
+      "videoId": "Najxa4O5QKg",
+      "title": "나시 칸다르 : 이것저것 반찬 많이 놓고 먹는 밥보다 괜히 하나에 집중하는 밥이 더 좋을 때가 있죠 그게 이거입니다",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 나시 칸다르 : 이것저것 반찬 많이 놓고 먹는 밥보다 괜히 하나에 집중하는 밥이 더 좋을 때가 있죠 그게 이거입니다",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Najxa4O5QKg"
+        }
+      ]
+    },
+    {
+      "videoId": "5l-VCKO4Fmg",
+      "title": "차 퀘이 칵 : 돼지고기 기름 + 간장으로 만든 고소~한 팟타이",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 차 퀘이 칵 : 돼지고기 기름 + 간장으로 만든 고소~한 팟타이",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5l-VCKO4Fmg"
+        }
+      ]
+    },
+    {
+      "videoId": "oP9n78Z8MZ4",
+      "title": "카야 토스트 : 고소함에. 고소함을 더하다.",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 카야 토스트 : 고소함에. 고소함을 더하다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=oP9n78Z8MZ4"
+        }
+      ]
+    },
+    {
+      "videoId": "dc-zbt6mAH8",
+      "title": "초두부 : 물을 덜어내면서 먹어야할 정도로 물이 많아 수두부라고도 불리는 촉촉한 두부😋",
+      "concept": "말레이시아 페낭",
+      "locations": [
+        {
+          "name": "New Lane Street Foodstalls",
+          "address": "Lorong Baru, 10450 George Town, Pulau Pinang, 말레이시아",
+          "latitude": 5.4148035,
+          "longitude": 100.3265211,
+          "googleMapsId": "ChIJC0ubEb7DSjARF1xS3hJwQdY",
+          "googleMapsUri": "https://maps.google.com/?cid=15438744223944432663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 말레이시아 페낭 편. 초두부 : 물을 덜어내면서 먹어야할 정도로 물이 많아 수두부라고도 불리는 촉촉한 두부😋",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=dc-zbt6mAH8"
+        }
+      ]
+    },
+    {
+      "videoId": "VFbsnMLTvto",
+      "title": "연길냉면 : 굉장히 자극적이고 새콤달콤해서 오이냉면 같은 맛입니다. 온 가게가 다 이래요 ㅇㅅㅇ",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 연길냉면 : 굉장히 자극적이고 새콤달콤해서 오이냉면 같은 맛입니다. 온 가게가 다 이래요 ㅇㅅㅇ",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=VFbsnMLTvto"
+        }
+      ]
+    },
+    {
+      "videoId": "9X1EDyXUJ0s",
+      "title": "꿔바로우 : 냉면에 넣어 먹는 꿔바로우. 그 맛과 식감은??😗",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 꿔바로우 : 냉면에 넣어 먹는 꿔바로우. 그 맛과 식감은??😗",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=9X1EDyXUJ0s"
+        }
+      ]
+    },
+    {
+      "videoId": "vFYcBu-DGpU",
+      "title": "연변 양꼬치 : 살코기 다음 기름 다음 살코기 다음 기름",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 연변 양꼬치 : 살코기 다음 기름 다음 살코기 다음 기름",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vFYcBu-DGpU"
+        }
+      ]
+    },
+    {
+      "videoId": "ihOMzVl_oYM",
+      "title": "피주궈 : 양꼬치가 남았다면? 맥주와 함께 부어주세요🍺",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 피주궈 : 양꼬치가 남았다면? 맥주와 함께 부어주세요🍺",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ihOMzVl_oYM"
+        }
+      ]
+    },
+    {
+      "videoId": "ke0gEJ3_uqU",
+      "title": "찰떡 : 연변의 이른 아침 들려오는 방아 찧는 소리..",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 찰떡 : 연변의 이른 아침 들려오는 방아 찧는 소리..",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ke0gEJ3_uqU"
+        }
+      ]
+    },
+    {
+      "videoId": "d8hTyhkvjgQ",
+      "title": "소탕 : 소즙과 부추꽃장만 있다면 어디든 갈 수 있어..",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 소탕 : 소즙과 부추꽃장만 있다면 어디든 갈 수 있어..",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=d8hTyhkvjgQ"
+        }
+      ]
+    },
+    {
+      "videoId": "gRRTQsijx3c",
+      "title": "찹쌀 순대 : 백종원 픽, 여태까지 찹쌀 들어간 순대 먹어본 것 중에서는 거의 일등 같은데요?🥇",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 찹쌀 순대 : 백종원 픽, 여태까지 찹쌀 들어간 순대 먹어본 것 중에서는 거의 일등 같은데요?🥇",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=gRRTQsijx3c"
+        }
+      ]
+    },
+    {
+      "videoId": "CdGDd2yxWxg",
+      "title": "짝태구이 : 백종원 픽 짝태구이 소스 '라면수프 + 맥주(?)'",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 짝태구이 : 백종원 픽 짝태구이 소스 '라면수프 + 맥주(?)'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CdGDd2yxWxg"
+        }
+      ]
+    },
+    {
+      "videoId": "r1wYibhsegg",
+      "title": "짝태 볶음 : 연변에 오면 꼭 먹어야해유. 맵습니다. 그치만 JMT😋",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 짝태 볶음 : 연변에 오면 꼭 먹어야해유. 맵습니다. 그치만 JMT😋",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=r1wYibhsegg"
+        }
+      ]
+    },
+    {
+      "videoId": "6drvL2-Iuk0",
+      "title": "장국 : 100% 성공 조합. 된장찌개 + 돼지고기",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 장국 : 100% 성공 조합. 된장찌개 + 돼지고기",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6drvL2-Iuk0"
+        }
+      ]
+    },
+    {
+      "videoId": "ucVT3KdQxRc",
+      "title": "옥수수면 : 백종원이 젓가락 쪽쪽 빨게 만든 그 음식!!🥢",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 옥수수면 : 백종원이 젓가락 쪽쪽 빨게 만든 그 음식!!🥢",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ucVT3KdQxRc"
+        }
+      ]
+    },
+    {
+      "videoId": "U-6jbotyWw4",
+      "title": "가지 돌솥밥 : 가지밥은 볶음밥을 눌려 먹는 것처럼 나중에 누룽지로 먹는 게 맛있습니다👍",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 가지 돌솥밥 : 가지밥은 볶음밥을 눌려 먹는 것처럼 나중에 누룽지로 먹는 게 맛있습니다👍",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=U-6jbotyWw4"
+        }
+      ]
+    },
+    {
+      "videoId": "Yt4CzyLBOxw",
+      "title": "차이 : 백종원이 알려주는 차이 마시는 법🍵",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 차이 : 백종원이 알려주는 차이 마시는 법🍵",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Yt4CzyLBOxw"
+        }
+      ]
+    },
+    {
+      "videoId": "Mo7XERLbhe0",
+      "title": "만트 : 만두 위에 요구르트(?), 고추기름을 올려요 그리고 고춧가루 너무 신기하죠😗",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 만트 : 만두 위에 요구르트(?), 고추기름을 올려요 그리고 고춧가루 너무 신기하죠😗",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Mo7XERLbhe0"
+        }
+      ]
+    },
+    {
+      "videoId": "R9oN2nNcs5o",
+      "title": "랍스타 롤 : 버터에 구운 식빵에 랍스타를 싸악- 고급진 간식 완-성",
+      "concept": "미국 뉴욕",
+      "locations": [
+        {
+          "name": "그리니치 빌리지",
+          "address": "미국 뉴욕 그리니치 빌리지",
+          "latitude": 40.7335719,
+          "longitude": -74.0027418,
+          "googleMapsId": "ChIJpxMyDJRZwokRX0XfgiHEgog",
+          "googleMapsUri": "https://maps.google.com/?cid=9836640184339219807&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 뉴욕 편. 랍스타 롤 : 버터에 구운 식빵에 랍스타를 싸악- 고급진 간식 완-성",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=R9oN2nNcs5o"
+        }
+      ]
+    },
+    {
+      "videoId": "sT9wwi5g2Ww",
+      "title": "'바구니'따꼬 : 길거리에 서서 먹어줘야 또 맛있는거 먼지알지?😘",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. '바구니'따꼬 : 길거리에 서서 먹어줘야 또 맛있는거 먼지알지?😘",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sT9wwi5g2Ww"
+        }
+      ]
+    },
+    {
+      "videoId": "azwXa-4QqnA",
+      "title": "칠레 엔 노가다 : 멕시코에서도 딱 4개월만 먹을 수 있다는 이것!",
+      "concept": "멕시코",
+      "locations": [
+        {
+          "name": "Historic center of Mexico City",
+          "address": "Historic center of Mexico City, Centro, Mexico City, CDMX, 멕시코",
+          "latitude": 19.4357068,
+          "longitude": -99.131757,
+          "googleMapsId": "ChIJvU0OLi350YURPYnEQKd0VZA",
+          "googleMapsUri": "https://maps.google.com/?cid=10400347176177011005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 멕시코 편. 칠레 엔 노가다 : 멕시코에서도 딱 4개월만 먹을 수 있다는 이것!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=azwXa-4QqnA"
+        }
+      ]
+    },
+    {
+      "videoId": "l-onc_c2lrM",
+      "title": "이 조합이 단돈 2,000원?!! 백종원도 놀라버린 가격ㄷㄷ🔥 베트남식 고급스러운 소고기 스튜에 바삭하고 고소한 반미를 찍어 먹으면 끝이쥬-! | 스트리트푸드파이터2",
+      "concept": "베트남 하노이",
+      "locations": [
+        {
+          "name": "Old Quarter",
+          "address": "Old Quarter, Hoàn Kiếm, Ha Noi, 베트남",
+          "latitude": 21.035266399999998,
+          "longitude": 105.8500124,
+          "googleMapsId": "ChIJ95W4Ib-rNTERpMcyh8TGG2Q",
+          "googleMapsUri": "https://maps.google.com/?cid=7213577775548123044&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 베트남 하노이 편. 이 조합이 단돈 2,000원?!! 백종원도 놀라버린 가격ㄷㄷ🔥 베트남식 고급스러운 소고기 스튜에 바삭하고 고소한 반미를 찍어 먹으면 끝이쥬-! | 스트리트푸드파이터2",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=l-onc_c2lrM"
+        }
+      ]
+    },
+    {
+      "videoId": "gxeOvylKFq4",
+      "title": "백종원이 방문한 쑤안 할머니 식당🎊 이름 들어가면 다 맛집이라던데...👍 수제비를 얇게 썰어놓은 야들야들한 피에 볶은 돼지고기를 넣은 한국식 만두 먹방! | 스트리트푸드파이터2",
+      "concept": "중국 연변",
+      "locations": [
+        {
+          "name": "Yanji West Market Parking Lot",
+          "address": "중국 Yan Bian Chao Xian Zu Zi Zhi Zhou, Yan Ji Shi, CN 吉林省 延边朝鲜族自治州 延吉市 150 米 邮政编码: 133002",
+          "latitude": 42.90621,
+          "longitude": 129.50677,
+          "googleMapsId": "ChIJH7FG-_a2Sl4ReXmUa-WUxJk",
+          "googleMapsUri": "https://maps.google.com/?cid=11080144696311576953&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 연변 편. 백종원이 방문한 쑤안 할머니 식당🎊 이름 들어가면 다 맛집이라던데...👍 수제비를 얇게 썰어놓은 야들야들한 피에 볶은 돼지고기를 넣은 한국식 만두 먹방! | 스트리트푸드파이터2",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=gxeOvylKFq4"
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2/video_info.json
+++ b/.claude/workspace/youtube/PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2/video_info.json
@@ -1,0 +1,949 @@
+{
+  "type": "playlist",
+  "id": "PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2",
+  "title": "[#스트리트푸드파이터2] 정주행",
+  "description": "",
+  "url": "https://www.youtube.com/playlist?list=PLgbB1gJhmG7AbFF7O-kA2lQXYt1eRDFM2",
+  "channelName": "tvN Joy",
+  "channel": {
+    "id": "UC78PMQprrZTbU0IlMDsYZPw",
+    "title": "tvN Joy",
+    "handle": "@tvnjoy_official",
+    "url": "https://www.youtube.com/@tvnjoy_official",
+    "description": "NO.1 K콘텐츠 채널, 즐거움엔 tvN",
+    "thumbnailUrl": "https://yt3.ggpht.com/bpSGI1weZmTuMvzXz0k9vwRDugXHTCDPc9qlih808OH88OKUHxhK6uzBGxbjzzQ5czMav9zVOQ=s800-c-k-c0x00ffffff-no-rj"
+  },
+  "selectedVideos": [
+    {
+      "videoId": "vTG6PxKuOCQ",
+      "title": "푸드 무비의 선구자, 백종원과 제작진이 돌아왔다! 스트리트푸드파이터2 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 0,
+      "url": "https://www.youtube.com/watch?v=vTG6PxKuOCQ"
+    },
+    {
+      "videoId": "RVZo-Yd4r08",
+      "title": "이스탄불 케밥 : 소고기와 양고기를 알맞은 비율로 차곡차곡 쌓아 올린, 백종원 숨겨진 케밥 단골집 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 1,
+      "url": "https://www.youtube.com/watch?v=RVZo-Yd4r08"
+    },
+    {
+      "videoId": "sCctPC96hHo",
+      "title": "이스켄데르 케밥 : 버터의 축복. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 2,
+      "url": "https://www.youtube.com/watch?v=sCctPC96hHo"
+    },
+    {
+      "videoId": "CKzUY2xcSdQ",
+      "title": "타북 필라프 : 닭백숙 국물로 지은 밥 느낌?!?!?! 볶음밥으로 착각할 정도로 밥알이 따로놉니다. 먹어봐야 압니다. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 3,
+      "url": "https://www.youtube.com/watch?v=CKzUY2xcSdQ"
+    },
+    {
+      "videoId": "UwY5Pqn8r3Y",
+      "title": "아이란 : 터키의 국민 음료. 요구르트가 들어갔지만 밥 먹으면서 먹는 냉국 같은 존재?!?!!? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 4,
+      "url": "https://www.youtube.com/watch?v=UwY5Pqn8r3Y"
+    },
+    {
+      "videoId": "1mVFAbxMJeA",
+      "title": "시미트 : 전통 화덕 기이이이잎은 곳에서 굽는 갓 구운 빵의 미친 매력. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 5,
+      "url": "https://www.youtube.com/watch?v=1mVFAbxMJeA"
+    },
+    {
+      "videoId": "zftY4Fs5wuU",
+      "title": "카이막 : 터키에 왔다면 꼭 한번은 먹어봐야 할 천상의 맛 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 6,
+      "url": "https://www.youtube.com/watch?v=zftY4Fs5wuU"
+    },
+    {
+      "videoId": "DHmqyWPqpv4",
+      "title": "카이막 : 우유 10kg으로 만들어지는 양 400g? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 7,
+      "url": "https://www.youtube.com/watch?v=DHmqyWPqpv4"
+    },
+    {
+      "videoId": "66mJhvl4klk",
+      "title": "미디예 돌마 : 홍합과 양파의 만남. 그 자리에서 10개는 뚝딱!?!?! #스푸파2",
+      "channelName": "tvN Joy",
+      "position": 8,
+      "url": "https://www.youtube.com/watch?v=66mJhvl4klk"
+    },
+    {
+      "videoId": "hEkt2Q5EQa4",
+      "title": "돈두르마 카다이프 : 쫀~독한 아이스크림 돈두르마와 소면을 튀긴 것 같은 식감의 카다이프의 만남. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 9,
+      "url": "https://www.youtube.com/watch?v=hEkt2Q5EQa4"
+    },
+    {
+      "videoId": "6m6gRtQwgV0",
+      "title": "탄투니: 단순하게 고기를 잘게잘게 썰어가지고 거기에 소금을 뿌려서 지금 특별한 양념을 안 한 것 같은 맛이에요 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 10,
+      "url": "https://www.youtube.com/watch?v=6m6gRtQwgV0"
+    },
+    {
+      "videoId": "mJkgEzykeF8",
+      "title": "괴프테 : 완자나 떡갈비 느낌의 미트볼?!?!?? 근데 이제 식감이 쫄깃한. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 11,
+      "url": "https://www.youtube.com/watch?v=mJkgEzykeF8"
+    },
+    {
+      "videoId": "FSAG7CgaqCk",
+      "title": "치이 쾨프테 : 길거리에서 파는 게 찐?! 고기가 하나도 없지만 너무 맛있는 진정한 비건 푸드!!! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 12,
+      "url": "https://www.youtube.com/watch?v=FSAG7CgaqCk"
+    },
+    {
+      "videoId": "8apWu4OotMU",
+      "title": "이시켐베 초르바스 : 내장을 거의 다지듯이 썰어서 제대로 올라오는 쿰쿰한 이 맛. 소주 좀 가져다 주세요!!! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 13,
+      "url": "https://www.youtube.com/watch?v=8apWu4OotMU"
+    },
+    {
+      "videoId": "kve9C7k3kXc",
+      "title": "쏘이 쎄오 : 아주 단순한 750원 짜리 아침. 하지만 맛은 따봉 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 14,
+      "url": "https://www.youtube.com/watch?v=kve9C7k3kXc"
+    },
+    {
+      "videoId": "-7l5KUi_pZI",
+      "title": "분 더우 맘 똠 : 분짜의 상위버전 한 번 중독되면 잘못하다간 못끊어요 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 15,
+      "url": "https://www.youtube.com/watch?v=-7l5KUi_pZI"
+    },
+    {
+      "videoId": "mT8bVAmO3LY",
+      "title": "맘 똠 : 곰삭은 황석어젓 같은 냄새?!?!? 안에 튀김이 들어가 있어서 섞으면 카푸치노같이 거품이나요 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 16,
+      "url": "https://www.youtube.com/watch?v=mT8bVAmO3LY"
+    },
+    {
+      "videoId": "OEegrwmnppg",
+      "title": "닭구이 : 닭발을 바로 구우면 콜라겐이 살아있어요 그래서 엄청 쫀독쫀독해 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 17,
+      "url": "https://www.youtube.com/watch?v=OEegrwmnppg"
+    },
+    {
+      "videoId": "Tw_Ep-iEuo8",
+      "title": "반 미 느엉 : 기름하고 꿀하고 발라서 구운 반미와 닭구이의 조합은? 맛 없을 수 없음 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 18,
+      "url": "https://www.youtube.com/watch?v=Tw_Ep-iEuo8"
+    },
+    {
+      "videoId": "mKPfmrQvZgg",
+      "title": "꿔이 : 이 매력은 하노이에서만 느낄 수 있습니다 호치민가서 쌀국수 먹을 때 이거 안준다고 뭐라하면 안됩니다!!! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 19,
+      "url": "https://www.youtube.com/watch?v=mKPfmrQvZgg"
+    },
+    {
+      "videoId": "_TmYAydLkUE",
+      "title": "반 똠 : 찍어먹는 느억맘 소스가 진짜 꿀맛. 먹다보면 나도 모르게 마셔벌임ㅇㅇ.. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 20,
+      "url": "https://www.youtube.com/watch?v=_TmYAydLkUE"
+    },
+    {
+      "videoId": "imzbIa81KaI",
+      "title": "반 꾸온 꼬 년 : 하노이 사람들은 차암 행복하겠다 간식을 이렇게 먹으니 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 21,
+      "url": "https://www.youtube.com/watch?v=imzbIa81KaI"
+    },
+    {
+      "videoId": "7FvuOGJZUuE",
+      "title": "거위고기 : 씹다보면 껍데기에서 기름이 쭉쭉 나오니까 고소해요 닭똥집 맛?!?!?! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 22,
+      "url": "https://www.youtube.com/watch?v=7FvuOGJZUuE"
+    },
+    {
+      "videoId": "hbxTavxKk9U",
+      "title": "반 쯩 : 새콤달콤하게 절인 거랑 같이 먹으면 더 꿀맛 부렵죠? 750원으로 이런 아침을 먹을 수 있다는 게ㅎㅎ #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 23,
+      "url": "https://www.youtube.com/watch?v=hbxTavxKk9U"
+    },
+    {
+      "videoId": "wf5r-GUh0mU",
+      "title": "짜오 롱 : 죽입니다 죽인데 순대, 내장, 선지가 들어가 있어요 아, 한잔해야하는데… #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 24,
+      "url": "https://www.youtube.com/watch?v=wf5r-GUh0mU"
+    },
+    {
+      "videoId": "7PcfURXJlPc",
+      "title": "분 옥 : 새코옴한데 시워언한, 상상도 하지 못한 재료들의 조합!!! 그 맛은? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 25,
+      "url": "https://www.youtube.com/watch?v=7PcfURXJlPc"
+    },
+    {
+      "videoId": "kyP2aE5Js60",
+      "title": "반 미 & 솟 방 : 딱 보시면 스튜입니다. 단, 다른건 고수가 듬뿍 들어간… 바사삭 소리가 환.상. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 26,
+      "url": "https://www.youtube.com/watch?v=kyP2aE5Js60"
+    },
+    {
+      "videoId": "3dKte6rpx7s",
+      "title": "피자 : 백종원의 찐 뉴요커 따라잡기ㅋㅋㅋㅋ #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 27,
+      "url": "https://www.youtube.com/watch?v=3dKte6rpx7s"
+    },
+    {
+      "videoId": "A1IYJjST2js",
+      "title": "피자2 : 석탄 화덕에서 만든 피자에서만 느낄 수 있는 바삭바삭한 이 가게 피자🍕 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 28,
+      "url": "https://www.youtube.com/watch?v=A1IYJjST2js"
+    },
+    {
+      "videoId": "ba--mjuBUFw",
+      "title": "포터하우스 스테이크 : 온 비법이 다들어간 육즙. 이 집 스테이크는 맛이 계속 올라갑니다 예술이에요🥩 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 29,
+      "url": "https://www.youtube.com/watch?v=ba--mjuBUFw"
+    },
+    {
+      "videoId": "Zbj3YLVLoj4",
+      "title": "포터하우스 스테이크2 : 침 고이는 선홍빛 마블링 백선생님을 감동시킨 스테이크 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 30,
+      "url": "https://www.youtube.com/watch?v=Zbj3YLVLoj4"
+    },
+    {
+      "videoId": "5I2NFZ65jCc",
+      "title": "럼버잭 : 아침엔 살 걱정 안해도 되쥬~ #스트리트푸드파이터2 #뉴욕편",
+      "channelName": "tvN Joy",
+      "position": 31,
+      "url": "https://www.youtube.com/watch?v=5I2NFZ65jCc"
+    },
+    {
+      "videoId": "vdCn0I-_7QQ",
+      "title": "뉴욕 햄버거 : 햄버거는 먹으면서 다음 먹을 걸 찾을 수 있어유ㅎㅎ #스트리트푸드파이터2 #뉴욕편",
+      "channelName": "tvN Joy",
+      "position": 32,
+      "url": "https://www.youtube.com/watch?v=vdCn0I-_7QQ"
+    },
+    {
+      "videoId": "Cmc4BtUJ4Ck",
+      "title": "뉴욕 치즈케이크 : 그냥 치즈케이크가 아닙니다. 앞에 뉴욕이 붙어야해요 이쁘죠? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 33,
+      "url": "https://www.youtube.com/watch?v=Cmc4BtUJ4Ck"
+    },
+    {
+      "videoId": "XTtidLKK96k",
+      "title": "버펄로 윙 : 여기서 버팔로 윙 안 먹어 봤으면 먹어봤다 말하면 안 됨🍻 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 34,
+      "url": "https://www.youtube.com/watch?v=XTtidLKK96k"
+    },
+    {
+      "videoId": "eJTvH49yTSk",
+      "title": "베이글 : 보기만해도 마음이 므흣해지는 크림치즈 + 베이글 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 35,
+      "url": "https://www.youtube.com/watch?v=eJTvH49yTSk"
+    },
+    {
+      "videoId": "BjMizteUE2A",
+      "title": "콘 브레드 : 꽁짠데 갓 만들어서 따끈하고 맛을 보자하는 빵. 하지만 이제 칼로리는 보장 못 하는. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 36,
+      "url": "https://www.youtube.com/watch?v=BjMizteUE2A"
+    },
+    {
+      "videoId": "x60mZ-nIODw",
+      "title": "프라이드치킨 : 닭다리, 닭날개가 먹다 남은 부위라고?!?! 아프리카계 미국인들의 소울푸드 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 37,
+      "url": "https://www.youtube.com/watch?v=x60mZ-nIODw"
+    },
+    {
+      "videoId": "p0T5WnrKEYA",
+      "title": "굴 : 미국 동부, 전혀 안비리고 달달한 굴이 있다??!?!? #스트리트푸드파이터2 #뉴욕편",
+      "channelName": "tvN Joy",
+      "position": 38,
+      "url": "https://www.youtube.com/watch?v=p0T5WnrKEYA"
+    },
+    {
+      "videoId": "s8QeRTIEK_k",
+      "title": "스쯔모 : 맥반석 돌로 굽는 중국식 와플 느낌? 고소한 간식으로 딱!! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 39,
+      "url": "https://www.youtube.com/watch?v=s8QeRTIEK_k"
+    },
+    {
+      "videoId": "BbxgWO02X2I",
+      "title": "유차마화 : 자극적이진 않은데, 무의식중에 계속 먹게 되는 맛?! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 40,
+      "url": "https://www.youtube.com/watch?v=BbxgWO02X2I"
+    },
+    {
+      "videoId": "0iAaHNN9vtw",
+      "title": "유포면 : 들어가는게 별거 없는데 너~~무 맛있는 이 요리🥢 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 41,
+      "url": "https://www.youtube.com/watch?v=0iAaHNN9vtw"
+    },
+    {
+      "videoId": "2zSwxWEQV58",
+      "title": "서봉주 : 비교적 저렴하지만 시안의 명주라고 불리는 술🍶 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 42,
+      "url": "https://www.youtube.com/watch?v=2zSwxWEQV58"
+    },
+    {
+      "videoId": "MiLdS5ikyq8",
+      "title": "후루터우 샤오차오 : 한국의 대창볶음이 있다면 중국엔 이 요리가 있다!! 서봉주랑 먹으면~크👍 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 43,
+      "url": "https://www.youtube.com/watch?v=MiLdS5ikyq8"
+    },
+    {
+      "videoId": "U-XPZHLjJWw",
+      "title": "후라탕 : 요즘 유행하는 마라와 후추의 조합?!? 완자까지 들어있으니 JMT!! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 44,
+      "url": "https://www.youtube.com/watch?v=U-XPZHLjJWw"
+    },
+    {
+      "videoId": "VkfKGpRDCcY",
+      "title": "쩡가오 : 이게 다~ 대추입니다 대추 향이 풍부한 약밥의 느낌?!?!? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 45,
+      "url": "https://www.youtube.com/watch?v=VkfKGpRDCcY"
+    },
+    {
+      "videoId": "2YLjkhY5NZg",
+      "title": "샤오쯔몐 : 얇은 국수 면에 싸악 배어 있는 새~코옴한 국물 중독되는 그 맛🥢 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 46,
+      "url": "https://www.youtube.com/watch?v=2YLjkhY5NZg"
+    },
+    {
+      "videoId": "tjwAXEpLw1Y",
+      "title": "삼진세트 : 매콤한 떡볶이 소스에 튀김을 찍어 먹으면 조화가 되듯 완벽한 조화로우움 #스트리트푸드파잍이터터2",
+      "channelName": "tvN Joy",
+      "position": 47,
+      "url": "https://www.youtube.com/watch?v=tjwAXEpLw1Y"
+    },
+    {
+      "videoId": "rC0_gbd8eu8",
+      "title": "양 내장탕 : 중국 왔으면 이건 제대로 한 번 먹어봐야죠 쿰쿰한 맛을 좋아하는 분 무조건 좋아합니다!! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 48,
+      "url": "https://www.youtube.com/watch?v=rC0_gbd8eu8"
+    },
+    {
+      "videoId": "INcgtsw-lYA",
+      "title": "펀정러우 : 갈비찜을 빵 안에 넣어 먹는 맛?!? 하얀 소 내장 기름을 꼭 넣어서 드세유 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 49,
+      "url": "https://www.youtube.com/watch?v=INcgtsw-lYA"
+    },
+    {
+      "videoId": "v7vKA5vT8nY",
+      "title": "따꼬 : 따꼬는 어떤 음식을 싸 먹는 방법을 말하는 겁니다 몰랐쥬? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 50,
+      "url": "https://www.youtube.com/watch?v=v7vKA5vT8nY"
+    },
+    {
+      "videoId": "ABkWkgC9_WA",
+      "title": "살사 소스 :  따꼬 가게마다 비법이 들어간 특별 소스를 만듭니다 그만큼 중요하다는 거죠 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 51,
+      "url": "https://www.youtube.com/watch?v=ABkWkgC9_WA"
+    },
+    {
+      "videoId": "CScfmK4RhoE",
+      "title": "바르바꼬아 : 어? 맛있다. 양고기를 깊은 구덩이에서 오래 구워요 그래서 되게 부드러워요🍖 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 52,
+      "url": "https://www.youtube.com/watch?v=CScfmK4RhoE"
+    },
+    {
+      "videoId": "mqwtd4QEm6c",
+      "title": "석회수 : 옥수수 속의 섬유질을 소화 가능하게 만들어주는 이 물의 정체 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 53,
+      "url": "https://www.youtube.com/watch?v=mqwtd4QEm6c"
+    },
+    {
+      "videoId": "lMZWUGLxo30",
+      "title": "반데라 : 시고 짭짜름하다?! 멕시코의 밤을 즐겁게 만드는 방법🥃 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 54,
+      "url": "https://www.youtube.com/watch?v=lMZWUGLxo30"
+    },
+    {
+      "videoId": "kfjlQsTRR2Q",
+      "title": "판시따 : 멕시코에서 해장국을 먹고 싶다면? 환-상 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 55,
+      "url": "https://www.youtube.com/watch?v=kfjlQsTRR2Q"
+    },
+    {
+      "videoId": "4i_QSyhZA90",
+      "title": "판시따 : 족발, 천엽, 양고기 등 소 내장을 끓인 스프?! 또띠아에 싸 먹으면 바로 해장 뚝딱 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 56,
+      "url": "https://www.youtube.com/watch?v=4i_QSyhZA90"
+    },
+    {
+      "videoId": "3KowjCYp4hU",
+      "title": "케사디야 : 돼기고기 튀김 + 돼지껍데기 튀김 + 치즈 무적의 삼위일체👍 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 57,
+      "url": "https://www.youtube.com/watch?v=3KowjCYp4hU"
+    },
+    {
+      "videoId": "Ql3oIX1BdCk",
+      "title": "엘로떼 : 옥수수 싫어하는 사람람의 입맛도 영원히 바꿔줄 마약 옥수수 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 58,
+      "url": "https://www.youtube.com/watch?v=Ql3oIX1BdCk"
+    },
+    {
+      "videoId": "vLlhtvdwsQg",
+      "title": "몰레 콘 포요 : 카레에 초콜릿을 넣어봤는가 초콜릿으로 만든 천국의 맛 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 59,
+      "url": "https://www.youtube.com/watch?v=vLlhtvdwsQg"
+    },
+    {
+      "videoId": "Vc7kC6taeK0",
+      "title": "따말&아똘레 : 옥수수 반죽에 닭고기가 쏘옥?! 2000원의 행복 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 60,
+      "url": "https://www.youtube.com/watch?v=Vc7kC6taeK0"
+    },
+    {
+      "videoId": "lLskv19Vfoc",
+      "title": "칠라킬레스 : 대한민국 어디에서도 찾을 수 없는 맛! 촤르륵 흘러 내리는 노른자를 느껴봐 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 61,
+      "url": "https://www.youtube.com/watch?v=lLskv19Vfoc"
+    },
+    {
+      "videoId": "sNt2MLnuiNQ",
+      "title": "포솔레 : 한국 국밥 vs 멕시코 국밥 과연 백종원의 선택은?! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 62,
+      "url": "https://www.youtube.com/watch?v=sNt2MLnuiNQ"
+    },
+    {
+      "videoId": "kQ_hBSIlc5Y",
+      "title": "또스따다스+크레마 : 국밥에 또띠야를 넣어서 먹는다면?! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 63,
+      "url": "https://www.youtube.com/watch?v=kQ_hBSIlc5Y"
+    },
+    {
+      "videoId": "LRhiA0BX4rw",
+      "title": "러우저우&홍사오러우 : 백쌤이 이상한 신음소리를 내기 시작했습니다. #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 64,
+      "url": "https://www.youtube.com/watch?v=LRhiA0BX4rw"
+    },
+    {
+      "videoId": "8CyOd9Rr7lY",
+      "title": "족발국수 : 국수에 삶은 족발이 풍덩!! 이거 먹으면 합격한다?! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 65,
+      "url": "https://www.youtube.com/watch?v=8CyOd9Rr7lY"
+    },
+    {
+      "videoId": "LPGZq4MIg0k",
+      "title": "깨 끙 : 닭고기 없는 닭고기 말이 튀김!? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 66,
+      "url": "https://www.youtube.com/watch?v=LPGZq4MIg0k"
+    },
+    {
+      "videoId": "W6ZirHCGDec",
+      "title": "전주나이차 : 동글동글 검은색 진주들이 잔뜩 들어간 대만 대표 음료수🥤 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 67,
+      "url": "https://www.youtube.com/watch?v=W6ZirHCGDec"
+    },
+    {
+      "videoId": "5GcK2-mbkqQ",
+      "title": "굴전 : 이 비주얼은 못 참지. 우리 다이어트는,, 잠시 쉬기로 해요. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 68,
+      "url": "https://www.youtube.com/watch?v=5GcK2-mbkqQ"
+    },
+    {
+      "videoId": "LXSorJ47htc",
+      "title": "루 러우 판 : 이른 아침 졸린 눈이 번쩍?!👀 떠지게 만드는 맛!! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 69,
+      "url": "https://www.youtube.com/watch?v=LXSorJ47htc"
+    },
+    {
+      "videoId": "bwrnQCeuvv8",
+      "title": "타이완식 소시지 : 고기와 비계가 씹히는 소시지에 마늘을 같이 먹으면? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 70,
+      "url": "https://www.youtube.com/watch?v=bwrnQCeuvv8"
+    },
+    {
+      "videoId": "EwYcFwk-VFw",
+      "title": "대창굴국수 : 굴 있쥬 돼지 대창 있쥬 안 어울릴 것 같쥬? 무지하게 잘 어울려유☺️ #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 71,
+      "url": "https://www.youtube.com/watch?v=EwYcFwk-VFw"
+    },
+    {
+      "videoId": "S1Zdt8ya7Ec",
+      "title": "우육면 : 고기가 실종되었습니다. 입 안에서. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 72,
+      "url": "https://www.youtube.com/watch?v=S1Zdt8ya7Ec"
+    },
+    {
+      "videoId": "hCF9rgFmymA",
+      "title": "스무위 덮밥 : 이게 장어야 푸딩이야? ㅇㅅㅇ 입 안에서 장어가 살살 녹아유 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 73,
+      "url": "https://www.youtube.com/watch?v=hCF9rgFmymA"
+    },
+    {
+      "videoId": "1913r9IXCiw",
+      "title": "쓰선탕 : 더위 먹은 사람들도 이것만 먹으면 벌떡! 일어난다는 이 음식! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 74,
+      "url": "https://www.youtube.com/watch?v=1913r9IXCiw"
+    },
+    {
+      "videoId": "06MUNiVH6DM",
+      "title": "펑리수 : 대만의 대표 간식 쫀독한 파인애플 필링이 가~득차서 새콤달콤 맛있다! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 75,
+      "url": "https://www.youtube.com/watch?v=06MUNiVH6DM"
+    },
+    {
+      "videoId": "469R33ZNL_c",
+      "title": "브리오쉬에 젤라토 : 빵과 젤라또? 이건 근본이다. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 76,
+      "url": "https://www.youtube.com/watch?v=469R33ZNL_c"
+    },
+    {
+      "videoId": "YBHxVbYQh8A",
+      "title": "빠넬레&까질리 : 해변가에서 병맥 하나 들고 따악 앉아서 먹으면 이게 행복..🍻 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 77,
+      "url": "https://www.youtube.com/watch?v=YBHxVbYQh8A"
+    },
+    {
+      "videoId": "BpHUAnZftxs",
+      "title": "카포나타 : 사과가 없어요. 근데 미친 사과라 불립니다. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 78,
+      "url": "https://www.youtube.com/watch?v=BpHUAnZftxs"
+    },
+    {
+      "videoId": "iCwiJQF_ul8",
+      "title": "알라 노르마 : 고기 빠진 파스타. 노맛? ㄴㄴ 존맛탱 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 79,
+      "url": "https://www.youtube.com/watch?v=iCwiJQF_ul8"
+    },
+    {
+      "videoId": "Kh8iWZj0irs",
+      "title": "스티키올라 : 한국 곱창 맛. 한 입 먹는 순간 소주가 술술술 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 80,
+      "url": "https://www.youtube.com/watch?v=Kh8iWZj0irs"
+    },
+    {
+      "videoId": "TM6H2OeRLUs",
+      "title": "아란치니 : 맛있는 주먹밥을 기름에 풍덩? 말해 뭐해♥ #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 81,
+      "url": "https://www.youtube.com/watch?v=TM6H2OeRLUs"
+    },
+    {
+      "videoId": "fkYwpbJtOtw",
+      "title": "파니 카 메우사 : 내장 좋아하는 사람 모여라🙋🏻‍♀️ #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 82,
+      "url": "https://www.youtube.com/watch?v=fkYwpbJtOtw"
+    },
+    {
+      "videoId": "wdpfXQXS2Kg",
+      "title": "탈리에레 : 소금에 절인 생 햄과 와인의 환상적 콜라보🍷 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 83,
+      "url": "https://www.youtube.com/watch?v=wdpfXQXS2Kg"
+    },
+    {
+      "videoId": "q39FCOMEK2Y",
+      "title": "에트나 로쏘 : 에트나산 포도로 만든 와인이 가져다주는 천상의 맛(황홀) #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 84,
+      "url": "https://www.youtube.com/watch?v=q39FCOMEK2Y"
+    },
+    {
+      "videoId": "4DKJYHkjvk8",
+      "title": "쿠스쿠스 : 이게 무슨 파스타야? 먹어 보면 압니다. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 85,
+      "url": "https://www.youtube.com/watch?v=4DKJYHkjvk8"
+    },
+    {
+      "videoId": "z6U2KvCWBbI",
+      "title": "사르데 아 베카피코 : 생선과 완자의 상상 불가능한 만남 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 86,
+      "url": "https://www.youtube.com/watch?v=z6U2KvCWBbI"
+    },
+    {
+      "videoId": "jLrBp1jOD2M",
+      "title": "스핀치오네 : 스펀지 피자?! 이탈리아의 엔초비가 들어간 독특한 맛과 식감 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 87,
+      "url": "https://www.youtube.com/watch?v=jLrBp1jOD2M"
+    },
+    {
+      "videoId": "RXipqsF1-2o",
+      "title": "요우먼따샤 : 가재를 둘러싼 마한 맛의 강렬한 양념 은은~한 고추기름의 매콤함까지 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 88,
+      "url": "https://www.youtube.com/watch?v=RXipqsF1-2o"
+    },
+    {
+      "videoId": "4Z3JHGYSALw",
+      "title": "러깐몐 : 중국 10대 면요리🍜 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 89,
+      "url": "https://www.youtube.com/watch?v=4Z3JHGYSALw"
+    },
+    {
+      "videoId": "MwjSh0SlMKg",
+      "title": "몐양싼정: 3단 찜 요리 이게 고기야? 솜사탕이야? 각양각색의 요리에 신난 백종원 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 90,
+      "url": "https://www.youtube.com/watch?v=MwjSh0SlMKg"
+    },
+    {
+      "videoId": "Y6py3x0x2t8",
+      "title": "어우펀 : 사과 맛이 나는데 단팥에 대추가 들어가 있다? 묘한 식감의 요리 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 91,
+      "url": "https://www.youtube.com/watch?v=Y6py3x0x2t8"
+    },
+    {
+      "videoId": "dZr9FPLIfRU",
+      "title": "연근 갈비탕 : 뜨-끈한 갈비탕에 연근이 퐁-당🍲 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 92,
+      "url": "https://www.youtube.com/watch?v=dZr9FPLIfRU"
+    },
+    {
+      "videoId": "t3G6ar27DiA",
+      "title": "몐워 & 눠미지 : 백쌤이 분식집에 알려줬던 쌀도넛의 원조 애피타이저로 먹으면 딱! #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 93,
+      "url": "https://www.youtube.com/watch?v=t3G6ar27DiA"
+    },
+    {
+      "videoId": "C0IsGA_MvoI",
+      "title": "후탕펀 & 요우티아오 : 생선 국물 베이스로 한 걸-쭉한 쌀국수! 후추가 후추후추 들어가 하나도 안비림. #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 94,
+      "url": "https://www.youtube.com/watch?v=C0IsGA_MvoI"
+    },
+    {
+      "videoId": "HQi0peG8QW4",
+      "title": "위터우파오판 : 백종원의 합격을 받은 생선 조림 고소~합니다😋 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 95,
+      "url": "https://www.youtube.com/watch?v=HQi0peG8QW4"
+    },
+    {
+      "videoId": "FT_X7hvwSTc",
+      "title": "자자 : 재료를 직접 고르고 소스도 직접! 재료가 살아 있는 튀김 요리😛 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 96,
+      "url": "https://www.youtube.com/watch?v=FT_X7hvwSTc"
+    },
+    {
+      "videoId": "-xXkQyEI-BQ",
+      "title": "고구마 몐워 : 고구마 + 기름 = 끝 아는 맛의 무서움🍠 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 97,
+      "url": "https://www.youtube.com/watch?v=-xXkQyEI-BQ"
+    },
+    {
+      "videoId": "J2ag1Qm62Bk",
+      "title": "뉴자훠궈 : 흰 쌀밥이나 면추가를 부르는 미친 국물의 마라맛 내장 요리 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 98,
+      "url": "https://www.youtube.com/watch?v=J2ag1Qm62Bk"
+    },
+    {
+      "videoId": "yEuOEYLSJVk",
+      "title": "싼셴또우피 : 우한의 대표 아침 겉은 바삭한데 속은 쫀득한 찹쌀이 거기다 각종 재료들이?!?! 환.상 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 99,
+      "url": "https://www.youtube.com/watch?v=yEuOEYLSJVk"
+    },
+    {
+      "videoId": "HL5y5q1hZV4",
+      "title": "요우빙빠오샤오마이 : 탄수화물 + 탄수화물 + 탄수화물 = 환상🍴 #스트리트푸드파이터2 #우한편",
+      "channelName": "tvN Joy",
+      "position": 100,
+      "url": "https://www.youtube.com/watch?v=HL5y5q1hZV4"
+    },
+    {
+      "videoId": "gWeIaVY0xvw",
+      "title": "나시 르막 : 흰 쌀밥에 삶은 달걀 그리고 삼발 소스. 게임 끝입니다. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 101,
+      "url": "https://www.youtube.com/watch?v=gWeIaVY0xvw"
+    },
+    {
+      "videoId": "9ExZ0jOfv4g",
+      "title": "뿔룻 타이타이 : 코코넛 맛 나는 짭조름한 찹쌀밥이에요 근데 여기에 이제 카야 잼을 더하면? #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 102,
+      "url": "https://www.youtube.com/watch?v=9ExZ0jOfv4g"
+    },
+    {
+      "videoId": "toO-7luxcGk",
+      "title": "바꾸떼 : 기운이 불뚝불뚝 솟는 찌인한 고기 국물 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 103,
+      "url": "https://www.youtube.com/watch?v=toO-7luxcGk"
+    },
+    {
+      "videoId": "CpCz2NB8Zbg",
+      "title": "록록 : 직접 꼬치를 골라서 데쳐 먹는데 매콤한 소스가 조화롭게 챱챱~🍢 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 104,
+      "url": "https://www.youtube.com/watch?v=CpCz2NB8Zbg"
+    },
+    {
+      "videoId": "F4Rx68S4tjM",
+      "title": "아팜 발릭 : 코코넛향이 확 올라오는 팬케이크🥞 + 바나나🍌 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 105,
+      "url": "https://www.youtube.com/watch?v=F4Rx68S4tjM"
+    },
+    {
+      "videoId": "1cJieTHfAx0",
+      "title": "로작 : 신박한 오징어 샐러드🥗 역시 미식의 천국, 길거리 음식의 천국 인정 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 106,
+      "url": "https://www.youtube.com/watch?v=1cJieTHfAx0"
+    },
+    {
+      "videoId": "eV7KoQnTLuo",
+      "title": "로띠 & 떼 따릭 : 기름이나 버터, 마가린으로 반죽해서 숙성해서 페스츄리처럼 찢어집니다 커리에 찍어 먹으면 끝. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 107,
+      "url": "https://www.youtube.com/watch?v=eV7KoQnTLuo"
+    },
+    {
+      "videoId": "ej6KEpmngWg",
+      "title": "아쌈 락사 : 낯선 재료로 맛보는 익숙한 맛😛 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 108,
+      "url": "https://www.youtube.com/watch?v=ej6KEpmngWg"
+    },
+    {
+      "videoId": "2ibGprMylzs",
+      "title": "첸돌 : 향과 식감을 동시에 즐겨야하는 페낭의 빙수👍 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 109,
+      "url": "https://www.youtube.com/watch?v=2ibGprMylzs"
+    },
+    {
+      "videoId": "Najxa4O5QKg",
+      "title": "나시 칸다르 : 이것저것 반찬 많이 놓고 먹는 밥보다 괜히 하나에 집중하는 밥이 더 좋을 때가 있죠 그게 이거입니다 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 110,
+      "url": "https://www.youtube.com/watch?v=Najxa4O5QKg"
+    },
+    {
+      "videoId": "5l-VCKO4Fmg",
+      "title": "차 퀘이 칵 : 돼지고기 기름 + 간장으로 만든 고소~한 팟타이 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 111,
+      "url": "https://www.youtube.com/watch?v=5l-VCKO4Fmg"
+    },
+    {
+      "videoId": "oP9n78Z8MZ4",
+      "title": "카야 토스트 : 고소함에. 고소함을 더하다. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 112,
+      "url": "https://www.youtube.com/watch?v=oP9n78Z8MZ4"
+    },
+    {
+      "videoId": "dc-zbt6mAH8",
+      "title": "초두부 : 물을 덜어내면서 먹어야할 정도로 물이 많아 수두부라고도 불리는 촉촉한 두부😋 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 113,
+      "url": "https://www.youtube.com/watch?v=dc-zbt6mAH8"
+    },
+    {
+      "videoId": "VFbsnMLTvto",
+      "title": "연길냉면 : 굉장히 자극적이고 새콤달콤해서 오이냉면 같은 맛입니다. 온 가게가 다 이래요 ㅇㅅㅇ #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 114,
+      "url": "https://www.youtube.com/watch?v=VFbsnMLTvto"
+    },
+    {
+      "videoId": "9X1EDyXUJ0s",
+      "title": "꿔바로우 : 냉면에 넣어 먹는 꿔바로우. 그 맛과 식감은??😗 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 115,
+      "url": "https://www.youtube.com/watch?v=9X1EDyXUJ0s"
+    },
+    {
+      "videoId": "vFYcBu-DGpU",
+      "title": "연변 양꼬치 : 살코기 다음 기름 다음 살코기 다음 기름 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 116,
+      "url": "https://www.youtube.com/watch?v=vFYcBu-DGpU"
+    },
+    {
+      "videoId": "ihOMzVl_oYM",
+      "title": "피주궈 : 양꼬치가 남았다면? 맥주와 함께 부어주세요🍺 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 117,
+      "url": "https://www.youtube.com/watch?v=ihOMzVl_oYM"
+    },
+    {
+      "videoId": "ke0gEJ3_uqU",
+      "title": "찰떡 : 연변의 이른 아침 들려오는 방아 찧는 소리..#스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 118,
+      "url": "https://www.youtube.com/watch?v=ke0gEJ3_uqU"
+    },
+    {
+      "videoId": "d8hTyhkvjgQ",
+      "title": "소탕 : 소즙과 부추꽃장만 있다면 어디든 갈 수 있어.. #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 119,
+      "url": "https://www.youtube.com/watch?v=d8hTyhkvjgQ"
+    },
+    {
+      "videoId": "gRRTQsijx3c",
+      "title": "찹쌀 순대 : 백종원 픽, 여태까지 찹쌀 들어간 순대 먹어본 것 중에서는 거의 일등 같은데요?🥇#스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 120,
+      "url": "https://www.youtube.com/watch?v=gRRTQsijx3c"
+    },
+    {
+      "videoId": "CdGDd2yxWxg",
+      "title": "짝태구이 : 백종원 픽 짝태구이 소스 '라면수프 + 맥주(?)' #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 121,
+      "url": "https://www.youtube.com/watch?v=CdGDd2yxWxg"
+    },
+    {
+      "videoId": "r1wYibhsegg",
+      "title": "짝태 볶음 : 연변에 오면 꼭 먹어야해유. 맵습니다. 그치만 JMT😋 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 122,
+      "url": "https://www.youtube.com/watch?v=r1wYibhsegg"
+    },
+    {
+      "videoId": "6drvL2-Iuk0",
+      "title": "장국 : 100% 성공 조합. 된장찌개 + 돼지고기 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 123,
+      "url": "https://www.youtube.com/watch?v=6drvL2-Iuk0"
+    },
+    {
+      "videoId": "ucVT3KdQxRc",
+      "title": "옥수수면 : 백종원이 젓가락 쪽쪽 빨게 만든 그 음식!!🥢 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 124,
+      "url": "https://www.youtube.com/watch?v=ucVT3KdQxRc"
+    },
+    {
+      "videoId": "U-6jbotyWw4",
+      "title": "가지 돌솥밥 : 가지밥은 볶음밥을 눌려 먹는 것처럼 나중에 누룽지로 먹는 게 맛있습니다👍 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 125,
+      "url": "https://www.youtube.com/watch?v=U-6jbotyWw4"
+    },
+    {
+      "videoId": "Yt4CzyLBOxw",
+      "title": "차이 : 백종원이 알려주는 차이 마시는 법🍵 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 126,
+      "url": "https://www.youtube.com/watch?v=Yt4CzyLBOxw"
+    },
+    {
+      "videoId": "Mo7XERLbhe0",
+      "title": "만트 : 만두 위에 요구르트(?), 고추기름을 올려요 그리고 고춧가루 너무 신기하죠😗 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 127,
+      "url": "https://www.youtube.com/watch?v=Mo7XERLbhe0"
+    },
+    {
+      "videoId": "R9oN2nNcs5o",
+      "title": "랍스타 롤 : 버터에 구운 식빵에 랍스타를 싸악- 고급진 간식 완-성 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 128,
+      "url": "https://www.youtube.com/watch?v=R9oN2nNcs5o"
+    },
+    {
+      "videoId": "sT9wwi5g2Ww",
+      "title": "'바구니'따꼬 : 길거리에 서서 먹어줘야 또 맛있는거 먼지알지?😘 #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 129,
+      "url": "https://www.youtube.com/watch?v=sT9wwi5g2Ww"
+    },
+    {
+      "videoId": "azwXa-4QqnA",
+      "title": "칠레 엔 노가다 : 멕시코에서도 딱 4개월만 먹을 수 있다는 이것! #스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 130,
+      "url": "https://www.youtube.com/watch?v=azwXa-4QqnA"
+    },
+    {
+      "videoId": "l-onc_c2lrM",
+      "title": "이 조합이 단돈 2,000원?!! 백종원도 놀라버린 가격ㄷㄷ🔥 베트남식 고급스러운 소고기 스튜에 바삭하고 고소한 반미를 찍어 먹으면 끝이쥬-! | 스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 131,
+      "url": "https://www.youtube.com/watch?v=l-onc_c2lrM"
+    },
+    {
+      "videoId": "gxeOvylKFq4",
+      "title": "백종원이 방문한 쑤안 할머니 식당🎊 이름 들어가면 다 맛집이라던데...👍 수제비를 얇게 썰어놓은 야들야들한 피에 볶은 돼지고기를 넣은 한국식 만두 먹방! | 스트리트푸드파이터2",
+      "channelName": "tvN Joy",
+      "position": 132,
+      "url": "https://www.youtube.com/watch?v=gxeOvylKFq4"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c/_create_manifest.json
+++ b/.claude/workspace/youtube/PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c/_create_manifest.json
@@ -1,0 +1,436 @@
+{
+  "sunreiId": "SR01kyhxp2gwq2nfkqw9nt0na55y",
+  "sourceId": "SRC01kyhxp2ezjzark6h2yjy5f8dt",
+  "spots": [
+    {
+      "spotId": "SS01kyhxp2hz8czbj3jqm404rert",
+      "videoId": "FI_n_xthvss",
+      "videoTitle": "백종원의 세계 맛집 도장 깨기 시작!"
+    },
+    {
+      "spotId": "SS01kyhxp2j0zhzjm3c0b1s0d84d",
+      "videoId": "tIN8hbUhT9s",
+      "videoTitle": "가문 대대로 전해져 내려온 소스와 면의 절묘한 조화"
+    },
+    {
+      "spotId": "SS01kyhxp2gywbsqwgq7zsfp0w3w",
+      "videoId": "DNN6T7t8zWk",
+      "videoTitle": "백종원이 비행기 타고 내리자마자 온 곳"
+    },
+    {
+      "spotId": "SS01kyhxp2gz5grea5t0mveq5p9k",
+      "videoId": "0jwYJGoE19k",
+      "videoTitle": "미슐랭 빵집보다 맛있는 대륙의 페이스트리"
+    },
+    {
+      "spotId": "SS01kyhxp2h0jfjw83qm355p0nsp",
+      "videoId": "5lxGFcDO5og",
+      "videoTitle": "사천 음식의 대표 주자 마파두부, 청두에서 맛보는 원조의 손맛"
+    },
+    {
+      "spotId": "SS01kyhxp2h13vx2d7z3cnfd8psm",
+      "videoId": "WrgtkN1DGJY",
+      "videoTitle": "백종원도 먹다 눈물 흘린 청두의 소울 푸드"
+    },
+    {
+      "spotId": "SS01kyhxp2h2zfhkf4xfja0r8w21",
+      "videoId": "CKu3hTDRfls",
+      "videoTitle": "사천음식의 지휘자, 홍유가 식탁에 오르기까지"
+    },
+    {
+      "spotId": "SS01kyhxp2h36t10xky9v9myfzm1",
+      "videoId": "1zytti7f5X8",
+      "videoTitle": "중국 여행에서 뭘 시켜야할 지 모르겠다면? 사천음식의 대표주자들 '궁보우지딩 & 위샹체쯔'"
+    },
+    {
+      "spotId": "SS01kyhxp2h4wrvwxcsaszts6fn5",
+      "videoId": "d0qsvi13EG0",
+      "videoTitle": "백종원을 감회에 젖게 만든 한 찻집의 묘한 분위기"
+    },
+    {
+      "spotId": "SS01kyhxp2h557pjsvxv8y2neqqe",
+      "videoId": "YiLQauZLHZM",
+      "videoTitle": "벌써부터 액땜을? 스푸파 첫 화만에 백종원에게 일어난 봉변"
+    },
+    {
+      "spotId": "SS01kyhxp2h6b5b539fecy5hs9tq",
+      "videoId": "Z4k_Faz40C8",
+      "videoTitle": "마라촨vs훠궈vs바지락 사천 요리 중 백종원 픽 최고의 술안주는?"
+    },
+    {
+      "spotId": "SS01kyhxp2h6a92e8tsmk5q9hgzx",
+      "videoId": "OI0GahD301s",
+      "videoTitle": "한 번 빠지면 헤어나올 수 없는 이 세상 조합, 토마토라면 '퐌케민' + 연유토스트"
+    },
+    {
+      "spotId": "SS01kyhxp2h7xj4jy32wsz0f6jtz",
+      "videoId": "bX2QWpbNTuc",
+      "videoTitle": "맥주엔 '볶은 게' 제격, 홍콩 제일의 맥주 안주 '베이퐁통 게 볶음'"
+    },
+    {
+      "spotId": "SS01kyhxp2h8pwj4pqwc6h309369",
+      "videoId": "KDoZTDS5iKk",
+      "videoTitle": "사장님 그곳은 괜찮으신가...? 보고 나면 못 걸어다닐 것 같은 완탕면 반죽"
+    },
+    {
+      "spotId": "SS01kyhxp2h98zxg8e11ptx13dzt",
+      "videoId": "OZNhcgeBpMY",
+      "videoTitle": "익숙한 맛에서 느껴지는 독특한 식감! 새우와 돼지고기의 절묘한 조화 '완탕면'"
+    },
+    {
+      "spotId": "SS01kyhxp2haag8sy6z1yeng3ft8",
+      "videoId": "x2LdT_Pf9P0",
+      "videoTitle": "백종원도 방송 중에 맥주 시키게 한 홍콩식 굴전"
+    },
+    {
+      "spotId": "SS01kyhxp2hbaqrtejv8q23j16bc",
+      "videoId": "fMbfv4mveZo",
+      "videoTitle": "백종원마저 벽을 느꼈다... '완벽' 그 자체, 홍콩식 뽀짜이판"
+    },
+    {
+      "spotId": "SS01kyhxp2hcrcc356k3mtg5457c",
+      "videoId": "AV99LPgd8BY",
+      "videoTitle": "이것이 홍콩의 피X츄 돈까스? 홍콩의 소울 푸드 '카레위단'"
+    },
+    {
+      "spotId": "SS01kyhxp2hddxmjc389j9w6k19h",
+      "videoId": "hajKoKvz6FE",
+      "videoTitle": "한국 간 요리와는 차원이 다른 식감? 백종원이 홍콩에 오면 꼭 먹는다는 돼지 간 요리"
+    },
+    {
+      "spotId": "SS01kyhxp2he4ngmtfh3br53470f",
+      "videoId": "_9PQErHct4s",
+      "videoTitle": "홍콩의 컵밥? 인기만점 딤섬들과 간장의 조화 '종판'"
+    },
+    {
+      "spotId": "SS01kyhxp2hetwhtc02bsj3csqe4",
+      "videoId": "ErW1_uGHJjk",
+      "videoTitle": "오로지 우유와 생강으로만 만든 홍콩의 보배, 생강 우유 푸딩"
+    },
+    {
+      "spotId": "SS01kyhxp2hfwwsfvx0caktd7nxw",
+      "videoId": "DZXY2nFzN0w",
+      "videoTitle": "배 위에서 즐기는 태국식 현지 쌀국수"
+    },
+    {
+      "spotId": "SS01kyhxp2hg08f4142s1dddre5a",
+      "videoId": "tFh6qarA0ro",
+      "videoTitle": "한국사람은 무한대로 먹을 수 있는 돼지고기 꼬치구이"
+    },
+    {
+      "spotId": "SS01kyhxp2hhfvs06grtn8r0g2y9",
+      "videoId": "1zOWrpi4cgY",
+      "videoTitle": "튀긴 면과 계란, 고명들의 환상의 호흡! 태국에서 반드시 먹어야 할 '랏나'"
+    },
+    {
+      "spotId": "SS01kyhxp2hjf2mj3xkzw8gks5jp",
+      "videoId": "bQqH1BLd3Rk",
+      "videoTitle": "전세계에서 줄 서먹는 삼겹살튀김 + 쌀국수집"
+    },
+    {
+      "spotId": "SS01kyhxp2hk513cpr69w9ctkq5y",
+      "videoId": "O0Sst8_8LPM",
+      "videoTitle": "백종원이 호텔 조식도 거르고 찾아간 태국 현지 아침 식사! 태국식 덮밥 '카오 랏 깽'"
+    },
+    {
+      "spotId": "SS01kyhxp2hmncn0a8c532w33hqd",
+      "videoId": "JPtAUA9O7xo",
+      "videoTitle": "태국 현지인들도 인정한 소갈비국수 맛집, 백종원이 알려주는 200% 즐기는 방법"
+    },
+    {
+      "spotId": "SS01kyhxp2hn9dpam2sr0x7ep8wy",
+      "videoId": "Y35QtGHoYu4",
+      "videoTitle": "3대 째 운영 중인 태국 족발 장인집! 현지인들이 줄 서 먹는 족발덮밥 '카오카무'"
+    },
+    {
+      "spotId": "SS01kyhxp2hpv1d640fwtqntnhgc",
+      "videoId": "SC35veRULzE",
+      "videoTitle": "백종원도 감동한 태국의 소스들, 연어 샐러드와 돼지 항정살 튀김"
+    },
+    {
+      "spotId": "SS01kyhxp2hq0nmwxjpntpc8f0zf",
+      "videoId": "ipxFyXDHdWs",
+      "videoTitle": "11시 이후의 태국에서만 먹을 수 있는 특별한 라면"
+    },
+    {
+      "spotId": "SS01kyhxp2hrsk2ebsmt6xnr498h",
+      "videoId": "jXfAMAV5diw",
+      "videoTitle": "일본에 가면 꼭 먹어봐야 할 미친 마블링의 소고기"
+    },
+    {
+      "spotId": "SS01kyhxp2hsymh63x21neac5tge",
+      "videoId": "l9o9dMI8oFM",
+      "videoTitle": "일본 직장인들이 퇴근 후 맥주 한잔씩 걸치는 로컬 맛집, 꼬치구이 전문점"
+    },
+    {
+      "spotId": "SS01kyhxp2hth9zzret07a1ahkr9",
+      "videoId": "BkVO3AWHNdI",
+      "videoTitle": "술이 술술 넘어가게 하는 술도둑 니꼬미! 백선생은 호? 불호?"
+    },
+    {
+      "spotId": "SS01kyhxp2hvbry89yhzydpvybb8",
+      "videoId": "aP9ANA5eGwc",
+      "videoTitle": "연인과의 일본 여행에서 무조건 칭찬받는 법"
+    },
+    {
+      "spotId": "SS01kyhxp2hwj4q82epev8efaw4s",
+      "videoId": "ki2t93jsCuc",
+      "videoTitle": "백종원이 끊임없이 강아지 신음소리 남발한 JMT 쓰키지 시장투어!"
+    },
+    {
+      "spotId": "SS01kyhxp2hxsm4sx31xrzc6c94p",
+      "videoId": "ogePPpNzHj0",
+      "videoTitle": "참치에 '이것'은 언제나 옳다"
+    },
+    {
+      "spotId": "SS01kyhxp2hytfh9g5q4mxhya6x3",
+      "videoId": "vXdua12fw3Y",
+      "videoTitle": "백종원 인생 최고의 오야코동"
+    },
+    {
+      "spotId": "SS01kyhxp2j05ed662m1ztyq27pk",
+      "videoId": "9uhuWdB8i0k",
+      "videoTitle": "진짜 맛있는 거 찾은 백종원 특) 흰 쌀밥시킴"
+    },
+    {
+      "spotId": "SS01kyhxp2j1aet01aevp9hwee5j",
+      "videoId": "BpMRgHYHoEs",
+      "videoTitle": "메밀국수를 씹고 뜯고 맛보고 즐기는 3 STEP"
+    },
+    {
+      "spotId": "SS01kyhxp2j2mssdgyjrqp4w40xj",
+      "videoId": "Xmr1s740IAc",
+      "videoTitle": "백종원이 인정한 버터+크림 조합? 게살 크림 크로켓"
+    },
+    {
+      "spotId": "SS01kyhxp2j3ywqvvdekxfntdgvg",
+      "videoId": "xtWIzfWWxOU",
+      "videoTitle": "한국인은 3단계부터? 한국인 취저 매운 라멘"
+    },
+    {
+      "spotId": "SS01kyhxp2j4mnjpr8a77yf6bkrg",
+      "videoId": "ANvBwArVsik",
+      "videoTitle": "하와이에 가면 꼭, 반드시, 무조건 먹어봐야 할 치킨"
+    },
+    {
+      "spotId": "SS01kyhxp2j51xarwta3setwjvsv",
+      "videoId": "exmDpf9FZJI",
+      "videoTitle": "초강력한 버터갈릭소스와 하와이안 통새우의 이중주"
+    },
+    {
+      "spotId": "SS01kyhxp2j699f0rj4ns9wmwq1q",
+      "videoId": "AJHOPoPc6u4",
+      "videoTitle": "몇 천 km 넘어 온 하와이에서 만난 깍두기"
+    },
+    {
+      "spotId": "SS01kyhxp2j7jycqfvad9dvwhnzp",
+      "videoId": "0u7V5KXFKIU",
+      "videoTitle": "아무리 백종원씨라도 하와이안 피자는 좀;"
+    },
+    {
+      "spotId": "SS01kyhxp2j8h6fbhc2gtt4bm8xj",
+      "videoId": "OGh-8IGqfec",
+      "videoTitle": "아침 세트 메뉴가 스테이크 + 써니 사이드 업인 곳"
+    },
+    {
+      "spotId": "SS01kyhxp2j9ttebyrdnk4cj7fta",
+      "videoId": "Timb7X59Hjk",
+      "videoTitle": "남태평양의 지상낙원, 하와이에서 펼쳐지는 참치 융단 폭격"
+    },
+    {
+      "spotId": "SS01kyhxp2jafqt8jq55x2q9xry4",
+      "videoId": "UCl8ag2UcUc",
+      "videoTitle": "하와이에서만 먹을 수 있는 커피와 디저트의 조합 '말라사다, 코나커피'"
+    },
+    {
+      "spotId": "SS01kyhxp2jb6x2gtrcqfjwjbw8w",
+      "videoId": "GLV_4WSHQGQ",
+      "videoTitle": "백종원도 난처하게 한 맛? 무슨 맛인지 모를 하와이 전통 음식"
+    },
+    {
+      "spotId": "SS01kyhxp2jbat7ndhwf1rfb1y1f",
+      "videoId": "wy-Z_rSnfTA",
+      "videoTitle": "백종원의 최애 하와이안 푸드"
+    },
+    {
+      "spotId": "SS01kyhxp2jw6c46nmmr4nxvn4pd",
+      "videoId": "e9s5XCO6e7E",
+      "videoTitle": "하와이 어느 가게를 가도 평타는 치는 하와이 국민 음식"
+    },
+    {
+      "spotId": "SS01kyhxp2jwp1fats9sjzf9z84t",
+      "videoId": "vEqQUL31FtI",
+      "videoTitle": "땅 속에서 익힌 고기로 만든 에그 베네딕트"
+    },
+    {
+      "spotId": "SS01kyhxp2jys5rpajqt206rkcbb",
+      "videoId": "V_HxnWzI1Kg",
+      "videoTitle": "먹으면서도 계속 입맛을 돋우는 태국 음식의 완벽한 조합"
+    },
+    {
+      "spotId": "SS01kyhxp2jzx8xxj2rbdvp9rmwz",
+      "videoId": "m6OrtT8KCIc",
+      "videoTitle": "백종원이 골목에 들어온 이유는? 투박한 매력의 매운 생선 쌀국수"
+    },
+    {
+      "spotId": "SS01kyhxp2k0m4ktt2yy9b9wcsdw",
+      "videoId": "YQXstVONsys",
+      "videoTitle": "한국에 호떡이 있다면 태국엔 로띠가 있다!!"
+    },
+    {
+      "spotId": "SS01kyhxp2k0djjhz8m4hphfbty0",
+      "videoId": "q7jvWcQUeys",
+      "videoTitle": "스푸파에서 빼놓을 수 없는 시장 탐방, 먹거리 천지인 태국 시장"
+    },
+    {
+      "spotId": "SS01kyhxp2k1xqq6yxwnywz9rd5p",
+      "videoId": "1ZmB9_5_aaI",
+      "videoTitle": "태국 왕가에서 아기를 만들기 위해 만들었던 음식"
+    },
+    {
+      "spotId": "SS01kyhxp2k2f64j0esspeq0hqjq",
+      "videoId": "zbFNyeAqJkc",
+      "videoTitle": "태국의 맛을 알고 싶다면 그냥 이걸 드세요"
+    },
+    {
+      "spotId": "SS01kyhxp2k3fcddggp2m7tss44t",
+      "videoId": "F6wWzwe4l_g",
+      "videoTitle": "태국인들이 좋아하는 것만 골라 만든 국수"
+    },
+    {
+      "spotId": "SS01kyhxp2k4frf3rv073rkvxbwn",
+      "videoId": "Urib6RV4ZZE",
+      "videoTitle": "매콤, 새콤, 달콤의 세 가지 맛이 어우러진 태국 남부식 카레"
+    },
+    {
+      "spotId": "SS01kyhxp2k5f7x7jbte2wykfh7k",
+      "videoId": "I_S3zyMYMwg",
+      "videoTitle": "카레로 새우와 콩을 품다. 태국 음식 중에서도 독보적 영역의 요리, '사떠 팟 꿍'"
+    },
+    {
+      "spotId": "SS01kyhxp2k6b9dmtxvt5r6066r4",
+      "videoId": "Bn2GpaFeQhE",
+      "videoTitle": "돼지고기를 못 먹는 사람들을 위한 태국의 스페셜한 치킨 요리"
+    },
+    {
+      "spotId": "SS01kyhxp2k73b1rnnbznrpk71s7",
+      "videoId": "uNCAYL79g-4",
+      "videoTitle": "한 편의 예술같은 태국 남부의 하이라이트, 해산물 요리"
+    },
+    {
+      "spotId": "SS01kyhxp2k8n9ay5es5b79c3m40",
+      "videoId": "kh2Dks_aTnQ",
+      "videoTitle": "후쿠오카의 자랑거리 한 입 교자, 그 중에서도 단연 최고라 할 수 있는 이곳"
+    },
+    {
+      "spotId": "SS01kyhxp2k90tvwp99sx879yvth",
+      "videoId": "3df92w-Ia0g",
+      "videoTitle": "백피셜) 돈코츠 라멘 고장 후쿠오카 중에서도 원조 of 원조 맛집"
+    },
+    {
+      "spotId": "SS01kyhxp2kapz9b44k856f3pmyw",
+      "videoId": "WLD7jcGk7XU",
+      "videoTitle": "백선생이 가는 시장은 뭐가 달라도 다르다? 내 입맛대로 골라먹는 '대학 덮밥'"
+    },
+    {
+      "spotId": "SS01kyhxp2kbexqhs29na2gqd44w",
+      "videoId": "u1OG20oYUGA",
+      "videoTitle": "상맛집 특) 메뉴 두 개 밖에 없음"
+    },
+    {
+      "spotId": "SS01kyhxp2kcgqxjs9gbn3ranaj1",
+      "videoId": "Agzh4ZqhWmc",
+      "videoTitle": "후쿠오카 카레가 한국보다 찐하다?? 하나 하나가 조화로운 카레 정식"
+    },
+    {
+      "spotId": "SS01kyhxp2kdde2w0x945fp824bq",
+      "videoId": "p90M2o1Y2es",
+      "videoTitle": "차원이 다른 고소함! 신선한 고등어만을 사용하는 고등어 회 & 구이"
+    },
+    {
+      "spotId": "SS01kyhxp2keyh8yg0zqsw2xa28p",
+      "videoId": "91mTzjF-pXk",
+      "videoTitle": "'닭한마리' 마니아라면 반드시 먹어봐야 할 후쿠오카의 닭고기 전골"
+    },
+    {
+      "spotId": "SS01kyhxp2kfgxss3hyyx3mb9nsz",
+      "videoId": "szTwhdRf43U",
+      "videoTitle": "백종원도 '우마이' 연발시킨 이 조합... 절대 못 막습니다"
+    },
+    {
+      "spotId": "SS01kyhxp2kgxt4pkxnggkj00t7x",
+      "videoId": "lFuHLNrsPWw",
+      "videoTitle": "천상의 조합, 명란구이 + 마요네즈"
+    },
+    {
+      "spotId": "SS01kyhxp2khnzb1h2qbejvh9meh",
+      "videoId": "pNCtZ0hDLPE",
+      "videoTitle": "일본의 집밥은 어떤 느낌일까? 현지에서 즐기는 후쿠오카 미소 가정식"
+    },
+    {
+      "spotId": "SS01kyhxp2kh9mhjs5yv6rfepnpd",
+      "videoId": "GMqtev_H4ug",
+      "videoTitle": "백종원이 추천하는 후쿠오카 여행 종착역 카페"
+    },
+    {
+      "spotId": "SS01kyhxp2kky0ae0krtkdfqhxcy",
+      "videoId": "Ot2fErQVYRY",
+      "videoTitle": "백종원이 하얼빈에 와서 가장 먼저 들른 곳"
+    },
+    {
+      "spotId": "SS01kyhxp2km3r9nc7adcdwz3bhr",
+      "videoId": "BMR9ozxW7XY",
+      "videoTitle": "중학생들이 한 번 구워 달라고 했다가 소문 나서 대박 난 간식"
+    },
+    {
+      "spotId": "SS01kyhxp2kmtk81qq5bc4ect7zt",
+      "videoId": "Bg061UVOKs8",
+      "videoTitle": "하얼빈에서 즐기는 2000원의 행복! 입 안에 퍼지는 고소함의 향연 '건두부무침 & 소고기 두부탕'"
+    },
+    {
+      "spotId": "SS01kyhxp2knwafr7abzwaf2yjje",
+      "videoId": "D_hs6CCz7Y8",
+      "videoTitle": "찹쌀 가루가 들어가지 않는 찹쌀 탕수육"
+    },
+    {
+      "spotId": "SS01kyhxp2kp83sgyw4e8rs59rcb",
+      "videoId": "b7CWxShUixc",
+      "videoTitle": "카페라떼 아닙니다..."
+    },
+    {
+      "spotId": "SS01kyhxp2kqbgvv5reczqzj7k9y",
+      "videoId": "d7Q-0zDJdD8",
+      "videoTitle": "백종원이 비행기에서부터 기대했다는 가게"
+    },
+    {
+      "spotId": "SS01kyhxp2mmnhsjfy2949tjgygb",
+      "videoId": "AO091J6GI2w",
+      "videoTitle": "하얼빈의 100년 전통 만두 가게"
+    },
+    {
+      "spotId": "SS01kyhxp2mnd96avtjnn58xqrgk",
+      "videoId": "vK243dTRUY8",
+      "videoTitle": "백종원쌤 한국 음식 많이 그리웠구나... 쏸차이탕을 김치찌개로 개조하는 백종원쌤"
+    },
+    {
+      "spotId": "SS01kyhxp2mp3sx0mxg7xasbzp6b",
+      "videoId": "GIXy2-oO6mM",
+      "videoTitle": "예상이 가서 더 먹고 싶은 맛, 역 앞에 있는 맛집의 행복"
+    },
+    {
+      "spotId": "SS01kyhxp2mqjcxr1vhmwg0v0m3w",
+      "videoId": "FDp5Uy8KZtE",
+      "videoTitle": "완벽한 맛! 하나하나 먹어도 맛있는 걸 싸먹으니 그저 맛없없"
+    },
+    {
+      "spotId": "SS01kyhxp2mrxt0nn2xhmr22v3cv",
+      "videoId": "4dDicW2b3b0",
+      "videoTitle": "백종원도 받자마자 할 말을 잃은 美친 존재감의 생선찜"
+    },
+    {
+      "spotId": "SS01kyhxp2mssq4zvmsdy1est8j1",
+      "videoId": "R2AC_KGlVfQ",
+      "videoTitle": "맛집 인증이 속출한 하얼빈 최고의 맛"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c/locations.json
+++ b/.claude/workspace/youtube/PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c/locations.json
@@ -1,0 +1,1466 @@
+{
+  "videos": [
+    {
+      "videoId": "FI_n_xthvss",
+      "title": "백종원의 세계 맛집 도장 깨기 시작!",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 백종원의 세계 맛집 도장 깨기 시작!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=FI_n_xthvss"
+        }
+      ]
+    },
+    {
+      "videoId": "tIN8hbUhT9s",
+      "title": "가문 대대로 전해져 내려온 소스와 면의 절묘한 조화",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 가문 대대로 전해져 내려온 소스와 면의 절묘한 조화",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tIN8hbUhT9s"
+        }
+      ]
+    },
+    {
+      "videoId": "DNN6T7t8zWk",
+      "title": "백종원이 비행기 타고 내리자마자 온 곳",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 백종원이 비행기 타고 내리자마자 온 곳",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DNN6T7t8zWk"
+        }
+      ]
+    },
+    {
+      "videoId": "0jwYJGoE19k",
+      "title": "미슐랭 빵집보다 맛있는 대륙의 페이스트리",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 미슐랭 빵집보다 맛있는 대륙의 페이스트리",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0jwYJGoE19k"
+        }
+      ]
+    },
+    {
+      "videoId": "5lxGFcDO5og",
+      "title": "사천 음식의 대표 주자 마파두부, 청두에서 맛보는 원조의 손맛",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 사천 음식의 대표 주자 마파두부, 청두에서 맛보는 원조의 손맛",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5lxGFcDO5og"
+        }
+      ]
+    },
+    {
+      "videoId": "WrgtkN1DGJY",
+      "title": "백종원도 먹다 눈물 흘린 청두의 소울 푸드",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 백종원도 먹다 눈물 흘린 청두의 소울 푸드",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=WrgtkN1DGJY"
+        }
+      ]
+    },
+    {
+      "videoId": "CKu3hTDRfls",
+      "title": "사천음식의 지휘자, 홍유가 식탁에 오르기까지",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 사천음식의 지휘자, 홍유가 식탁에 오르기까지",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CKu3hTDRfls"
+        }
+      ]
+    },
+    {
+      "videoId": "1zytti7f5X8",
+      "title": "중국 여행에서 뭘 시켜야할 지 모르겠다면? 사천음식의 대표주자들 '궁보우지딩 & 위샹체쯔'",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 중국 여행에서 뭘 시켜야할 지 모르겠다면? 사천음식의 대표주자들 '궁보우지딩 & 위샹체쯔'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1zytti7f5X8"
+        }
+      ]
+    },
+    {
+      "videoId": "d0qsvi13EG0",
+      "title": "백종원을 감회에 젖게 만든 한 찻집의 묘한 분위기",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 백종원을 감회에 젖게 만든 한 찻집의 묘한 분위기",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=d0qsvi13EG0"
+        }
+      ]
+    },
+    {
+      "videoId": "YiLQauZLHZM",
+      "title": "벌써부터 액땜을? 스푸파 첫 화만에 백종원에게 일어난 봉변",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 벌써부터 액땜을? 스푸파 첫 화만에 백종원에게 일어난 봉변",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YiLQauZLHZM"
+        }
+      ]
+    },
+    {
+      "videoId": "Z4k_Faz40C8",
+      "title": "마라촨vs훠궈vs바지락 사천 요리 중 백종원 픽 최고의 술안주는?",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 마라촨vs훠궈vs바지락 사천 요리 중 백종원 픽 최고의 술안주는?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Z4k_Faz40C8"
+        }
+      ]
+    },
+    {
+      "videoId": "OI0GahD301s",
+      "title": "한 번 빠지면 헤어나올 수 없는 이 세상 조합, 토마토라면 '퐌케민' + 연유토스트",
+      "concept": "중국 청두",
+      "locations": [
+        {
+          "name": "Kuan Alley and Zhai Alley",
+          "address": "중국 Si Chuan Sheng, Cheng Du Shi, Qing Yang Qu, 长顺上街127号 邮政编码: 610032",
+          "latitude": 30.663611099999997,
+          "longitude": 104.0525,
+          "googleMapsId": "ChIJRxJWE9jE7zYRZVJ_scoyS4M",
+          "googleMapsUri": "https://maps.google.com/?cid=9460711288364552805&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 청두 편. 한 번 빠지면 헤어나올 수 없는 이 세상 조합, 토마토라면 '퐌케민' + 연유토스트",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=OI0GahD301s"
+        }
+      ]
+    },
+    {
+      "videoId": "bX2QWpbNTuc",
+      "title": "맥주엔 '볶은 게' 제격, 홍콩 제일의 맥주 안주 '베이퐁통 게 볶음'",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 맥주엔 '볶은 게' 제격, 홍콩 제일의 맥주 안주 '베이퐁통 게 볶음'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bX2QWpbNTuc"
+        }
+      ]
+    },
+    {
+      "videoId": "KDoZTDS5iKk",
+      "title": "사장님 그곳은 괜찮으신가...? 보고 나면 못 걸어다닐 것 같은 완탕면 반죽",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 사장님 그곳은 괜찮으신가...? 보고 나면 못 걸어다닐 것 같은 완탕면 반죽",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KDoZTDS5iKk"
+        }
+      ]
+    },
+    {
+      "videoId": "OZNhcgeBpMY",
+      "title": "익숙한 맛에서 느껴지는 독특한 식감! 새우와 돼지고기의 절묘한 조화 '완탕면'",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 익숙한 맛에서 느껴지는 독특한 식감! 새우와 돼지고기의 절묘한 조화 '완탕면'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=OZNhcgeBpMY"
+        }
+      ]
+    },
+    {
+      "videoId": "x2LdT_Pf9P0",
+      "title": "백종원도 방송 중에 맥주 시키게 한 홍콩식 굴전",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 백종원도 방송 중에 맥주 시키게 한 홍콩식 굴전",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=x2LdT_Pf9P0"
+        }
+      ]
+    },
+    {
+      "videoId": "fMbfv4mveZo",
+      "title": "백종원마저 벽을 느꼈다... '완벽' 그 자체, 홍콩식 뽀짜이판",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 백종원마저 벽을 느꼈다... '완벽' 그 자체, 홍콩식 뽀짜이판",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=fMbfv4mveZo"
+        }
+      ]
+    },
+    {
+      "videoId": "AV99LPgd8BY",
+      "title": "이것이 홍콩의 피X츄 돈까스? 홍콩의 소울 푸드 '카레위단'",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 이것이 홍콩의 피X츄 돈까스? 홍콩의 소울 푸드 '카레위단'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=AV99LPgd8BY"
+        }
+      ]
+    },
+    {
+      "videoId": "hajKoKvz6FE",
+      "title": "한국 간 요리와는 차원이 다른 식감? 백종원이 홍콩에 오면 꼭 먹는다는 돼지 간 요리",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 한국 간 요리와는 차원이 다른 식감? 백종원이 홍콩에 오면 꼭 먹는다는 돼지 간 요리",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=hajKoKvz6FE"
+        }
+      ]
+    },
+    {
+      "videoId": "_9PQErHct4s",
+      "title": "홍콩의 컵밥? 인기만점 딤섬들과 간장의 조화 '종판'",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 홍콩의 컵밥? 인기만점 딤섬들과 간장의 조화 '종판'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=_9PQErHct4s"
+        }
+      ]
+    },
+    {
+      "videoId": "ErW1_uGHJjk",
+      "title": "오로지 우유와 생강으로만 만든 홍콩의 보배, 생강 우유 푸딩",
+      "concept": "홍콩",
+      "locations": [
+        {
+          "name": "템플스트리트 야시장",
+          "address": "Temple St, Jordan, 홍콩",
+          "latitude": 22.3065185,
+          "longitude": 114.1699805,
+          "googleMapsId": "ChIJzcAL8-oABDQRpDOEry9D3bc",
+          "googleMapsUri": "https://maps.google.com/?cid=13248819550881067940&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 홍콩 편. 오로지 우유와 생강으로만 만든 홍콩의 보배, 생강 우유 푸딩",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ErW1_uGHJjk"
+        }
+      ]
+    },
+    {
+      "videoId": "DZXY2nFzN0w",
+      "title": "배 위에서 즐기는 태국식 현지 쌀국수",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 배 위에서 즐기는 태국식 현지 쌀국수",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DZXY2nFzN0w"
+        }
+      ]
+    },
+    {
+      "videoId": "tFh6qarA0ro",
+      "title": "한국사람은 무한대로 먹을 수 있는 돼지고기 꼬치구이",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 한국사람은 무한대로 먹을 수 있는 돼지고기 꼬치구이",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tFh6qarA0ro"
+        }
+      ]
+    },
+    {
+      "videoId": "1zOWrpi4cgY",
+      "title": "튀긴 면과 계란, 고명들의 환상의 호흡! 태국에서 반드시 먹어야 할 '랏나'",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 튀긴 면과 계란, 고명들의 환상의 호흡! 태국에서 반드시 먹어야 할 '랏나'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1zOWrpi4cgY"
+        }
+      ]
+    },
+    {
+      "videoId": "bQqH1BLd3Rk",
+      "title": "전세계에서 줄 서먹는 삼겹살튀김 + 쌀국수집",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 전세계에서 줄 서먹는 삼겹살튀김 + 쌀국수집",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bQqH1BLd3Rk"
+        }
+      ]
+    },
+    {
+      "videoId": "O0Sst8_8LPM",
+      "title": "백종원이 호텔 조식도 거르고 찾아간 태국 현지 아침 식사! 태국식 덮밥 '카오 랏 깽'",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 백종원이 호텔 조식도 거르고 찾아간 태국 현지 아침 식사! 태국식 덮밥 '카오 랏 깽'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=O0Sst8_8LPM"
+        }
+      ]
+    },
+    {
+      "videoId": "JPtAUA9O7xo",
+      "title": "태국 현지인들도 인정한 소갈비국수 맛집, 백종원이 알려주는 200% 즐기는 방법",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 태국 현지인들도 인정한 소갈비국수 맛집, 백종원이 알려주는 200% 즐기는 방법",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JPtAUA9O7xo"
+        }
+      ]
+    },
+    {
+      "videoId": "Y35QtGHoYu4",
+      "title": "3대 째 운영 중인 태국 족발 장인집! 현지인들이 줄 서 먹는 족발덮밥 '카오카무'",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 3대 째 운영 중인 태국 족발 장인집! 현지인들이 줄 서 먹는 족발덮밥 '카오카무'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Y35QtGHoYu4"
+        }
+      ]
+    },
+    {
+      "videoId": "SC35veRULzE",
+      "title": "백종원도 감동한 태국의 소스들, 연어 샐러드와 돼지 항정살 튀김",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 백종원도 감동한 태국의 소스들, 연어 샐러드와 돼지 항정살 튀김",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SC35veRULzE"
+        }
+      ]
+    },
+    {
+      "videoId": "ipxFyXDHdWs",
+      "title": "11시 이후의 태국에서만 먹을 수 있는 특별한 라면",
+      "concept": "태국 방콕",
+      "locations": [
+        {
+          "name": "Yaowarat Road",
+          "address": "Yaowarat Rd, Krung Thep Maha Nakhon, 태국",
+          "latitude": 13.7373794,
+          "longitude": 100.5129349,
+          "googleMapsId": "ChIJ95Nh9yGZ4jARAjfcG2uIZFg",
+          "googleMapsUri": "https://maps.google.com/?cid=6369365766619019010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 방콕 편. 11시 이후의 태국에서만 먹을 수 있는 특별한 라면",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ipxFyXDHdWs"
+        }
+      ]
+    },
+    {
+      "videoId": "jXfAMAV5diw",
+      "title": "일본에 가면 꼭 먹어봐야 할 미친 마블링의 소고기",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 일본에 가면 꼭 먹어봐야 할 미친 마블링의 소고기",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=jXfAMAV5diw"
+        }
+      ]
+    },
+    {
+      "videoId": "l9o9dMI8oFM",
+      "title": "일본 직장인들이 퇴근 후 맥주 한잔씩 걸치는 로컬 맛집, 꼬치구이 전문점",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 일본 직장인들이 퇴근 후 맥주 한잔씩 걸치는 로컬 맛집, 꼬치구이 전문점",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=l9o9dMI8oFM"
+        }
+      ]
+    },
+    {
+      "videoId": "BkVO3AWHNdI",
+      "title": "술이 술술 넘어가게 하는 술도둑 니꼬미! 백선생은 호? 불호?",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 술이 술술 넘어가게 하는 술도둑 니꼬미! 백선생은 호? 불호?",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BkVO3AWHNdI"
+        }
+      ]
+    },
+    {
+      "videoId": "aP9ANA5eGwc",
+      "title": "연인과의 일본 여행에서 무조건 칭찬받는 법",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 연인과의 일본 여행에서 무조건 칭찬받는 법",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=aP9ANA5eGwc"
+        }
+      ]
+    },
+    {
+      "videoId": "ki2t93jsCuc",
+      "title": "백종원이 끊임없이 강아지 신음소리 남발한 JMT 쓰키지 시장투어!",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 백종원이 끊임없이 강아지 신음소리 남발한 JMT 쓰키지 시장투어!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ki2t93jsCuc"
+        }
+      ]
+    },
+    {
+      "videoId": "ogePPpNzHj0",
+      "title": "참치에 '이것'은 언제나 옳다",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 참치에 '이것'은 언제나 옳다",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ogePPpNzHj0"
+        }
+      ]
+    },
+    {
+      "videoId": "vXdua12fw3Y",
+      "title": "백종원 인생 최고의 오야코동",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 백종원 인생 최고의 오야코동",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vXdua12fw3Y"
+        }
+      ]
+    },
+    {
+      "videoId": "9uhuWdB8i0k",
+      "title": "진짜 맛있는 거 찾은 백종원 특) 흰 쌀밥시킴",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 진짜 맛있는 거 찾은 백종원 특) 흰 쌀밥시킴",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=9uhuWdB8i0k"
+        }
+      ]
+    },
+    {
+      "videoId": "BpMRgHYHoEs",
+      "title": "메밀국수를 씹고 뜯고 맛보고 즐기는 3 STEP",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 메밀국수를 씹고 뜯고 맛보고 즐기는 3 STEP",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BpMRgHYHoEs"
+        }
+      ]
+    },
+    {
+      "videoId": "Xmr1s740IAc",
+      "title": "백종원이 인정한 버터+크림 조합? 게살 크림 크로켓",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 백종원이 인정한 버터+크림 조합? 게살 크림 크로켓",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Xmr1s740IAc"
+        }
+      ]
+    },
+    {
+      "videoId": "xtWIzfWWxOU",
+      "title": "한국인은 3단계부터? 한국인 취저 매운 라멘",
+      "concept": "일본 도쿄",
+      "locations": [
+        {
+          "name": "쓰키지 장외시장",
+          "address": "일본 〒104-0045 Tokyo, Chuo City, Tsukiji, 4-chōme−16 および６丁目一部",
+          "latitude": 35.6647703,
+          "longitude": 139.7702515,
+          "googleMapsId": "ChIJW2cLzSGLGGARXAKXv6EkbqI",
+          "googleMapsUri": "https://maps.google.com/?cid=11704332758705177180&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 도쿄 편. 한국인은 3단계부터? 한국인 취저 매운 라멘",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xtWIzfWWxOU"
+        }
+      ]
+    },
+    {
+      "videoId": "ANvBwArVsik",
+      "title": "하와이에 가면 꼭, 반드시, 무조건 먹어봐야 할 치킨",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 하와이에 가면 꼭, 반드시, 무조건 먹어봐야 할 치킨",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ANvBwArVsik"
+        }
+      ]
+    },
+    {
+      "videoId": "exmDpf9FZJI",
+      "title": "초강력한 버터갈릭소스와 하와이안 통새우의 이중주",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 초강력한 버터갈릭소스와 하와이안 통새우의 이중주",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=exmDpf9FZJI"
+        }
+      ]
+    },
+    {
+      "videoId": "AJHOPoPc6u4",
+      "title": "몇 천 km 넘어 온 하와이에서 만난 깍두기",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 몇 천 km 넘어 온 하와이에서 만난 깍두기",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=AJHOPoPc6u4"
+        }
+      ]
+    },
+    {
+      "videoId": "0u7V5KXFKIU",
+      "title": "아무리 백종원씨라도 하와이안 피자는 좀;",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 아무리 백종원씨라도 하와이안 피자는 좀;",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0u7V5KXFKIU"
+        }
+      ]
+    },
+    {
+      "videoId": "OGh-8IGqfec",
+      "title": "아침 세트 메뉴가 스테이크 + 써니 사이드 업인 곳",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 아침 세트 메뉴가 스테이크 + 써니 사이드 업인 곳",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=OGh-8IGqfec"
+        }
+      ]
+    },
+    {
+      "videoId": "Timb7X59Hjk",
+      "title": "남태평양의 지상낙원, 하와이에서 펼쳐지는 참치 융단 폭격",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 남태평양의 지상낙원, 하와이에서 펼쳐지는 참치 융단 폭격",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Timb7X59Hjk"
+        }
+      ]
+    },
+    {
+      "videoId": "UCl8ag2UcUc",
+      "title": "하와이에서만 먹을 수 있는 커피와 디저트의 조합 '말라사다, 코나커피'",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 하와이에서만 먹을 수 있는 커피와 디저트의 조합 '말라사다, 코나커피'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=UCl8ag2UcUc"
+        }
+      ]
+    },
+    {
+      "videoId": "GLV_4WSHQGQ",
+      "title": "백종원도 난처하게 한 맛? 무슨 맛인지 모를 하와이 전통 음식",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 백종원도 난처하게 한 맛? 무슨 맛인지 모를 하와이 전통 음식",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GLV_4WSHQGQ"
+        }
+      ]
+    },
+    {
+      "videoId": "wy-Z_rSnfTA",
+      "title": "백종원의 최애 하와이안 푸드",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 백종원의 최애 하와이안 푸드",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=wy-Z_rSnfTA"
+        }
+      ]
+    },
+    {
+      "videoId": "e9s5XCO6e7E",
+      "title": "하와이 어느 가게를 가도 평타는 치는 하와이 국민 음식",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 하와이 어느 가게를 가도 평타는 치는 하와이 국민 음식",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=e9s5XCO6e7E"
+        }
+      ]
+    },
+    {
+      "videoId": "vEqQUL31FtI",
+      "title": "땅 속에서 익힌 고기로 만든 에그 베네딕트",
+      "concept": "미국 하와이",
+      "locations": [
+        {
+          "name": "KCC 파머스 마켓",
+          "address": "Parking Lot B, 4303 Diamond Head Rd, Honolulu, HI 96816 미국",
+          "latitude": 21.2701942,
+          "longitude": -157.8025224,
+          "googleMapsId": "ChIJZ7mSe4NyAHwRdllrFpUQ1fA",
+          "googleMapsUri": "https://maps.google.com/?cid=17353794971654379894&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 미국 하와이 편. 땅 속에서 익힌 고기로 만든 에그 베네딕트",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vEqQUL31FtI"
+        }
+      ]
+    },
+    {
+      "videoId": "V_HxnWzI1Kg",
+      "title": "먹으면서도 계속 입맛을 돋우는 태국 음식의 완벽한 조합",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 먹으면서도 계속 입맛을 돋우는 태국 음식의 완벽한 조합",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=V_HxnWzI1Kg"
+        }
+      ]
+    },
+    {
+      "videoId": "m6OrtT8KCIc",
+      "title": "백종원이 골목에 들어온 이유는? 투박한 매력의 매운 생선 쌀국수",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 백종원이 골목에 들어온 이유는? 투박한 매력의 매운 생선 쌀국수",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=m6OrtT8KCIc"
+        }
+      ]
+    },
+    {
+      "videoId": "YQXstVONsys",
+      "title": "한국에 호떡이 있다면 태국엔 로띠가 있다!!",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 한국에 호떡이 있다면 태국엔 로띠가 있다!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YQXstVONsys"
+        }
+      ]
+    },
+    {
+      "videoId": "q7jvWcQUeys",
+      "title": "스푸파에서 빼놓을 수 없는 시장 탐방, 먹거리 천지인 태국 시장",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 스푸파에서 빼놓을 수 없는 시장 탐방, 먹거리 천지인 태국 시장",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=q7jvWcQUeys"
+        }
+      ]
+    },
+    {
+      "videoId": "1ZmB9_5_aaI",
+      "title": "태국 왕가에서 아기를 만들기 위해 만들었던 음식",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 태국 왕가에서 아기를 만들기 위해 만들었던 음식",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1ZmB9_5_aaI"
+        }
+      ]
+    },
+    {
+      "videoId": "zbFNyeAqJkc",
+      "title": "태국의 맛을 알고 싶다면 그냥 이걸 드세요",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 태국의 맛을 알고 싶다면 그냥 이걸 드세요",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zbFNyeAqJkc"
+        }
+      ]
+    },
+    {
+      "videoId": "F6wWzwe4l_g",
+      "title": "태국인들이 좋아하는 것만 골라 만든 국수",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 태국인들이 좋아하는 것만 골라 만든 국수",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=F6wWzwe4l_g"
+        }
+      ]
+    },
+    {
+      "videoId": "Urib6RV4ZZE",
+      "title": "매콤, 새콤, 달콤의 세 가지 맛이 어우러진 태국 남부식 카레",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 매콤, 새콤, 달콤의 세 가지 맛이 어우러진 태국 남부식 카레",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Urib6RV4ZZE"
+        }
+      ]
+    },
+    {
+      "videoId": "I_S3zyMYMwg",
+      "title": "카레로 새우와 콩을 품다. 태국 음식 중에서도 독보적 영역의 요리, '사떠 팟 꿍'",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 카레로 새우와 콩을 품다. 태국 음식 중에서도 독보적 영역의 요리, '사떠 팟 꿍'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=I_S3zyMYMwg"
+        }
+      ]
+    },
+    {
+      "videoId": "Bn2GpaFeQhE",
+      "title": "돼지고기를 못 먹는 사람들을 위한 태국의 스페셜한 치킨 요리",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 돼지고기를 못 먹는 사람들을 위한 태국의 스페셜한 치킨 요리",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Bn2GpaFeQhE"
+        }
+      ]
+    },
+    {
+      "videoId": "uNCAYL79g-4",
+      "title": "한 편의 예술같은 태국 남부의 하이라이트, 해산물 요리",
+      "concept": "태국 푸껫",
+      "locations": [
+        {
+          "name": "Old Phuket Town",
+          "address": "Old Phuket Town, Mueang Phuket District, Phuket 83000 태국",
+          "latitude": 7.8858652,
+          "longitude": 98.38761970000002,
+          "googleMapsId": "ChIJyXu3hvoxUDAR86GPJxPu9G8",
+          "googleMapsUri": "https://maps.google.com/?cid=8067334598562914803&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 태국 푸껫 편. 한 편의 예술같은 태국 남부의 하이라이트, 해산물 요리",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=uNCAYL79g-4"
+        }
+      ]
+    },
+    {
+      "videoId": "kh2Dks_aTnQ",
+      "title": "후쿠오카의 자랑거리 한 입 교자, 그 중에서도 단연 최고라 할 수 있는 이곳",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 후쿠오카의 자랑거리 한 입 교자, 그 중에서도 단연 최고라 할 수 있는 이곳",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kh2Dks_aTnQ"
+        }
+      ]
+    },
+    {
+      "videoId": "3df92w-Ia0g",
+      "title": "백피셜) 돈코츠 라멘 고장 후쿠오카 중에서도 원조 of 원조 맛집",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 백피셜) 돈코츠 라멘 고장 후쿠오카 중에서도 원조 of 원조 맛집",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=3df92w-Ia0g"
+        }
+      ]
+    },
+    {
+      "videoId": "WLD7jcGk7XU",
+      "title": "백선생이 가는 시장은 뭐가 달라도 다르다? 내 입맛대로 골라먹는 '대학 덮밥'",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 백선생이 가는 시장은 뭐가 달라도 다르다? 내 입맛대로 골라먹는 '대학 덮밥'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=WLD7jcGk7XU"
+        }
+      ]
+    },
+    {
+      "videoId": "u1OG20oYUGA",
+      "title": "상맛집 특) 메뉴 두 개 밖에 없음",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 상맛집 특) 메뉴 두 개 밖에 없음",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=u1OG20oYUGA"
+        }
+      ]
+    },
+    {
+      "videoId": "Agzh4ZqhWmc",
+      "title": "후쿠오카 카레가 한국보다 찐하다?? 하나 하나가 조화로운 카레 정식",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 후쿠오카 카레가 한국보다 찐하다?? 하나 하나가 조화로운 카레 정식",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Agzh4ZqhWmc"
+        }
+      ]
+    },
+    {
+      "videoId": "p90M2o1Y2es",
+      "title": "차원이 다른 고소함! 신선한 고등어만을 사용하는 고등어 회 & 구이",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 차원이 다른 고소함! 신선한 고등어만을 사용하는 고등어 회 & 구이",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=p90M2o1Y2es"
+        }
+      ]
+    },
+    {
+      "videoId": "91mTzjF-pXk",
+      "title": "'닭한마리' 마니아라면 반드시 먹어봐야 할 후쿠오카의 닭고기 전골",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. '닭한마리' 마니아라면 반드시 먹어봐야 할 후쿠오카의 닭고기 전골",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=91mTzjF-pXk"
+        }
+      ]
+    },
+    {
+      "videoId": "szTwhdRf43U",
+      "title": "백종원도 '우마이' 연발시킨 이 조합... 절대 못 막습니다",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 백종원도 '우마이' 연발시킨 이 조합... 절대 못 막습니다",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=szTwhdRf43U"
+        }
+      ]
+    },
+    {
+      "videoId": "lFuHLNrsPWw",
+      "title": "천상의 조합, 명란구이 + 마요네즈",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 천상의 조합, 명란구이 + 마요네즈",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=lFuHLNrsPWw"
+        }
+      ]
+    },
+    {
+      "videoId": "pNCtZ0hDLPE",
+      "title": "일본의 집밥은 어떤 느낌일까? 현지에서 즐기는 후쿠오카 미소 가정식",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 일본의 집밥은 어떤 느낌일까? 현지에서 즐기는 후쿠오카 미소 가정식",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=pNCtZ0hDLPE"
+        }
+      ]
+    },
+    {
+      "videoId": "GMqtev_H4ug",
+      "title": "백종원이 추천하는 후쿠오카 여행 종착역 카페",
+      "concept": "일본 후쿠오카",
+      "locations": [
+        {
+          "name": "나카스 포장마차 거리",
+          "address": "일본 〒810-0801 Fukuoka, Hakata Ward, Nakasu, 1-chōme−8, 那珂川 通り",
+          "latitude": 33.590398199999996,
+          "longitude": 130.4082999,
+          "googleMapsId": "ChIJRbuyypWRQTURbITjwMeuLnM",
+          "googleMapsUri": "https://maps.google.com/?cid=8299763336248263788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 일본 후쿠오카 편. 백종원이 추천하는 후쿠오카 여행 종착역 카페",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GMqtev_H4ug"
+        }
+      ]
+    },
+    {
+      "videoId": "Ot2fErQVYRY",
+      "title": "백종원이 하얼빈에 와서 가장 먼저 들른 곳",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 백종원이 하얼빈에 와서 가장 먼저 들른 곳",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Ot2fErQVYRY"
+        }
+      ]
+    },
+    {
+      "videoId": "BMR9ozxW7XY",
+      "title": "중학생들이 한 번 구워 달라고 했다가 소문 나서 대박 난 간식",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 중학생들이 한 번 구워 달라고 했다가 소문 나서 대박 난 간식",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BMR9ozxW7XY"
+        }
+      ]
+    },
+    {
+      "videoId": "Bg061UVOKs8",
+      "title": "하얼빈에서 즐기는 2000원의 행복! 입 안에 퍼지는 고소함의 향연 '건두부무침 & 소고기 두부탕'",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 하얼빈에서 즐기는 2000원의 행복! 입 안에 퍼지는 고소함의 향연 '건두부무침 & 소고기 두부탕'",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Bg061UVOKs8"
+        }
+      ]
+    },
+    {
+      "videoId": "D_hs6CCz7Y8",
+      "title": "찹쌀 가루가 들어가지 않는 찹쌀 탕수육",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 찹쌀 가루가 들어가지 않는 찹쌀 탕수육",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=D_hs6CCz7Y8"
+        }
+      ]
+    },
+    {
+      "videoId": "b7CWxShUixc",
+      "title": "카페라떼 아닙니다...",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 카페라떼 아닙니다...",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=b7CWxShUixc"
+        }
+      ]
+    },
+    {
+      "videoId": "d7Q-0zDJdD8",
+      "title": "백종원이 비행기에서부터 기대했다는 가게",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 백종원이 비행기에서부터 기대했다는 가게",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=d7Q-0zDJdD8"
+        }
+      ]
+    },
+    {
+      "videoId": "AO091J6GI2w",
+      "title": "하얼빈의 100년 전통 만두 가게",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 하얼빈의 100년 전통 만두 가게",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=AO091J6GI2w"
+        }
+      ]
+    },
+    {
+      "videoId": "vK243dTRUY8",
+      "title": "백종원쌤 한국 음식 많이 그리웠구나... 쏸차이탕을 김치찌개로 개조하는 백종원쌤",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 백종원쌤 한국 음식 많이 그리웠구나... 쏸차이탕을 김치찌개로 개조하는 백종원쌤",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vK243dTRUY8"
+        }
+      ]
+    },
+    {
+      "videoId": "GIXy2-oO6mM",
+      "title": "예상이 가서 더 먹고 싶은 맛, 역 앞에 있는 맛집의 행복",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 예상이 가서 더 먹고 싶은 맛, 역 앞에 있는 맛집의 행복",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GIXy2-oO6mM"
+        }
+      ]
+    },
+    {
+      "videoId": "FDp5Uy8KZtE",
+      "title": "완벽한 맛! 하나하나 먹어도 맛있는 걸 싸먹으니 그저 맛없없",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 완벽한 맛! 하나하나 먹어도 맛있는 걸 싸먹으니 그저 맛없없",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=FDp5Uy8KZtE"
+        }
+      ]
+    },
+    {
+      "videoId": "4dDicW2b3b0",
+      "title": "백종원도 받자마자 할 말을 잃은 美친 존재감의 생선찜",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 백종원도 받자마자 할 말을 잃은 美친 존재감의 생선찜",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=4dDicW2b3b0"
+        }
+      ]
+    },
+    {
+      "videoId": "R2AC_KGlVfQ",
+      "title": "맛집 인증이 속출한 하얼빈 최고의 맛",
+      "concept": "중국 하얼빈",
+      "locations": [
+        {
+          "name": "Central Street",
+          "address": "J5JQ+HHV, Zhong Xin Da Jie, Dao Li Qu, Ha Er Bin Shi, Hei Long Jiang Sheng, 중국 150079",
+          "latitude": 45.631487,
+          "longitude": 126.18893100000001,
+          "googleMapsId": "ChIJHbY59hmNQ14Rw71pSYvz7W4",
+          "googleMapsUri": "https://maps.google.com/?cid=7993312693210168771&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "description": "스트리트 푸드 파이터 중국 하얼빈 편. 맛집 인증이 속출한 하얼빈 최고의 맛",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=R2AC_KGlVfQ"
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c/video_info.json
+++ b/.claude/workspace/youtube/PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c/video_info.json
@@ -1,0 +1,627 @@
+{
+  "type": "playlist",
+  "id": "PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c",
+  "title": "백종원의 [#스트리트푸드파이터] 시즌1 몰아보기",
+  "description": "",
+  "url": "https://www.youtube.com/playlist?list=PLgbB1gJhmG7DWksYdc3AKRjRuzc4TMd5c",
+  "channelName": "tvN Joy",
+  "channel": {
+    "id": "UC78PMQprrZTbU0IlMDsYZPw",
+    "title": "tvN Joy",
+    "handle": "@tvnjoy_official",
+    "url": "https://www.youtube.com/@tvnjoy_official",
+    "description": "NO.1 K콘텐츠 채널, 즐거움엔 tvN",
+    "thumbnailUrl": "https://yt3.ggpht.com/bpSGI1weZmTuMvzXz0k9vwRDugXHTCDPc9qlih808OH88OKUHxhK6uzBGxbjzzQ5czMav9zVOQ=s800-c-k-c0x00ffffff-no-rj"
+  },
+  "selectedVideos": [
+    {
+      "videoId": "FI_n_xthvss",
+      "title": "백종원의 세계 맛집 도장 깨기 시작! #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 0,
+      "url": "https://www.youtube.com/watch?v=FI_n_xthvss"
+    },
+    {
+      "videoId": "tIN8hbUhT9s",
+      "title": "가문 대대로 전해져 내려온 소스와 면의 절묘한 조화 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 1,
+      "url": "https://www.youtube.com/watch?v=tIN8hbUhT9s"
+    },
+    {
+      "videoId": "DNN6T7t8zWk",
+      "title": "백종원이 비행기 타고 내리자마자 온 곳 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 2,
+      "url": "https://www.youtube.com/watch?v=DNN6T7t8zWk"
+    },
+    {
+      "videoId": "0jwYJGoE19k",
+      "title": "미슐랭 빵집보다 맛있는 대륙의 페이스트리 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 3,
+      "url": "https://www.youtube.com/watch?v=0jwYJGoE19k"
+    },
+    {
+      "videoId": "5lxGFcDO5og",
+      "title": "사천 음식의 대표 주자 마파두부, 청두에서 맛보는 원조의 손맛 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 4,
+      "url": "https://www.youtube.com/watch?v=5lxGFcDO5og"
+    },
+    {
+      "videoId": "WrgtkN1DGJY",
+      "title": "백종원도 먹다 눈물 흘린 청두의 소울 푸드 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 5,
+      "url": "https://www.youtube.com/watch?v=WrgtkN1DGJY"
+    },
+    {
+      "videoId": "CKu3hTDRfls",
+      "title": "사천음식의 지휘자, 홍유가 식탁에 오르기까지 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 6,
+      "url": "https://www.youtube.com/watch?v=CKu3hTDRfls"
+    },
+    {
+      "videoId": "1zytti7f5X8",
+      "title": "중국 여행에서 뭘 시켜야할 지 모르겠다면? 사천음식의 대표주자들 '궁보우지딩 & 위샹체쯔' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 7,
+      "url": "https://www.youtube.com/watch?v=1zytti7f5X8"
+    },
+    {
+      "videoId": "d0qsvi13EG0",
+      "title": "백종원을 감회에 젖게 만든 한 찻집의 묘한 분위기 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 8,
+      "url": "https://www.youtube.com/watch?v=d0qsvi13EG0"
+    },
+    {
+      "videoId": "YiLQauZLHZM",
+      "title": "벌써부터 액땜을? 스푸파 첫 화만에 백종원에게 일어난 봉변 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 9,
+      "url": "https://www.youtube.com/watch?v=YiLQauZLHZM"
+    },
+    {
+      "videoId": "Z4k_Faz40C8",
+      "title": "마라촨vs훠궈vs바지락 사천 요리 중 백종원 픽 최고의 술안주는? #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 10,
+      "url": "https://www.youtube.com/watch?v=Z4k_Faz40C8"
+    },
+    {
+      "videoId": "OI0GahD301s",
+      "title": "한 번 빠지면 헤어나올 수 없는 이 세상 조합, 토마토라면 '퐌케민' + 연유토스트 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 11,
+      "url": "https://www.youtube.com/watch?v=OI0GahD301s"
+    },
+    {
+      "videoId": "bX2QWpbNTuc",
+      "title": "맥주엔 '볶은 게' 제격, 홍콩 제일의 맥주 안주 '베이퐁통 게 볶음' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 12,
+      "url": "https://www.youtube.com/watch?v=bX2QWpbNTuc"
+    },
+    {
+      "videoId": "KDoZTDS5iKk",
+      "title": "사장님 그곳은 괜찮으신가...? 보고 나면 못 걸어다닐 것 같은 완탕면 반죽 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 13,
+      "url": "https://www.youtube.com/watch?v=KDoZTDS5iKk"
+    },
+    {
+      "videoId": "OZNhcgeBpMY",
+      "title": "익숙한 맛에서 느껴지는 독특한 식감! 새우와 돼지고기의 절묘한 조화 '완탕면' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 14,
+      "url": "https://www.youtube.com/watch?v=OZNhcgeBpMY"
+    },
+    {
+      "videoId": "x2LdT_Pf9P0",
+      "title": "백종원도 방송 중에 맥주 시키게 한 홍콩식 굴전 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 15,
+      "url": "https://www.youtube.com/watch?v=x2LdT_Pf9P0"
+    },
+    {
+      "videoId": "fMbfv4mveZo",
+      "title": "백종원마저 벽을 느꼈다... '완벽' 그 자체, 홍콩식 뽀짜이판 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 16,
+      "url": "https://www.youtube.com/watch?v=fMbfv4mveZo"
+    },
+    {
+      "videoId": "AV99LPgd8BY",
+      "title": "이것이 홍콩의 피X츄 돈까스? 홍콩의 소울 푸드 '카레위단' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 17,
+      "url": "https://www.youtube.com/watch?v=AV99LPgd8BY"
+    },
+    {
+      "videoId": "hajKoKvz6FE",
+      "title": "한국 간 요리와는 차원이 다른 식감? 백종원이 홍콩에 오면 꼭 먹는다는 돼지 간 요리 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 18,
+      "url": "https://www.youtube.com/watch?v=hajKoKvz6FE"
+    },
+    {
+      "videoId": "_9PQErHct4s",
+      "title": "홍콩의 컵밥? 인기만점 딤섬들과 간장의 조화 '종판' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 19,
+      "url": "https://www.youtube.com/watch?v=_9PQErHct4s"
+    },
+    {
+      "videoId": "ErW1_uGHJjk",
+      "title": "오로지 우유와 생강으로만 만든 홍콩의 보배, 생강 우유 푸딩 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 20,
+      "url": "https://www.youtube.com/watch?v=ErW1_uGHJjk"
+    },
+    {
+      "videoId": "DZXY2nFzN0w",
+      "title": "배 위에서 즐기는 태국식 현지 쌀국수 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 21,
+      "url": "https://www.youtube.com/watch?v=DZXY2nFzN0w"
+    },
+    {
+      "videoId": "tFh6qarA0ro",
+      "title": "한국사람은 무한대로 먹을 수 있는 돼지고기 꼬치구이 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 22,
+      "url": "https://www.youtube.com/watch?v=tFh6qarA0ro"
+    },
+    {
+      "videoId": "1zOWrpi4cgY",
+      "title": "튀긴 면과 계란, 고명들의 환상의 호흡! 태국에서 반드시 먹어야 할 '랏나' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 23,
+      "url": "https://www.youtube.com/watch?v=1zOWrpi4cgY"
+    },
+    {
+      "videoId": "bQqH1BLd3Rk",
+      "title": "전세계에서 줄 서먹는 삼겹살튀김 + 쌀국수집 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 24,
+      "url": "https://www.youtube.com/watch?v=bQqH1BLd3Rk"
+    },
+    {
+      "videoId": "O0Sst8_8LPM",
+      "title": "백종원이 호텔 조식도 거르고 찾아간 태국 현지 아침 식사! 태국식 덮밥 '카오 랏 깽' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 25,
+      "url": "https://www.youtube.com/watch?v=O0Sst8_8LPM"
+    },
+    {
+      "videoId": "JPtAUA9O7xo",
+      "title": "태국 현지인들도 인정한 소갈비국수 맛집, 백종원이 알려주는 200% 즐기는 방법 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 26,
+      "url": "https://www.youtube.com/watch?v=JPtAUA9O7xo"
+    },
+    {
+      "videoId": "Y35QtGHoYu4",
+      "title": "3대 째 운영 중인 태국 족발 장인집! 현지인들이 줄 서 먹는 족발덮밥 '카오카무' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 27,
+      "url": "https://www.youtube.com/watch?v=Y35QtGHoYu4"
+    },
+    {
+      "videoId": "SC35veRULzE",
+      "title": "백종원도 감동한 태국의 소스들, 연어 샐러드와 돼지 항정살 튀김 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 28,
+      "url": "https://www.youtube.com/watch?v=SC35veRULzE"
+    },
+    {
+      "videoId": "ipxFyXDHdWs",
+      "title": "11시 이후의 태국에서만 먹을 수 있는 특별한 라면 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 29,
+      "url": "https://www.youtube.com/watch?v=ipxFyXDHdWs"
+    },
+    {
+      "videoId": "jXfAMAV5diw",
+      "title": "일본에 가면 꼭 먹어봐야 할 미친 마블링의 소고기 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 30,
+      "url": "https://www.youtube.com/watch?v=jXfAMAV5diw"
+    },
+    {
+      "videoId": "l9o9dMI8oFM",
+      "title": "일본 직장인들이 퇴근 후 맥주 한잔씩 걸치는 로컬 맛집, 꼬치구이 전문점 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 31,
+      "url": "https://www.youtube.com/watch?v=l9o9dMI8oFM"
+    },
+    {
+      "videoId": "BkVO3AWHNdI",
+      "title": "술이 술술 넘어가게 하는 술도둑 니꼬미! 백선생은 호? 불호? #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 32,
+      "url": "https://www.youtube.com/watch?v=BkVO3AWHNdI"
+    },
+    {
+      "videoId": "aP9ANA5eGwc",
+      "title": "연인과의 일본 여행에서 무조건 칭찬받는 법 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 33,
+      "url": "https://www.youtube.com/watch?v=aP9ANA5eGwc"
+    },
+    {
+      "videoId": "ki2t93jsCuc",
+      "title": "백종원이 끊임없이 강아지 신음소리 남발한 JMT 쓰키지 시장투어! #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 34,
+      "url": "https://www.youtube.com/watch?v=ki2t93jsCuc"
+    },
+    {
+      "videoId": "ogePPpNzHj0",
+      "title": "참치에 '이것'은 언제나 옳다 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 35,
+      "url": "https://www.youtube.com/watch?v=ogePPpNzHj0"
+    },
+    {
+      "videoId": "vXdua12fw3Y",
+      "title": "백종원 인생 최고의 오야코동 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 36,
+      "url": "https://www.youtube.com/watch?v=vXdua12fw3Y"
+    },
+    {
+      "videoId": "9uhuWdB8i0k",
+      "title": "진짜 맛있는 거 찾은 백종원 특) 흰 쌀밥시킴 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 37,
+      "url": "https://www.youtube.com/watch?v=9uhuWdB8i0k"
+    },
+    {
+      "videoId": "BpMRgHYHoEs",
+      "title": "메밀국수를 씹고 뜯고 맛보고 즐기는 3 STEP #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 38,
+      "url": "https://www.youtube.com/watch?v=BpMRgHYHoEs"
+    },
+    {
+      "videoId": "Xmr1s740IAc",
+      "title": "백종원이 인정한 버터+크림 조합? 게살 크림 크로켓 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 39,
+      "url": "https://www.youtube.com/watch?v=Xmr1s740IAc"
+    },
+    {
+      "videoId": "xtWIzfWWxOU",
+      "title": "한국인은 3단계부터? 한국인 취저 매운 라멘 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 40,
+      "url": "https://www.youtube.com/watch?v=xtWIzfWWxOU"
+    },
+    {
+      "videoId": "ANvBwArVsik",
+      "title": "하와이에 가면 꼭, 반드시, 무조건 먹어봐야 할 치킨 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 41,
+      "url": "https://www.youtube.com/watch?v=ANvBwArVsik"
+    },
+    {
+      "videoId": "exmDpf9FZJI",
+      "title": "초강력한 버터갈릭소스와 하와이안 통새우의 이중주 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 42,
+      "url": "https://www.youtube.com/watch?v=exmDpf9FZJI"
+    },
+    {
+      "videoId": "AJHOPoPc6u4",
+      "title": "몇 천 km 넘어 온 하와이에서 만난 깍두기 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 43,
+      "url": "https://www.youtube.com/watch?v=AJHOPoPc6u4"
+    },
+    {
+      "videoId": "0u7V5KXFKIU",
+      "title": "아무리 백종원씨라도 하와이안 피자는 좀; #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 44,
+      "url": "https://www.youtube.com/watch?v=0u7V5KXFKIU"
+    },
+    {
+      "videoId": "OGh-8IGqfec",
+      "title": "아침 세트 메뉴가 스테이크 + 써니 사이드 업인 곳 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 45,
+      "url": "https://www.youtube.com/watch?v=OGh-8IGqfec"
+    },
+    {
+      "videoId": "Timb7X59Hjk",
+      "title": "남태평양의 지상낙원, 하와이에서 펼쳐지는 참치 융단 폭격 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 46,
+      "url": "https://www.youtube.com/watch?v=Timb7X59Hjk"
+    },
+    {
+      "videoId": "UCl8ag2UcUc",
+      "title": "하와이에서만 먹을 수 있는 커피와 디저트의 조합 '말라사다, 코나커피' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 47,
+      "url": "https://www.youtube.com/watch?v=UCl8ag2UcUc"
+    },
+    {
+      "videoId": "GLV_4WSHQGQ",
+      "title": "백종원도 난처하게 한 맛? 무슨 맛인지 모를 하와이 전통 음식 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 48,
+      "url": "https://www.youtube.com/watch?v=GLV_4WSHQGQ"
+    },
+    {
+      "videoId": "wy-Z_rSnfTA",
+      "title": "백종원의 최애 하와이안 푸드 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 49,
+      "url": "https://www.youtube.com/watch?v=wy-Z_rSnfTA"
+    },
+    {
+      "videoId": "e9s5XCO6e7E",
+      "title": "하와이 어느 가게를 가도 평타는 치는 하와이 국민 음식 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 50,
+      "url": "https://www.youtube.com/watch?v=e9s5XCO6e7E"
+    },
+    {
+      "videoId": "vEqQUL31FtI",
+      "title": "땅 속에서 익힌 고기로 만든 에그 베네딕트 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 51,
+      "url": "https://www.youtube.com/watch?v=vEqQUL31FtI"
+    },
+    {
+      "videoId": "V_HxnWzI1Kg",
+      "title": "먹으면서도 계속 입맛을 돋우는 태국 음식의 완벽한 조합 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 52,
+      "url": "https://www.youtube.com/watch?v=V_HxnWzI1Kg"
+    },
+    {
+      "videoId": "m6OrtT8KCIc",
+      "title": "백종원이 골목에 들어온 이유는? 투박한 매력의 매운 생선 쌀국수 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 53,
+      "url": "https://www.youtube.com/watch?v=m6OrtT8KCIc"
+    },
+    {
+      "videoId": "YQXstVONsys",
+      "title": "한국에 호떡이 있다면 태국엔 로띠가 있다!! #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 54,
+      "url": "https://www.youtube.com/watch?v=YQXstVONsys"
+    },
+    {
+      "videoId": "q7jvWcQUeys",
+      "title": "스푸파에서 빼놓을 수 없는 시장 탐방, 먹거리 천지인 태국 시장 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 55,
+      "url": "https://www.youtube.com/watch?v=q7jvWcQUeys"
+    },
+    {
+      "videoId": "1ZmB9_5_aaI",
+      "title": "태국 왕가에서 아기를 만들기 위해 만들었던 음식 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 56,
+      "url": "https://www.youtube.com/watch?v=1ZmB9_5_aaI"
+    },
+    {
+      "videoId": "zbFNyeAqJkc",
+      "title": "태국의 맛을 알고 싶다면 그냥 이걸 드세요 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 57,
+      "url": "https://www.youtube.com/watch?v=zbFNyeAqJkc"
+    },
+    {
+      "videoId": "F6wWzwe4l_g",
+      "title": "태국인들이 좋아하는 것만 골라 만든 국수 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 58,
+      "url": "https://www.youtube.com/watch?v=F6wWzwe4l_g"
+    },
+    {
+      "videoId": "Urib6RV4ZZE",
+      "title": "매콤, 새콤, 달콤의 세 가지 맛이 어우러진 태국 남부식 카레 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 59,
+      "url": "https://www.youtube.com/watch?v=Urib6RV4ZZE"
+    },
+    {
+      "videoId": "I_S3zyMYMwg",
+      "title": "카레로 새우와 콩을 품다. 태국 음식 중에서도 독보적 영역의 요리, '사떠 팟 꿍' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 60,
+      "url": "https://www.youtube.com/watch?v=I_S3zyMYMwg"
+    },
+    {
+      "videoId": "Bn2GpaFeQhE",
+      "title": "돼지고기를 못 먹는 사람들을 위한 태국의 스페셜한 치킨 요리 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 61,
+      "url": "https://www.youtube.com/watch?v=Bn2GpaFeQhE"
+    },
+    {
+      "videoId": "uNCAYL79g-4",
+      "title": "한 편의 예술같은 태국 남부의 하이라이트, 해산물 요리 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 62,
+      "url": "https://www.youtube.com/watch?v=uNCAYL79g-4"
+    },
+    {
+      "videoId": "kh2Dks_aTnQ",
+      "title": "후쿠오카의 자랑거리 한 입 교자, 그 중에서도 단연 최고라 할 수 있는 이곳 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 63,
+      "url": "https://www.youtube.com/watch?v=kh2Dks_aTnQ"
+    },
+    {
+      "videoId": "3df92w-Ia0g",
+      "title": "백피셜) 돈코츠 라멘 고장 후쿠오카 중에서도 원조 of 원조 맛집 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 64,
+      "url": "https://www.youtube.com/watch?v=3df92w-Ia0g"
+    },
+    {
+      "videoId": "WLD7jcGk7XU",
+      "title": "백선생이 가는 시장은 뭐가 달라도 다르다? 내 입맛대로 골라먹는 '대학 덮밥' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 65,
+      "url": "https://www.youtube.com/watch?v=WLD7jcGk7XU"
+    },
+    {
+      "videoId": "u1OG20oYUGA",
+      "title": "상맛집 특) 메뉴 두 개 밖에 없음 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 66,
+      "url": "https://www.youtube.com/watch?v=u1OG20oYUGA"
+    },
+    {
+      "videoId": "Agzh4ZqhWmc",
+      "title": "후쿠오카 카레가 한국보다 찐하다?? 하나 하나가 조화로운 카레 정식 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 67,
+      "url": "https://www.youtube.com/watch?v=Agzh4ZqhWmc"
+    },
+    {
+      "videoId": "p90M2o1Y2es",
+      "title": "차원이 다른 고소함! 신선한 고등어만을 사용하는 고등어 회 & 구이 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 68,
+      "url": "https://www.youtube.com/watch?v=p90M2o1Y2es"
+    },
+    {
+      "videoId": "91mTzjF-pXk",
+      "title": "'닭한마리' 마니아라면 반드시 먹어봐야 할 후쿠오카의 닭고기 전골 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 69,
+      "url": "https://www.youtube.com/watch?v=91mTzjF-pXk"
+    },
+    {
+      "videoId": "szTwhdRf43U",
+      "title": "백종원도 '우마이' 연발시킨 이 조합... 절대 못 막습니다 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 70,
+      "url": "https://www.youtube.com/watch?v=szTwhdRf43U"
+    },
+    {
+      "videoId": "lFuHLNrsPWw",
+      "title": "천상의 조합, 명란구이 + 마요네즈 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 71,
+      "url": "https://www.youtube.com/watch?v=lFuHLNrsPWw"
+    },
+    {
+      "videoId": "pNCtZ0hDLPE",
+      "title": "일본의 집밥은 어떤 느낌일까? 현지에서 즐기는 후쿠오카 미소 가정식 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 72,
+      "url": "https://www.youtube.com/watch?v=pNCtZ0hDLPE"
+    },
+    {
+      "videoId": "GMqtev_H4ug",
+      "title": "백종원이 추천하는 후쿠오카 여행 종착역 카페 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 73,
+      "url": "https://www.youtube.com/watch?v=GMqtev_H4ug"
+    },
+    {
+      "videoId": "Ot2fErQVYRY",
+      "title": "백종원이 하얼빈에 와서 가장 먼저 들른 곳 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 74,
+      "url": "https://www.youtube.com/watch?v=Ot2fErQVYRY"
+    },
+    {
+      "videoId": "BMR9ozxW7XY",
+      "title": "중학생들이 한 번 구워 달라고 했다가 소문 나서 대박 난 간식 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 75,
+      "url": "https://www.youtube.com/watch?v=BMR9ozxW7XY"
+    },
+    {
+      "videoId": "Bg061UVOKs8",
+      "title": "하얼빈에서 즐기는 2000원의 행복! 입 안에 퍼지는 고소함의 향연 '건두부무침 & 소고기 두부탕' #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 76,
+      "url": "https://www.youtube.com/watch?v=Bg061UVOKs8"
+    },
+    {
+      "videoId": "D_hs6CCz7Y8",
+      "title": "찹쌀 가루가 들어가지 않는 찹쌀 탕수육 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 77,
+      "url": "https://www.youtube.com/watch?v=D_hs6CCz7Y8"
+    },
+    {
+      "videoId": "b7CWxShUixc",
+      "title": "카페라떼 아닙니다... #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 78,
+      "url": "https://www.youtube.com/watch?v=b7CWxShUixc"
+    },
+    {
+      "videoId": "d7Q-0zDJdD8",
+      "title": "백종원이 비행기에서부터 기대했다는 가게 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 79,
+      "url": "https://www.youtube.com/watch?v=d7Q-0zDJdD8"
+    },
+    {
+      "videoId": "AO091J6GI2w",
+      "title": "하얼빈의 100년 전통 만두 가게 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 80,
+      "url": "https://www.youtube.com/watch?v=AO091J6GI2w"
+    },
+    {
+      "videoId": "vK243dTRUY8",
+      "title": "백종원쌤 한국 음식 많이 그리웠구나... 쏸차이탕을 김치찌개로 개조하는 백종원쌤 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 81,
+      "url": "https://www.youtube.com/watch?v=vK243dTRUY8"
+    },
+    {
+      "videoId": "GIXy2-oO6mM",
+      "title": "예상이 가서 더 먹고 싶은 맛, 역 앞에 있는 맛집의 행복 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 82,
+      "url": "https://www.youtube.com/watch?v=GIXy2-oO6mM"
+    },
+    {
+      "videoId": "FDp5Uy8KZtE",
+      "title": "완벽한 맛! 하나하나 먹어도 맛있는 걸 싸먹으니 그저 맛없없 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 83,
+      "url": "https://www.youtube.com/watch?v=FDp5Uy8KZtE"
+    },
+    {
+      "videoId": "4dDicW2b3b0",
+      "title": "백종원도 받자마자 할 말을 잃은 美친 존재감의 생선찜 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 84,
+      "url": "https://www.youtube.com/watch?v=4dDicW2b3b0"
+    },
+    {
+      "videoId": "R2AC_KGlVfQ",
+      "title": "맛집 인증이 속출한 하얼빈 최고의 맛 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 85,
+      "url": "https://www.youtube.com/watch?v=R2AC_KGlVfQ"
+    },
+    {
+      "videoId": "vTG6PxKuOCQ",
+      "title": "푸드 무비의 선구자, 백종원과 제작진이 돌아왔다! 스트리트푸드파이터2 #스트리트푸드파이터",
+      "channelName": "tvN Joy",
+      "position": 86,
+      "url": "https://www.youtube.com/watch?v=vTG6PxKuOCQ"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs/_create_manifest.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs/_create_manifest.json
@@ -1,0 +1,66 @@
+{
+  "sunreiId": "SR01kyhwcx1w4n61ds2k99gc8ekt",
+  "sourceId": "SRC01kyhw8vq7ze5mry327y36vrwd",
+  "spots": [
+    {
+      "spotId": "SS01kyhwcx1yeawvj235zyh2anv2",
+      "videoId": "a687bvSmnSA",
+      "videoTitle": "현지보다 맛있는 미슐랭 쓰리 스타 프렌치 레스토랑🍽 고급 재료도 아낌없이 쓰는 싱가포르 Les Amis에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx203bkygmp1tt2bbs9e",
+      "videoId": "EoVwaCSbUs0",
+      "videoTitle": "한국인 입맛에도 딱 맞는 싱가포르 현지 맛집?👀 하이난 치킨 라이스, 싱가포르식 갈비탕 등 꼭 먹어야 하는 음식을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx216w1ab6dvy06ydtyr",
+      "videoId": "EoVwaCSbUs0",
+      "videoTitle": "한국인 입맛에도 딱 맞는 싱가포르 현지 맛집?👀 하이난 치킨 라이스, 싱가포르식 갈비탕 등 꼭 먹어야 하는 음식을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx23hrh0qb2m8w62x2ks",
+      "videoId": "EoVwaCSbUs0",
+      "videoTitle": "한국인 입맛에도 딱 맞는 싱가포르 현지 맛집?👀 하이난 치킨 라이스, 싱가포르식 갈비탕 등 꼭 먹어야 하는 음식을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx25jrqrg3xes22kwqft",
+      "videoId": "Xki66D97_mg",
+      "videoTitle": "싱가포르 최고의 광동식 중식당!🥢 겉바속촉 베이징 덕부터 최고급 랍스타까지 먹고 왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx26j6azpdpcxzr9ntv7",
+      "videoId": "Xki66D97_mg",
+      "videoTitle": "싱가포르 최고의 광동식 중식당!🥢 겉바속촉 베이징 덕부터 최고급 랍스타까지 먹고 왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx283wtv3wsw6cbxqcda",
+      "videoId": "TfBM6lmyCr0",
+      "videoTitle": "식욕을 자극하는 싱가포르 명물 음식 칠리 크랩!🦀 현지인들이 가는 칠리 크랩 맛집과 호커센터 맛집에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx2a1vb2b0ka8ghq5kha",
+      "videoId": "TfBM6lmyCr0",
+      "videoTitle": "식욕을 자극하는 싱가포르 명물 음식 칠리 크랩!🦀 현지인들이 가는 칠리 크랩 맛집과 호커센터 맛집에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx2c85zkwppcn5jybdyy",
+      "videoId": "iQZ68CeLpoI",
+      "videoTitle": "파격적인 비주얼의 피시 헤드 커리!🐟 맛과 개성을 모두 잡은 싱가포르 현지인 맛집에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx2e3rxt54axybpgbt2t",
+      "videoId": "iQZ68CeLpoI",
+      "videoTitle": "파격적인 비주얼의 피시 헤드 커리!🐟 맛과 개성을 모두 잡은 싱가포르 현지인 맛집에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx2f7ak0vpty6ygqa14n",
+      "videoId": "iQZ68CeLpoI",
+      "videoTitle": "파격적인 비주얼의 피시 헤드 커리!🐟 맛과 개성을 모두 잡은 싱가포르 현지인 맛집에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcx2hx2xc5ab3v7p942sn",
+      "videoId": "bvmge7Gv6U8",
+      "videoTitle": "미식의 천국 싱가포르의 전통 파인 다이닝?🍽 중국 요리법과 동남아 특유의 향신료가 접목된 개성있는 페라나칸 음식!"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs/locations.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs/locations.json
@@ -3,198 +3,179 @@
     {
       "videoId": "a687bvSmnSA",
       "title": "현지보다 맛있는 미슐랭 쓰리 스타 프렌치 레스토랑🍽 고급 재료도 아낌없이 쓰는 싱가포르 Les Amis에 다녀왔습니다!",
-      "concept": "싱가포르 미슐랭 3스타 프렌치 파인다이닝 레스토랑 방문기",
+      "concept": "1",
       "locations": [
         {
-          "name": "Les Amis",
-          "displayName": "레자미",
+          "name": "레자미",
           "address": "1 Scotts Rd, #01 - 16 Shaw Centre, Singapore 228208",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 1 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=a687bvSmnSA",
           "latitude": 1.3066019,
           "longitude": 103.83143609999999,
           "googleMapsId": "ChIJR5yDbY0Z2jER6GcsxL56OLk",
-          "googleMapsUri": "https://maps.google.com/?cid=13346552455466084328",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=a687bvSmnSA",
-          "description": "싱가포르 미슐랭 3스타 프렌치 파인다이닝을 소개하는 영상에서 방문한 레스토랑. 조엘 로뷔숑의 제자 셰프 세바스찬이 이끄는 곳으로, 현지보다 맛있다는 평가를 받으며 고급 재료를 아낌없이 사용하는 것이 특징이다."
+          "googleMapsUri": "https://maps.google.com/?cid=13346552455466084328&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "EoVwaCSbUs0",
       "title": "한국인 입맛에도 딱 맞는 싱가포르 현지 맛집?👀 하이난 치킨 라이스, 싱가포르식 갈비탕 등 꼭 먹어야 하는 음식을 소개합니다!",
-      "concept": "싱가포르 현지 맛집 투어 - 바쿠테, 프론미, 하이난 치킨 라이스",
+      "concept": "11",
       "locations": [
         {
-          "name": "Song Fa Bak Kut Teh",
-          "displayName": "송파 바쿠테 본점",
-          "address": "11 New Bridge Rd, #01-01, 싱가포르 059383",
-          "latitude": 1.2890099,
-          "longitude": 103.84769829999999,
-          "googleMapsId": "ChIJP1jDgAoZ2jER9XCcxNoXvcc",
-          "googleMapsUri": "https://maps.google.com/?cid=14392686212514869493",
-          "source": "description",
-          "timestamp": null,
+          "name": "11 New Bridge Rd, #01 01",
+          "address": "11 New Bridge Rd, #01 01 싱가포르 059383",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 11 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=EoVwaCSbUs0",
-          "description": "싱가포르 현지 맛집 투어를 소개하는 영상에서 방문한 바쿠테 전문점. 후추 베이스의 맑은 국물이 특징이며, 한국인 입맛에도 딱 맞는 싱가포르 대표 음식으로 영상에서 추천되었다."
+          "latitude": 1.2890131999999999,
+          "longitude": 103.84772219999999,
+          "googleMapsId": "EioxMSBOZXcgQnJpZGdlIFJkLCAjMDEgMDEsIFNpbmdhcG9yZSAwNTkzODMiIRofChYKFAoSCTnPC4AKGdoxEefNlVDU2fanEgUwMSAwMQ",
+          "googleMapsUri": "https://maps.google.com/?q=11+New+Bridge+Rd,+%2301+01,+Singapore+059383&ftid=0x31da190a800bcf39:0x78be54a2c37c1b2c&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Jalan Sultan Prawn Mee",
-          "displayName": "Jalan Sultan Prawn Mee",
+          "name": "2 Jln. Ayer",
           "address": "2 Jln. Ayer, Singapura 389141",
-          "latitude": 1.3111089999999999,
-          "longitude": 103.872773,
-          "googleMapsId": "ChIJYX-3IjQY2jERadH0LMeyM74",
-          "googleMapsUri": "https://maps.google.com/?cid=13705494659541029225",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 11 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=EoVwaCSbUs0",
-          "description": "싱가포르 현지 맛집 투어를 소개하는 영상에서 방문한 프론미(새우 국수) 전문점. 현지인들이 즐겨 찾는 곳으로, 꼭 먹어야 하는 싱가포르 음식 중 하나로 영상에서 소개되었다."
+          "latitude": 1.3110921,
+          "longitude": 103.87279339999999,
+          "googleMapsId": "ChIJP9d3PTQY2jERv1O_s6eJ3Wc",
+          "googleMapsUri": "https://maps.google.com/?cid=7484289509127836607&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Maxwell Food Centre",
-          "displayName": "맥스웰 푸드 센터",
+          "name": "1 Kadayanallur St",
           "address": "1 Kadayanallur St, 싱가포르 069184",
-          "latitude": 1.2803361,
-          "longitude": 103.844767,
-          "googleMapsId": "ChIJseQsTQ0Z2jERqpBTWF0Zf84",
-          "googleMapsUri": "https://maps.google.com/?cid=14879639582559932586",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 11 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=EoVwaCSbUs0",
-          "description": "싱가포르 현지 맛집 투어를 소개하는 영상에서 방문한 대표 호커센터. 하이난 치킨 라이스 등 다양한 현지 음식을 맛볼 수 있으며, 한국인 입맛에도 잘 맞는 음식들을 소개하는 코스 중 하나로 추천되었다."
+          "latitude": 1.2802419,
+          "longitude": 103.84490579999999,
+          "googleMapsId": "ChIJpTu4snIZ2jERz1NefLXjNP0",
+          "googleMapsUri": "https://maps.google.com/?cid=18245458358999864271&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "Xki66D97_mg",
       "title": "싱가포르 최고의 광동식 중식당!🥢 겉바속촉 베이징 덕부터 최고급 랍스타까지 먹고 왔습니다!",
-      "concept": "싱가포르 광동식 중식당 - 베이징 덕, 랍스터 등 고급 중식",
+      "concept": "290",
       "locations": [
         {
           "name": "Imperial Treasure Super Peking Duck",
-          "displayName": "Imperial Treasure Super Peking Duck",
           "address": "290 Orchard Rd, #05 - 42 / 45, 싱가포르 238859",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 290 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Xki66D97_mg",
           "latitude": 1.3034033999999999,
           "longitude": 103.835489,
           "googleMapsId": "ChIJye26KJIZ2jERQ-cRCW2All0",
-          "googleMapsUri": "https://maps.google.com/?cid=6743718697825855299",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Xki66D97_mg",
-          "description": "싱가포르 최고의 광동식 중식당을 소개하는 영상에서 방문한 고급 레스토랑. 오차드로드 파라곤 몰에 위치하며, 겉바속촉 베이징 덕부터 최고급 랍스터까지 다양한 고급 중식을 선보인다."
+          "googleMapsUri": "https://maps.google.com/?cid=6743718697825855299&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Lei Garden",
-          "displayName": "Lei Garden Restaurant (Chijmes)",
+          "name": "Lei Garden Restaurant",
           "address": "30 Victoria St, #01-24 차임스 싱가포르 187996",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 290 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Xki66D97_mg",
           "latitude": 1.2953183,
           "longitude": 103.8523584,
           "googleMapsId": "ChIJNfw8b6QZ2jERDj-WK2kAsPw",
-          "googleMapsUri": "https://maps.google.com/?cid=18208053745161748238",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Xki66D97_mg",
-          "description": "싱가포르 광동식 중식당을 소개하는 영상에서 방문한 홍콩 기반 미슐랭 스타 레스토랑. 차임스에 위치하며, 정통 광동식 요리와 함께 고급스러운 분위기를 즐길 수 있는 곳으로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=18208053745161748238&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "TfBM6lmyCr0",
       "title": "식욕을 자극하는 싱가포르 명물 음식 칠리 크랩!🦀 현지인들이 가는 칠리 크랩 맛집과 호커센터 맛집에 다녀왔습니다!",
-      "concept": "싱가포르 칠리크랩 & 페퍼크랩 맛집, 호커센터",
+      "concept": "462",
       "locations": [
         {
-          "name": "Hua Yu Wee",
-          "displayName": "후아 유 위 시푸드 레스토랑",
+          "name": "462 Upper E Coast Rd",
           "address": "462 Upper E Coast Rd, 싱가포르 466508",
-          "latitude": 1.3146801,
-          "longitude": 103.9414907,
-          "googleMapsId": "ChIJ0_d0Q8Yi2jER45_0U9L73fI",
-          "googleMapsUri": "https://maps.google.com/?cid=17500420607801860067",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 462 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=TfBM6lmyCr0",
-          "description": "싱가포르 칠리크랩과 페퍼크랩 맛집을 소개하는 영상에서 방문한 로컬 시푸드 레스토랑. 이스트코스트에 위치하며, 현지인들이 즐겨 찾는 칠리크랩과 페퍼크랩이 유명한 곳이다."
+          "latitude": 1.3145981000000002,
+          "longitude": 103.94153250000001,
+          "googleMapsId": "ChIJD-7pW8Yi2jERPkeMt1NTOyU",
+          "googleMapsUri": "https://maps.google.com/?cid=2682829622056077118&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Makansutra Gluttons Bay",
-          "displayName": "마칸수트라 글루턴스 베이",
-          "address": "8 Raffles Ave., #01-15 Esplanade Mall, 싱가포르 039802",
-          "latitude": 1.2894024000000002,
-          "longitude": 103.8568698,
-          "googleMapsId": "ChIJ7f__L20Z2jERt9btVig_DGw",
-          "googleMapsUri": "https://maps.google.com/?cid=7785667298306414263",
-          "source": "description",
-          "timestamp": null,
+          "name": "Esplanade Mall",
+          "address": "8 Raffles Ave., 싱가포르 039802",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 462 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=TfBM6lmyCr0",
-          "description": "싱가포르 칠리크랩과 호커센터 맛집을 소개하는 영상에서 방문한 야외 호커센터. 에스플러네이드 옆에 위치하며, 사테 등 싱가포르 대표 길거리 음식을 즐길 수 있는 곳이다."
+          "latitude": 1.28976,
+          "longitude": 103.8560406,
+          "googleMapsId": "ChIJg3Da6ssZ2jERH-1dbXrgOAE",
+          "googleMapsUri": "https://maps.google.com/?cid=88067009159228703&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "iQZ68CeLpoI",
       "title": "파격적인 비주얼의 피시 헤드 커리!🐟 맛과 개성을 모두 잡은 싱가포르 현지인 맛집에 다녀왔습니다!",
-      "concept": "싱가포르 현지인 맛집 - 피시헤드커리, 바쿠밍, 소야소스치킨",
+      "concept": "54",
       "locations": [
         {
-          "name": "The Banana Leaf Apolo",
-          "displayName": "The Banana Leaf Apolo",
+          "name": "54 Race Course Rd",
           "address": "54 Race Course Rd, 싱가포르 218564",
-          "latitude": 1.3083862,
-          "longitude": 103.85105639999999,
-          "googleMapsId": "ChIJO_NQTscZ2jERh4vyBNFILBU",
-          "googleMapsUri": "https://maps.google.com/?cid=1525674436340124551",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 54 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=iQZ68CeLpoI",
-          "description": "싱가포르 현지인 맛집을 소개하는 영상에서 방문한 리틀인디아의 인도 레스토랑. 파격적인 비주얼의 피시 헤드 커리가 시그니처 메뉴이며, 맛과 개성을 모두 잡은 곳으로 영상에서 극찬을 받았다."
+          "latitude": 1.3083852,
+          "longitude": 103.85105689999999,
+          "googleMapsId": "ChIJx14YTscZ2jERQA1Pj6M5LtY",
+          "googleMapsUri": "https://maps.google.com/?cid=15433336347692043584&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Hill Street Tai Hwa Pork Noodle",
-          "displayName": "Hill Street Tai Hwa Pork Noodle, Crawford Lane",
-          "address": "466 Crawford Ln, #01-12, 싱가포르 190466",
+          "name": "466 Crawford Ln, #01-12",
+          "address": "466 Crawford Ln, #01-12 Block 466, 싱가포르 190466",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 54 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=iQZ68CeLpoI",
           "latitude": 1.3051265,
           "longitude": 103.8625357,
-          "googleMapsId": "ChIJuYHZKrQZ2jERuAMG3qVN5pk",
-          "googleMapsUri": "https://maps.google.com/?cid=11089636507236303800",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=iQZ68CeLpoI",
-          "description": "싱가포르 현지인 맛집을 소개하는 영상에서 방문한 미슐랭 1스타 호커 스톨. 바쿠밍(돼지고기 국수)이 유명하며, 싱가포르를 대표하는 호커 음식으로 영상에서 소개되었다."
+          "googleMapsId": "ChIJ13nxK7QZ2jERmHZKNnHCWCI",
+          "googleMapsUri": "https://maps.google.com/?cid=2474941786738030232&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Hawker Chan",
-          "displayName": "Hawker Chan - Tai Seng Branch",
+          "name": "Sukiya Gyudon • Curry (18 Tai Seng)",
           "address": "18 Tai Seng St, #01-02, Singapore 539775",
-          "latitude": 1.3360036,
-          "longitude": 103.8887428,
-          "googleMapsId": "ChIJVVI3jJIX2jERYGIgy3EtBNU",
-          "googleMapsUri": "https://maps.google.com/?cid=15349443396747944544",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 54 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=iQZ68CeLpoI",
-          "description": "싱가포르 현지인 맛집을 소개하는 영상에서 방문한 소야소스 치킨라이스 전문 호커 스톨. 미슐랭 스타를 받은 것으로 유명하며, 저렴한 가격에 수준 높은 치킨라이스를 맛볼 수 있다."
+          "latitude": 1.3360314,
+          "longitude": 103.8885832,
+          "googleMapsId": "ChIJnYo7ZZ0X2jERPZL6vFKxJL0",
+          "googleMapsUri": "https://maps.google.com/?cid=13629213341245936189&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "bvmge7Gv6U8",
       "title": "미식의 천국 싱가포르의 전통 파인 다이닝?🍽 중국 요리법과 동남아 특유의 향신료가 접목된 개성있는 페라나칸 음식!",
-      "concept": "싱가포르 페라나칸 파인다이닝 - 미슐랭 스타 레스토랑",
+      "concept": "17a",
       "locations": [
         {
-          "name": "Candlenut",
-          "displayName": "Candlenut",
+          "name": "17a Dempsey Rd",
           "address": "17a Dempsey Rd, 싱가포르 249676",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 17a 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bvmge7Gv6U8",
           "latitude": 1.3058022,
           "longitude": 103.81009499999999,
-          "googleMapsId": "ChIJ5ySHC3IZ2jERu-xiMMTjAVE",
-          "googleMapsUri": "https://maps.google.com/?cid=5837197023813758139",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bvmge7Gv6U8",
-          "description": "싱가포르 페라나칸 파인다이닝을 소개하는 영상에서 방문한 세계 최초 미슐랭 스타 페라나칸 레스토랑. 뎀시힐에 위치하며, 중국 요리법과 동남아 향신료가 접목된 개성 있는 전통 음식을 선보인다."
+          "googleMapsId": "ChIJuxQn1SIa2jERVDVna9OzpTo",
+          "googleMapsUri": "https://maps.google.com/?cid=4225981545978475860&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "zBFfSWln0Co",
+      "title": "\"홍콩 미슐랭보다 훨씬 낫네\" 2스타 셰프가 작정하고 만든 역대급 중식 코스 | Cherry Garden",
+      "concept": "5",
+      "locations": [
+        {
+          "name": "Cherry Garden by Chef Fei",
+          "address": "5 Raffles Ave., Floor 5, 싱가포르 039797",
+          "description": "Cherry Garden by Chef Fei — 비밀이야 in 한국 영상에서 소개한 5 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zBFfSWln0Co",
+          "latitude": 1.2906908,
+          "longitude": 103.858311,
+          "googleMapsId": "ChIJ8wanXKgZ2jERg2Arsgtf_W8",
+          "googleMapsUri": "https://maps.google.com/?cid=8069710611156263043&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     }

--- a/.claude/workspace/youtube/PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs/video_info.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs/video_info.json
@@ -1,0 +1,67 @@
+{
+  "type": "playlist",
+  "id": "PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs",
+  "title": "비밀이야 in 싱가포르🍽",
+  "description": "",
+  "url": "https://www.youtube.com/playlist?list=PLkmBZE3qxSdE1XFNY0NiK_-MY4eUtkHJs",
+  "channelName": "비밀이야 bimirya",
+  "channel": {
+    "id": "UCaKQ7_GT0k8u_sL0nE2tgkA",
+    "title": "비밀이야 bimirya",
+    "handle": "@bimirya",
+    "url": "https://www.youtube.com/@bimirya",
+    "description": "먹자! 마시자! 놀러 다니자!\n\n🍕 비즈니스 문의 : bimiryabdr@naver.com\n🍷 인스타그램 : www.instagram.com/bimirya\n🥪 네이버 블로그 : blog.naver.com/mardukas\n",
+    "thumbnailUrl": "https://yt3.ggpht.com/xTnhjCg0_h3Qdsy7Ar2B8AM8150MF0v-_CkRyCwRz6AK4-ZGEZVjYtWViSy6_9uxal7v1rHJKA=s800-c-k-c0x00ffffff-no-rj"
+  },
+  "selectedVideos": [
+    {
+      "videoId": "a687bvSmnSA",
+      "title": "현지보다 맛있는 미슐랭 쓰리 스타 프렌치 레스토랑🍽 고급 재료도 아낌없이 쓰는 싱가포르 Les Amis에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 0,
+      "url": "https://www.youtube.com/watch?v=a687bvSmnSA"
+    },
+    {
+      "videoId": "EoVwaCSbUs0",
+      "title": "한국인 입맛에도 딱 맞는 싱가포르 현지 맛집?👀 하이난 치킨 라이스, 싱가포르식 갈비탕 등 꼭 먹어야 하는 음식을 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 1,
+      "url": "https://www.youtube.com/watch?v=EoVwaCSbUs0"
+    },
+    {
+      "videoId": "Xki66D97_mg",
+      "title": "싱가포르 최고의 광동식 중식당!🥢 겉바속촉 베이징 덕부터 최고급 랍스타까지 먹고 왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 2,
+      "url": "https://www.youtube.com/watch?v=Xki66D97_mg"
+    },
+    {
+      "videoId": "TfBM6lmyCr0",
+      "title": "식욕을 자극하는 싱가포르 명물 음식 칠리 크랩!🦀 현지인들이 가는 칠리 크랩 맛집과 호커센터 맛집에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 3,
+      "url": "https://www.youtube.com/watch?v=TfBM6lmyCr0"
+    },
+    {
+      "videoId": "iQZ68CeLpoI",
+      "title": "파격적인 비주얼의 피시 헤드 커리!🐟 맛과 개성을 모두 잡은 싱가포르 현지인 맛집에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 4,
+      "url": "https://www.youtube.com/watch?v=iQZ68CeLpoI"
+    },
+    {
+      "videoId": "bvmge7Gv6U8",
+      "title": "미식의 천국 싱가포르의 전통 파인 다이닝?🍽 중국 요리법과 동남아 특유의 향신료가 접목된 개성있는 페라나칸 음식!",
+      "channelName": "비밀이야 bimirya",
+      "position": 5,
+      "url": "https://www.youtube.com/watch?v=bvmge7Gv6U8"
+    },
+    {
+      "videoId": "zBFfSWln0Co",
+      "title": "\"홍콩 미슐랭보다 훨씬 낫네\" 2스타 셰프가 작정하고 만든 역대급 중식 코스 | Cherry Garden",
+      "channelName": "비밀이야 bimirya",
+      "position": 6,
+      "url": "https://www.youtube.com/watch?v=zBFfSWln0Co"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF/_create_manifest.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF/_create_manifest.json
@@ -1,0 +1,851 @@
+{
+  "sunreiId": "SR01kyhxg7bhjyxt4xj9semgvbhv",
+  "sourceId": "SRC01kyhw8vq7ze5mry327y36vrwd",
+  "spots": [
+    {
+      "spotId": "SS01kyhxg7r75505m5d6en30gjr5",
+      "videoId": "KPXQuyz9j3Y",
+      "videoTitle": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕..."
+    },
+    {
+      "spotId": "SS01kyhxg7r8af7n6qwygre8dyj0",
+      "videoId": "KPXQuyz9j3Y",
+      "videoTitle": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕..."
+    },
+    {
+      "spotId": "SS01kyhxg7r9581x78chdn3hrhey",
+      "videoId": "KPXQuyz9j3Y",
+      "videoTitle": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕..."
+    },
+    {
+      "spotId": "SS01kyhxg7j0h56e9nbsbemsgh9v",
+      "videoId": "KPXQuyz9j3Y",
+      "videoTitle": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕..."
+    },
+    {
+      "spotId": "SS01kyhxg7r3fz2w3wtm1tmvecam",
+      "videoId": "KPXQuyz9j3Y",
+      "videoTitle": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕..."
+    },
+    {
+      "spotId": "SS01kyhxg7r4pm7n55wdkqanrvzk",
+      "videoId": "KPXQuyz9j3Y",
+      "videoTitle": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕..."
+    },
+    {
+      "spotId": "SS01kyhxg7c7f2ehccvemx7fk9vj",
+      "videoId": "KPXQuyz9j3Y",
+      "videoTitle": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕..."
+    },
+    {
+      "spotId": "SS01kyhxg7c9abk4mspr3pwbzfec",
+      "videoId": "_0uZEIemhlY",
+      "videoTitle": "공무원들만 몰래 가던 찐맛집🤫1만 원대 전국구 아구지리 (현지인 성지) | 대구 이방인횟집"
+    },
+    {
+      "spotId": "SS01kyhxg7cate78k5pwg3wej003",
+      "videoId": "vOB8Km0yvys",
+      "videoTitle": "가성비 1등! 세월이 검증한 서울대입구 곱창집 (지금 가셔야 합니다) | 신기루황소곱창구이"
+    },
+    {
+      "spotId": "SS01kyhxg7cc75g2mevhn8ce03rr",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7cd24ca2agd2s1mhzjw",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7cfj0hzd7yvfmzjqt20",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7cg2vhebhkqhmj7mvty",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7chjtet7eqywtxwckp0",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7ckc0cqq3enbt5t8r9j",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7cmb1prjhfqewf03bn1",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7cn0b891s414rp2z9ed",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7cqedrb4ayhemw9md6p",
+      "videoId": "SwKN0nERUHc",
+      "videoTitle": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌..."
+    },
+    {
+      "spotId": "SS01kyhxg7crdx3dhj3r8ta31zfz",
+      "videoId": "1ggSZsIoFPg",
+      "videoTitle": "마 이게 아구다! 해장 술을 부르는 부산 해장 절대강자 | 김해식당"
+    },
+    {
+      "spotId": "SS01kyhxg7csmnx2s2wq3p5ns92y",
+      "videoId": "1_uPaoNfaig",
+      "videoTitle": "부산 해장 무조건 여깁니다. 20년 다닌 1만 원대 또또또또간집 | 아저씨대구탕"
+    },
+    {
+      "spotId": "SS01kyhxg7cvp2pmzthv58s0gjbt",
+      "videoId": "kq0fq6wtrbg",
+      "videoTitle": "[EN]워크숍 또 가자는 직원들...🌊비밀이야의 속초 모음zip | 각두골, 당근마차, 춘선네, 동명항, 용바위식당"
+    },
+    {
+      "spotId": "SS01kyhxg7cw50qqsxwmse4rcdhp",
+      "videoId": "kq0fq6wtrbg",
+      "videoTitle": "[EN]워크숍 또 가자는 직원들...🌊비밀이야의 속초 모음zip | 각두골, 당근마차, 춘선네, 동명항, 용바위식당"
+    },
+    {
+      "spotId": "SS01kyhxg7cxcjxexryh205dawap",
+      "videoId": "kq0fq6wtrbg",
+      "videoTitle": "[EN]워크숍 또 가자는 직원들...🌊비밀이야의 속초 모음zip | 각두골, 당근마차, 춘선네, 동명항, 용바위식당"
+    },
+    {
+      "spotId": "SS01kyhxg7cz45jx7t4622ya2fmb",
+      "videoId": "kq0fq6wtrbg",
+      "videoTitle": "[EN]워크숍 또 가자는 직원들...🌊비밀이야의 속초 모음zip | 각두골, 당근마차, 춘선네, 동명항, 용바위식당"
+    },
+    {
+      "spotId": "SS01kyhxg7e1k36nrjqs0wm4s0q5",
+      "videoId": "kq0fq6wtrbg",
+      "videoTitle": "[EN]워크숍 또 가자는 직원들...🌊비밀이야의 속초 모음zip | 각두골, 당근마차, 춘선네, 동명항, 용바위식당"
+    },
+    {
+      "spotId": "SS01kyhxg7e3j607ydxwfmrhtf79",
+      "videoId": "axj_gYyPeUg",
+      "videoTitle": "6.25 전쟁도 겪은 부산 중식당😲 비밀이야가 유튜브 초창기부터 꾸준히 찾는 화상의 맛 (feat. 비밀이야가 많이 받는 DM은?)[EN]ㅣ동화반점"
+    },
+    {
+      "spotId": "SS01kyhxg7e4ehf9qh78nh5sxem8",
+      "videoId": "9gwbNOTVTao",
+      "videoTitle": "인생 안심? 비밀이야의 인생 안창살을 만난 한우 노포집[EN]ㅣ뜨락"
+    },
+    {
+      "spotId": "SS01kyhxg7e6qczwc4q97md5fyad",
+      "videoId": "tPlWG3n6zu0",
+      "videoTitle": "제주 고급 생선을 제대로 만나볼 수 있는 횟집🎣오래 전부터 미식가를 불러 모으던 그 곳에 방문했습니다[EN]ㅣ남경미락"
+    },
+    {
+      "spotId": "SS01kyhxg7e8g9hy9vwtn09cyyb7",
+      "videoId": "enXrget-zXk",
+      "videoTitle": "거부할 수 없는 푸짐한 거부갈비! 비밀이야가 인정한 제주도 맛집 추천🌟"
+    },
+    {
+      "spotId": "SS01kyhxg7e9cdc9sz00pcy9ckh6",
+      "videoId": "dn8OVfxevug",
+      "videoTitle": "한국인이 가장 좋아하는 맛은 직화맛? 볏짚 폼 미쳤다;; 웨이팅 어마무시한 서울 몽탄이 각잡고 제주로 내려가면 일어나는 일"
+    },
+    {
+      "spotId": "SS01kyhxg7ea1b8n3q0xp604k26s",
+      "videoId": "wt-HmPcECb8",
+      "videoTitle": "점심 스시 오마카세 추천! 70만원 쓰고 갔던 유일한 오너 셰프의 스시집🍣[EN]ㅣ스시 시미즈"
+    },
+    {
+      "spotId": "SS01kyhxg7ec5zjt0fkgh4qs9wb2",
+      "videoId": "g0Bwr7KN0_M",
+      "videoTitle": "슬슬 더워지는 날씨에 생각나는 미나리 삼겹살 + 화이트와인 조합이 극락인 이유🥓🍾[EN]ㅣ압구정 진주"
+    },
+    {
+      "spotId": "SS01kyhxg7edp00984x8mpwgmmz7",
+      "videoId": "wSYzoXXsF6o",
+      "videoTitle": "대표가 까주는 새우는 과연 맛있을까? 직원들과 10년차 단골집 방문! 속초의 밤은 이곳에서🌃ㅣ당근마차"
+    },
+    {
+      "spotId": "SS01kyhxg7ee5sednext7s8faxch",
+      "videoId": "cFnpvr2tEY4",
+      "videoTitle": "남자분들 주목 👀 국내 최고 돈카츠 맛집은? 생맥주와 말이 필요 없는 극락 조합 🍺ㅣ고성 보배진"
+    },
+    {
+      "spotId": "SS01kyhxg7efmykcfjwyae5hzyn3",
+      "videoId": "PKALkw1k3bE",
+      "videoTitle": "한국 다이닝에서 볼 수 없었던 메뉴! 더욱 독창적인 퍼포먼스로 돌아온 최현석 셰프님의 쵸이닷[EN]ㅣ쵸이닷"
+    },
+    {
+      "spotId": "SS01kyhxg7egha4j9wdg2j20njqy",
+      "videoId": "Y0sW9mpcIN0",
+      "videoTitle": "프랑스보다 더 프랑스같은 맛과 코스를 경험하고 싶다면? 직원들 함박웃음 짓게 한 비밀이야 최애 프렌치 레스토랑 그리고 Krug [EN]ㅣ레스쁘아"
+    },
+    {
+      "spotId": "SS01kyhxg7ej98xzpqyw4wesewsp",
+      "videoId": "GCOP8UPWkIo",
+      "videoTitle": "노량진 수산시장에서 모듬회 장르를 개척한 30년차 횟집! 돈이 줄줄세는 줄줄세트🐠 ㅣ더형제 강남"
+    },
+    {
+      "spotId": "SS01kyhxg7ekkfper7sd70mfn12c",
+      "videoId": "JhphrHU6mXg",
+      "videoTitle": "미남직원들과 함께한 회식ㅣ손흥민 드리블급인 셰프님의 오마카세ㅣ키라메키 [EN]"
+    },
+    {
+      "spotId": "SS01kyhxg7emsvma00909qe05w4c",
+      "videoId": "429mYqmcqQU",
+      "videoTitle": "1년에 한번 귀한 와인을 갖고 모이는 디너 생일 파티 🎉ㅣ아시아 베스트 50 의 주목해야 할 레스토랑ㅣ톡톡 [EN]"
+    },
+    {
+      "spotId": "SS01kyhxg7enj6128p4wvtwszyhk",
+      "videoId": "1GisLCTWmn0",
+      "videoTitle": "이건 평범한 오마카세가 아닙니다 [EN]ㅣ본앤브레드"
+    },
+    {
+      "spotId": "SS01kyhxg7epzyt35m5w69agmagp",
+      "videoId": "tHjfeQyMpM0",
+      "videoTitle": "여성 셰프님이어서 나오는 섬세한 포인트✨ 창덕궁과 창경궁뷰의 식사[EN]ㅣ더그린테이블"
+    },
+    {
+      "spotId": "SS01kyhxg7r5jkqvn095zj4knkxw",
+      "videoId": "BEZ73zUcII0",
+      "videoTitle": "인당 55만원씩 내고 대관해 버린 연말 회식 스케일?![EN]ㅣ스시하네"
+    },
+    {
+      "spotId": "SS01kyhxg7erygqg4zz9nakexm4p",
+      "videoId": "zOTWRUw_jY4",
+      "videoTitle": "여긴 이전하기 전에 가보셔야 합니다. 새로움의 연속, 꼭 보여드리고 싶은 맛!ㅣ강민철 레스토랑 [EN]"
+    },
+    {
+      "spotId": "SS01kyhxg7esnmj5ywyvjp818q51",
+      "videoId": "iOPYW2RmXL4",
+      "videoTitle": "서울 한복판에 제대로 궁중 한옥에서 대접해 주는 고급 다이닝이 있다? 핫플 예고된 식당ㅣ한국의집 [EN]"
+    },
+    {
+      "spotId": "SS01kyhxg7etfwkyvpnf70bx0dgz",
+      "videoId": "M9cZIA6V3Sg",
+      "videoTitle": "더욱 업그레이드 되어 돌아온 모던 한식의 선두주자 [EN]ㅣ밍글스"
+    },
+    {
+      "spotId": "SS01kyhxg7ewqh1z70n6yq194gmc",
+      "videoId": "v3X8Tpppy78",
+      "videoTitle": "[EN]한남 루프탑뷰가 이렇게 좋았나✨(데이트 코스로 강추) 계절마다 메뉴와 인테리어 컨셉이 변하는 이곳! l 쿡투게더한남"
+    },
+    {
+      "spotId": "SS01kyhxg7fcm0w767sma6wkydmj",
+      "videoId": "ULGt59R11w0",
+      "videoTitle": "[EN]사장님 말투가 너무 고급져요👨‍🍳 클래식 프렌치 레스토랑의 끝판왕ㅣ화이트크리스마스"
+    },
+    {
+      "spotId": "SS01kyhxg7fd3r7tcne8wces8wsz",
+      "videoId": "eUuVmF5NFk8",
+      "videoTitle": "[EN] 한국인이라면 못참는 흰쌀밥+고추장불고기+냉면 조합🤤ㅣ편집하다 침샘 폭발한 곳💦ㅣ현구3대 원조불고기"
+    },
+    {
+      "spotId": "SS01kyhxg7ff5egm05fahnd7xkbr",
+      "videoId": "tJOJzWB94So",
+      "videoTitle": "[EN] 점심 따로 먹으라 해도 따라오는 직원들 (feat.피리부는 비밀이야)ㅣ면서울"
+    },
+    {
+      "spotId": "SS01kyhxg7fg7aw97h5hne5qank3",
+      "videoId": "a2g7UPH2opU",
+      "videoTitle": "[EN] 청담동의 미슐랭 원스타&아시아 대표 레스토랑!! 이 음식을 이렇게 조합한다고..?ㅣ세븐스도어"
+    },
+    {
+      "spotId": "SS01kyhxg7fjzqbhzrmgk8pa6z7a",
+      "videoId": "PWIjDmYEjO4",
+      "videoTitle": "[EN] 여성 구독자와의 우연한 첫만남..?!🙊ㅣ무오키"
+    },
+    {
+      "spotId": "SS01kyhxg7fk2z3gyr7zc1adnvxs",
+      "videoId": "bcbosOeLIXk",
+      "videoTitle": "[EN] 살살 녹는 닭꼬치ㅣ한국에서 찾기 힘든 야키토리 맛집!!ㅣ야키토리해공"
+    },
+    {
+      "spotId": "SS01kyhxg7fmsqnhpxy1vjrarkmk",
+      "videoId": "H33H-4ei9sw",
+      "videoTitle": "(EN) 한우를 드라이에이징한 낯선 스테이크의 맛은 어떨까? l 본앤브레드"
+    },
+    {
+      "spotId": "SS01kyhxg7fnpnjwv28k9tbt0q4n",
+      "videoId": "1KNVmLD0PF8",
+      "videoTitle": "(EN) 기대 안하고 갔다가 깜짝 놀란 부산의 베이징 덕!🍗 겉도 윤기 좔좔 흐르기 어려운데.. ㅣ부우사안"
+    },
+    {
+      "spotId": "SS01kyhxg7fqvrgvrcwefewqrad7",
+      "videoId": "Pqb9y00bJDM",
+      "videoTitle": "(EN) 돼지고기 껍데기에 전통주를 온더락🥃으로? 제대로 즐기는 법!! (여름이었다🐷)ㅣ금돼지식당"
+    },
+    {
+      "spotId": "SS01kyhxg7frxqzhahy83w4h3skg",
+      "videoId": "bzzkH6OusXs",
+      "videoTitle": "(EN) 여름이니까 스태민어 코스의 매력에 빠져보자🎣 전복,소라,골뱅이,문어,새우,개불,해삼,옥돔,낚지볶음까지.. ㅣ 더형제"
+    },
+    {
+      "spotId": "SS01kyhxg7fsp9je7bt3wknb1j67",
+      "videoId": "DS8PwEMtE80",
+      "videoTitle": "(EN) 한국 파인 다이닝의 미래는 어떻게 될까? 무명이었을 때부터 25만원에 판매해 성공할 수 있었던 비결ㅣ솔밤"
+    },
+    {
+      "spotId": "SS01kyhxg7ftdt25x60r2nz808d8",
+      "videoId": "GPtli8Gaxek",
+      "videoTitle": "(EN) 국물이 시원하다고 느끼는 이유가 뭘까? 서울에 분점차리고 싶은 끝판왕 대구탕ㅣ아저씨대구탕"
+    },
+    {
+      "spotId": "SS01kyhxg7fv04y8kcyd5fh2wkkb",
+      "videoId": "CoyATC7Y-5o",
+      "videoTitle": "(EN) 영국 음식을 서울시청 근처에서 맛보자! | 플레눼"
+    },
+    {
+      "spotId": "SS01kyhxg7fwvx64je3hen41byrv",
+      "videoId": "DvfNL6Z43Jc",
+      "videoTitle": "(EN) 가게 오픈할 때부터 즐겨 먹었던 단골집 | 화상손만두"
+    },
+    {
+      "spotId": "SS01kyhxg7fxwgahz1tbexa7yjrk",
+      "videoId": "K_pcS_MI0zA",
+      "videoTitle": "(EN) 신경을 살려서 회를 썰고, 그 위에 캐비아를 올린🐙 | 셀렉트 구르메"
+    },
+    {
+      "spotId": "SS01kyhxg7fy5dszjpxsj115bbx5",
+      "videoId": "ycMAjic-ABc",
+      "videoTitle": "(EN) 시청자曰 \"제가 갔을 땐 이런 참치 없던데요?\" | 더 형제"
+    },
+    {
+      "spotId": "SS01kyhxg7g0hp101tcd841tr807",
+      "videoId": "D1WBB86yL08",
+      "videoTitle": "(EN) 장어 안 좋아하는 사람도 봐야됨 | 영동장어"
+    },
+    {
+      "spotId": "SS01kyhxg7g15r44qybb9dn751qq",
+      "videoId": "DhueGoWfuMU",
+      "videoTitle": "(EN) 이 날 먹은 와인 값이 차 한 대 값...? | 밍글스"
+    },
+    {
+      "spotId": "SS01kyhxg7g2gcsvvwfhftxrnq83",
+      "videoId": "Le88HtJ0kIk",
+      "videoTitle": "신화 이민우와 함께 맛본 튀김 오마카세🍤"
+    },
+    {
+      "spotId": "SS01kyhxg7g3fekfc2w1wfvzk9t9",
+      "videoId": "JcbR__2GISI",
+      "videoTitle": "비밀曰 \"이곳이 물건만큼은 확실하다\""
+    },
+    {
+      "spotId": "SS01kyhxg7h4kn381cfahjg1r759",
+      "videoId": "RZjCiWBmEHE",
+      "videoTitle": "울릉도로 오세요🌊"
+    },
+    {
+      "spotId": "SS01kyhxg7h5aj0h75zhfyhrr4dr",
+      "videoId": "RZjCiWBmEHE",
+      "videoTitle": "울릉도로 오세요🌊"
+    },
+    {
+      "spotId": "SS01kyhxg7h6j8hy5k6tr9z19wd1",
+      "videoId": "RZjCiWBmEHE",
+      "videoTitle": "울릉도로 오세요🌊"
+    },
+    {
+      "spotId": "SS01kyhxg7h815fnpt5qzh19hkjh",
+      "videoId": "OudlvfCD8sU",
+      "videoTitle": "일반인들은 맛볼 수 없는 울릉도 숨은 맛집🤫"
+    },
+    {
+      "spotId": "SS01kyhxg7h96vcytcjy7zqczw9b",
+      "videoId": "FlNpHNgIrBI",
+      "videoTitle": "대한민국에서 가장 비싼 숙소와 최고의 음식 퀄리티👍"
+    },
+    {
+      "spotId": "SS01kyhxg7ha1ky15mr3mpvvtggr",
+      "videoId": "5kb-BAzKrCo",
+      "videoTitle": "이번 컨셉은 '고려시대'라고 합니다"
+    },
+    {
+      "spotId": "SS01kyhxg7hcd9830tdmw19e4she",
+      "videoId": "bS6q_NZrdZg",
+      "videoTitle": "독일 원스타 찍어 누르는 삼성동 레스토랑"
+    },
+    {
+      "spotId": "SS01kyhxg7hdtfc4szyakbe258j8",
+      "videoId": "oXxLuTlqyso",
+      "videoTitle": "홍어 삭히지 않아도 맛있습니다"
+    },
+    {
+      "spotId": "SS01kyhxg7hf26x8cya9f5jy6dp9",
+      "videoId": "o-ZzOkoFo2I",
+      "videoTitle": "이제 닭 요리 하면 이 집밖에 떠오르지 않습니다"
+    },
+    {
+      "spotId": "SS01kyhxg7hjb9gbf66pg46y6kj9",
+      "videoId": "bN3yTHwDlUE",
+      "videoTitle": "국적, 장르에 구애받지 않는 비범한 퓨전 한식집!"
+    },
+    {
+      "spotId": "SS01kyhxg7hkpjffkjg91jsd6v78",
+      "videoId": "PlI-YPpsj0c",
+      "videoTitle": "여기는 무조건 가보셔야 합니다. 청파동의 자랑, 화상중식당 정!"
+    },
+    {
+      "spotId": "SS01kyhxg7hmp81jm2gdqxsfr6vc",
+      "videoId": "FFX5Kjqwmqw",
+      "videoTitle": "고기 퀄 1등 냉동삼겹살 집?! 순두부찌개랑 후식 볶음밥까지 완벽한 K-냉삼코스 ⭐️"
+    },
+    {
+      "spotId": "SS01kyhxg7hp6x1zjwwtd5mva117",
+      "videoId": "5N6c1lWDGlA",
+      "videoTitle": "프라이빗한 룸에서 즐기는 최고급 파인다이닝"
+    },
+    {
+      "spotId": "SS01kyhxg7hq23zaenre3nx1fvhm",
+      "videoId": "9Mv-0wckp_4",
+      "videoTitle": "선지와 고기를 듬뿍 넣은 국밥계의 최고봉!🥘 해장하러 갔다가 술 마시고 온다는 달래해장에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7hrkgv7axbtgy8an5gd",
+      "videoId": "GyE6P3C0bbs",
+      "videoTitle": "현지에도 없는 전설의 와인?🍷 파스타와 와인에 진심인 이탈리안 레스토랑, 압구정 몽고네에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7htzzzdbt1enemkygf6",
+      "videoId": "zM5v9W65TME",
+      "videoTitle": "놀라운 풍미의 숙성 돼지고기!🥩 솥뚜껑에 고기를 구워 먹는 마포 월화식당에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7hx1nhs1j4ncf6h33jh",
+      "videoId": "-6f9apDerjQ",
+      "videoTitle": "세계 최고 고기 전문가의 한우 코스 요리?🥩 다리오 체키니x본앤브레드 갈라 디너에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7hyk5b2b2766qpskmer",
+      "videoId": "YJRJmb4MCBg",
+      "videoTitle": "3만원 대에 즐기는 고퀄리티 스시 오마카세🍣 엄청난 경쟁률의 '스강신청'을 뚫고 아루히에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7hzhpba8qk3ewswdyp8",
+      "videoId": "buWff5isJ6k",
+      "videoTitle": "현대적으로 풀어낸 K-파인다이닝🍽 전복 & 칡소 밀푀유, 봄나물 플레이트 등 정성스럽고 독창적인 요리들을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7j2msw0s2azt4mdwm1n",
+      "videoId": "V5apja-6ibk",
+      "videoTitle": "한식과 프렌치 다이닝의 만남!🍴 극찬할 수밖에 없는 컨템포러리 레스토랑 임프레션에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7j3yqfsjs3d3qywhf56",
+      "videoId": "sky7MJvlLg0",
+      "videoTitle": "맛과 재료에 대한 장인 정신으로 미슐랭 스타를 받은 식당?⭐ 최고의 식재료로 구성된 독창적인 다이닝, 윤서울에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7j45c88e0pgvfxaqr4f",
+      "videoId": "GZk8D24XmUs",
+      "videoTitle": "70년 전통의 부산 원조 양대창🥢 현지인도 인정한 부산 옛날오막집에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jfp3ystdycn8pp4adw",
+      "videoId": "RMvBBd4hf9c",
+      "videoTitle": "최고의 재료로 선보이는 고급 튀김 오마카세!🍤 일식 덴푸라의 정점, 모퉁이우 덴푸라랩에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jgg71rg9e1djn8bx4h",
+      "videoId": "MoKj7rr_y18",
+      "videoTitle": "한식 파인 다이닝의 정수🍽 청담동에서 핫한 셰프님의 레스토랑에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jjqcekj6nh394j0gdb",
+      "videoId": "y7IYTEl5lok",
+      "videoTitle": "한우 ++ 채끝살을 11개월 숙성한 밀랍 에이징 스테이크🥩 독특한 그릴 방식의 숙성 스테이크 끝판왕 레스토랑에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jkb3nwc3jmf2s4xav9",
+      "videoId": "qxbRusRriwU",
+      "videoTitle": "투플러스 한우만 나오는 압구정 명품 오마카세🥩 예약이 전쟁이라는 이속우화 천공에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jn0j7gyd3f0x7rpqd2",
+      "videoId": "Rgsb9S3PNSA",
+      "videoTitle": "🍖살살 녹는 동파육과 해삼주스 등 중국 본토의 맛 그대로 재현한 고급 중식당 계향각에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jphbqe9paf887xbvnd",
+      "videoId": "816WnjDFVf4",
+      "videoTitle": "26만원짜리 고급 한식 다이닝 코스?!🍽 미슐랭 3스타, 한국을 대표하는 식당 중 하나인 가온에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jq8ym27dt54j7m7zew",
+      "videoId": "XmrnNH3YtBk",
+      "videoTitle": "홍콩 미쉐린 원 스타 중식당이 서울에?! 베이징 덕부터 디저트까지 총 26가지 메뉴 먹고 왔습니다!!"
+    },
+    {
+      "spotId": "SS01kyhxg7jr8zxw3cvdskn8by00",
+      "videoId": "joq90fyFDwk",
+      "videoTitle": "겨울에 땀 흘리며 먹는 전국 5대 짬뽕 도장깨기 2탄🔥 해물 가득, 찐한 국물의 역대급 짬뽕으로 유명한 중식당들만 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jt0v3514jdqha38fm0",
+      "videoId": "joq90fyFDwk",
+      "videoTitle": "겨울에 땀 흘리며 먹는 전국 5대 짬뽕 도장깨기 2탄🔥 해물 가득, 찐한 국물의 역대급 짬뽕으로 유명한 중식당들만 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jv37x8bbmvmz359qhp",
+      "videoId": "-c3WDwRlgR4",
+      "videoTitle": "추운 날엔 전국 5대 짬뽕집 도장깨기🔥 얼큰칼칼 인생 짬뽕으로 유명한 중식당들만 모아 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jw3qe13en28wk73tmm",
+      "videoId": "-c3WDwRlgR4",
+      "videoTitle": "추운 날엔 전국 5대 짬뽕집 도장깨기🔥 얼큰칼칼 인생 짬뽕으로 유명한 중식당들만 모아 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jymvd8cqck7c0xa48z",
+      "videoId": "-c3WDwRlgR4",
+      "videoTitle": "추운 날엔 전국 5대 짬뽕집 도장깨기🔥 얼큰칼칼 인생 짬뽕으로 유명한 중식당들만 모아 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7jzm4m2w7ktyvt8zbmc",
+      "videoId": "Kz5DzbFptTw",
+      "videoTitle": "강원도 가면 꼭 들러야할 막국수집! 시원한 동치미 국물 + 투박한 메밀면의 조화가 일품인 강원도 고성 막국수집을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7k0akmzcvh6eq2c7j5j",
+      "videoId": "X10ElovyR3Q",
+      "videoTitle": "서비스, 맛, 뷰 세 가지 다 잡은 중식당! 시그니처 북경오리 부터 해삼, 전복, 우럭찜, 맛있는 디저트까지! 대성공이었던 호텔 중식당을 여러분께 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7k21da0m5jnnv96rk9k",
+      "videoId": "Fw3Gt0q0Jt4",
+      "videoTitle": "온갖 해산물이 다~ 나온다는 부산 로컬 횟집! 🐟 해삼과 전복부터 갯장어회, 줄가자미회, 추어탕에 튀김과 후식까지! 바다를 통째로 대접하는 찐맛집을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7k3whh0s0ad2h2ysha6",
+      "videoId": "YPXPzy5Yzas",
+      "videoTitle": "고소한 회의 대표주자, 붕장어회 찐 맛집! 부산 무진장횟집"
+    },
+    {
+      "spotId": "SS01kyhxg7k4858229q2tj77vwss",
+      "videoId": "TSgUFZaOllY",
+      "videoTitle": "인생 갈치 맛집! 부산 가면 무조건, 국내 원탑 갈치요리 맛집을 찾아가봤습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7m9vfyfcyxgh6h6mw2k",
+      "videoId": "vdIHjpGFuL8",
+      "videoTitle": "1인 19만원의 광동식 프리미엄 중식당 더 그레이트 홍연, 과연 그 퀄리티는?"
+    },
+    {
+      "spotId": "SS01kyhxg7mb8v3j1wnvs7mgparq",
+      "videoId": "fVmHKwLv-TM",
+      "videoTitle": "정갈하고 세련된 전통 한식, 제철 식재료로 한식 파인다이닝을 선보이는 미슐랭 원스타 한식 레스토랑 온지음!"
+    },
+    {
+      "spotId": "SS01kyhxg7mc6yv4jpnmeg7fxzqx",
+      "videoId": "YKCqPgscTco",
+      "videoTitle": "이 가격에 이 맛이 가능하다고...?! 신라호텔 '팔선' 출신 셰프가 보여주는 중식 요리의 끝판왕! 이름값 제대로 하는 '진미'에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7mdjywnhtn4d0v27w7p",
+      "videoId": "tXufbXlZMUQ",
+      "videoTitle": "보양식 끝판왕 민어를 먹으러 노량진을 다녀왔습니다! 민어회, 민어전, 민어알전, 민어탕 등 민어의 향연(?)을 보여드립니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7menkve9v41z9eehdy5",
+      "videoId": "h73yl8VKssc",
+      "videoTitle": "한우의 끝판왕! 온갖 부위 총출동하는 한우 오마카세를 소개합니다! (Feat. 아시아 탑50 레스토랑)"
+    },
+    {
+      "spotId": "SS01kyhxg7mf4fp4z0nm61grjnqp",
+      "videoId": "4D7r65Pp5oU",
+      "videoTitle": "갓벽한 파인다이닝 레스토랑, 독창적인 요리로 특별한 경험을 선사하는 최현석 셰프님의 쵸이닷에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7mg1jg51ha7x2q3gb3q",
+      "videoId": "3Aq-UnJ_kNw",
+      "videoTitle": "곧 핫해질 신상 파스타 맛집?! 오픈과 동시에 예약이 치열한 가성비 좋은 레스토랑 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7mm8hpt0tft399kjpf3",
+      "videoId": "v2EG4EOw2Hs",
+      "videoTitle": "프랑스 미슐랭 2스타 출신 셰프의 시그니처 메뉴는?! 입문용으로 좋은 프렌치 레스토랑 소개해드립니다"
+    },
+    {
+      "spotId": "SS01kyhxg7mpe93nyjgmym8q6gms",
+      "videoId": "XW7KJlOAWlo",
+      "videoTitle": "술 없이는 못 배기는 역대급 가성비 가맥집! 을지로 신중부시장에 꼭꼭 숨어있는 보물 같은 찐맛집 다녀왔습니다"
+    },
+    {
+      "spotId": "SS01kyhxg7mq0yp4d07qaxyrdsh4",
+      "videoId": "lONALAWayq0",
+      "videoTitle": "제주 바다 경치 보면서 먹는 흑돼지 삼겹살! 여행 가면 무조건 가봐야 하는 제주도 찐 로컬 맛집을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7mrteq2993hb66x641h",
+      "videoId": "CL-R1SOkXjk",
+      "videoTitle": "1인분에 35,000원인 오겹살 정식이 있다?! 전라도식 역대급 상차림을 보면 납득이 가는 숨겨진 찐맛집!"
+    },
+    {
+      "spotId": "SS01kyhxg7msbbg1ve5sdaqxr36r",
+      "videoId": "aFXSdqpBd08",
+      "videoTitle": "100% 메밀면 막국수에 손이 계속 가는 감자옹심이는 덤, 속초에 가면 무조건 가야 되는 숨겨진 막국수 맛집 알려드립니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7mvgazxmrg7tbrstwwb",
+      "videoId": "HrcehmBmN9U",
+      "videoTitle": "국내 삼겹살은 바로 여기! 풍미가 일품인 두툼한 숙성 삽겹살과 목살, 고추장찌개의 맛.없.없 조합!"
+    },
+    {
+      "spotId": "SS01kyhxg7mwzcx5aedagper5tp3",
+      "videoId": "P9iTNwRl2NE",
+      "videoTitle": "술꾼들의 성지, '이모카세'하면 빠질 수 없는 을지로에서 가장 핫한 노포집, 나드리식품에 다녀왔습니다"
+    },
+    {
+      "spotId": "SS01kyhxg7mxqpmsvxth84jb2t4b",
+      "videoId": "k_zGFWz_bLQ",
+      "videoTitle": "기가 막히는 고소함과 담백함, 소맥이 땡기는 마성의 소곱창집! 곱창계 탑티어, 독보적인 퀄리티의 곱창집을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7mythgfveyh0yxrnvy4",
+      "videoId": "OEJ6aZO1adA",
+      "videoTitle": "서울에서 가장 핫한 생면 파스타 바! 입소문 덕에 극강의 예약 난이도를 자랑하는 파스타의 성지에 다녀왔습니다."
+    },
+    {
+      "spotId": "SS01kyhxg7mzgzwk41rh3dw6vvfy",
+      "videoId": "Z6QAEI3NQB4",
+      "videoTitle": "1인 55만원의 중식 보양식은 어떻게 나올까? 샥스핀, 불도장, 건전복과 건해삼 등 최고의 식재료로 만든 중국 코스요리 끝판왕!!"
+    },
+    {
+      "spotId": "SS01kyhxg7n01hwxps2vkd0k3n33",
+      "videoId": "CeA59CKY0s0",
+      "videoTitle": "4년 연속 아시아 베스트 레스토랑 50의 영광, 최애 셰프님들 중 한 분인 김대천 셰프님의 가심비 훌륭한  국내 탑티어 프렌치 레스토랑"
+    },
+    {
+      "spotId": "SS01kyhxg7n2r8195ktcvbgc0sg7",
+      "videoId": "bkTjH5wRSb4",
+      "videoTitle": "감칠맛 폭발 대표 밥도둑들의 향연!! 50년 내공의 오징어볶음, 제육볶음, 삼겹살, 부대찌개 전문 덕수궁 맛집, 한 번 가면 단골됩니다"
+    },
+    {
+      "spotId": "SS01kyhxg7n33ryxbfgagdh0vegw",
+      "videoId": "aOKKm_3e4HU",
+      "videoTitle": "극강의 풍미, 밀랍 에이징 스테이크 - 세계 TOP 5 레스토랑 출신 셰프가 선사하는 스테이크의 정점"
+    },
+    {
+      "spotId": "SS01kyhxg7n4yhsvwmy2dkgfdr9p",
+      "videoId": "5U7Ii_DL1IA",
+      "videoTitle": "서울에서 맛보는 통영 해산물 코스 요리? 통영 제철 해산물을 고급스럽게 풀어낸 실비집! 신선한 통영의 맛을 그대로 옮겨놓았습니다."
+    },
+    {
+      "spotId": "SS01kyhxg7n5ynh4w1y92yb3pkg6",
+      "videoId": "JrUue6fuz1Q",
+      "videoTitle": "신라호텔에 있는 국내 최고의 프렌치 레스토랑?! 파리 샹젤리제에 온 듯한 완벽한 식사를 즐길 수 있는 곳 알려드립니다."
+    },
+    {
+      "spotId": "SS01kyhxg7n6469hajy89xvfgz5j",
+      "videoId": "b3QLNrlMWe0",
+      "videoTitle": "시골집 분위기에서 먹는 가성비 좋은 한우 등심! 돌판 된장찌개와 푸짐한 반찬까지! 강원도 양양 찐맛집 알려드립니다"
+    },
+    {
+      "spotId": "SS01kyhxg7n7tnf8kktr47p6q7kr",
+      "videoId": "UyGAcSzeE_Y",
+      "videoTitle": "유명 맛집 블로거가 작정하고 식당을 열었더니 벌어진 일!? 성수동에서 곧 떠오를 핫플 미리 좌표 찍어드립니다."
+    },
+    {
+      "spotId": "SS01kyhxg7nn1qm4rtncfyd3frbd",
+      "videoId": "bvQzXbZx1_c",
+      "videoTitle": "백종원님도 찾아온다는 서울 한복판의 숨은 맛집! 일단 들어와서 앉으면 술이 술술 들어와서 맨정신에 절대 못 나가는 민물 매운탕 맛집"
+    },
+    {
+      "spotId": "SS01kyhxg7np79tnmyj2x4q3afk1",
+      "videoId": "LA-2LRALV6Y",
+      "videoTitle": "고기 먹으러 가는 칼국수 가게가 있다!? 서울에서 한복판에서 술이 쭉쭉 들어가는 40년 된 찐 맛집"
+    },
+    {
+      "spotId": "SS01kyhxg7nrv8gvz274akqejj5y",
+      "videoId": "uwucfKp_tDU",
+      "videoTitle": "돼지고기 항정살 가브리살 먹을때 좌표 찍어드립니다. 최자로드에서도 강추했던 그 식당! 고기 1타 강사가 추천하는 서울 찐맛집!"
+    },
+    {
+      "spotId": "SS01kyhxg7ntrvv73hyn0x92290k",
+      "videoId": "NPTKG-99lDY",
+      "videoTitle": "코리아에서 먹는 재팬+차이나!? 특급 호텔 출신 셰프가 만드는 국경을 넘나드는 콜라보! 몇 달을 기다리더라도 또 갈만한 서울의 중식+일식 찐맛집"
+    },
+    {
+      "spotId": "SS01kyhxg7nvg5ff2xmk5jt6qw7v",
+      "videoId": "UC__68w0Ohs",
+      "videoTitle": "호불호 끝판왕! 홍어로 논문 쓴 사람이 요리하면 어떤 음식이 만들어질까? 서울에서 찾기 힘든 홍어 제대로 하는 곳, 술 안 먹고 버틸 수 없는 찐맛집"
+    },
+    {
+      "spotId": "SS01kyhxg7nwrcj8rt1jc3aqcjqn",
+      "videoId": "ECpmFVpTWMA",
+      "videoTitle": "맛, 가격, 분위기 모두 잡은 소고기! 저렴하면 허름하다!? 편견을 깬 서울 가성비 맛집 소개합니다."
+    },
+    {
+      "spotId": "SS01kyhxg7nye6jst6q7txzgcek0",
+      "videoId": "G_lKwwiQAp0",
+      "videoTitle": "술 한잔 달라고 했더니, 술잔 40개 꺼내주는 곳!? 술잔뿐 아니라 음식도 다채로운 일식집! 강남에서 요즘 제대로 핫한 오마카세에 다녀왔습니다."
+    },
+    {
+      "spotId": "SS01kyhxg7nz09gxy05fxsky8gq9",
+      "videoId": "0ZzX_AAC4HM",
+      "videoTitle": "12만원짜리 튀김은 도대체 어떤 맛일까!? 미슐랭 가이드에 선정된 튀김! 청담동에 있는 꼬치 튀김 오마카세에 다녀왔습니다."
+    },
+    {
+      "spotId": "SS01kyhxg7p0m799askbrm4wwv48",
+      "videoId": "DYuqqnMKM60",
+      "videoTitle": "맛, 가격 둘 다 잡은 동해안 1위 자연산 횟집, 누구에게나 추천하는 가성비 좋은 횟집 알려드립니다."
+    },
+    {
+      "spotId": "SS01kyhxg7p1mknycmdas3q3tpna",
+      "videoId": "Wn1r8bWmeUA",
+      "videoTitle": "제주도 가면 흑돼지, 회도 좋지만 여기 가보는 건 어때요? 그동안 숨겨져있던 제대로 된 맛집 공개합니다."
+    },
+    {
+      "spotId": "SS01kyhxg7p2z7fv4w02c45vwtfw",
+      "videoId": "qxkYbEmQVj4",
+      "videoTitle": "지금 꼭 먹어야 하는 회!? 노량진 수산시장에서 가장 믿을 수 있는 20년 단골집 공개합니다. 수산시장 어려우면 그냥 여기서 드세요."
+    },
+    {
+      "spotId": "SS01kyhxg7p3stg3qmsx8z9mrfm1",
+      "videoId": "4J0OM2n3M8o",
+      "videoTitle": "곧 비싸질 곳입니다. 저렴하게 소고기 먹으려면 빨리 가세요. 어렵게 찾은 가성비 한우 오마카세!"
+    },
+    {
+      "spotId": "SS01kyhxg7r6bprfvx0d4zsa88s9",
+      "videoId": "bE0P3hvYjrM",
+      "videoTitle": "전라도 목포에 가면 가야할 횟집 TOP2! 민어vs홍어?? 둘 중에 고민하지 말고 그냥 둘 다 가세요."
+    },
+    {
+      "spotId": "SS01kyhxg7p5pc5rs6dykghbdyrs",
+      "videoId": "bE0P3hvYjrM",
+      "videoTitle": "전라도 목포에 가면 가야할 횟집 TOP2! 민어vs홍어?? 둘 중에 고민하지 말고 그냥 둘 다 가세요."
+    },
+    {
+      "spotId": "SS01kyhxg7p6dbbgaapy4137p11t",
+      "videoId": "ry3DwbV982U",
+      "videoTitle": "이거 된장찌개 아닙니다. 청국장도 아닙니다. 예멘 난민 출신 셰프가 만드는 리얼 아랍 음식입니다."
+    },
+    {
+      "spotId": "SS01kyhxg7p7dj93ewvfexv1c7xh",
+      "videoId": "yl0-vdm_UWE",
+      "videoTitle": "내장,껍질까지 다 털어(?)먹는 30만원짜리 회! 제주도까지 갔으면 그냥 여기서 드세요."
+    },
+    {
+      "spotId": "SS01kyhxg7qda15m5e35jhn1pd5g",
+      "videoId": "v8eVP8yIT7Y",
+      "videoTitle": "일본 북해도에 더 이상 여행을 가지 않아도 되는 이유, \"서울 용산을 침략한 징기스칸\""
+    },
+    {
+      "spotId": "SS01kyhxg7qeayas9fq9dyw17dxe",
+      "videoId": "AtN8zdqv_GU",
+      "videoTitle": "가성비 최고인 미슐랭 파인다이닝 알려드립니다. 특히 런치는 갓성비!!!"
+    },
+    {
+      "spotId": "SS01kyhxg7qf5cqdr2ydhnm5kerj",
+      "videoId": "8tRknqMN62A",
+      "videoTitle": "10년간 순대를 연구하면 만들어지는 순대 코스요리??"
+    },
+    {
+      "spotId": "SS01kyhxg7qh3y46v9x0pf7nyca6",
+      "videoId": "nNsC7LceKJI",
+      "videoTitle": "국밥으로 책 쓴 사람이 추천하는 소고기 국밥 TOP2!"
+    },
+    {
+      "spotId": "SS01kyhxg7qjc0ydq0h9tw9qmg82",
+      "videoId": "nNsC7LceKJI",
+      "videoTitle": "국밥으로 책 쓴 사람이 추천하는 소고기 국밥 TOP2!"
+    },
+    {
+      "spotId": "SS01kyhxg7qkq55jz9t5z9h00qjv",
+      "videoId": "XVthK_PAeE0",
+      "videoTitle": "내가 여수에 갔던 이유! 10년 단골 횟집 공개합니다."
+    },
+    {
+      "spotId": "SS01kyhxg7qmvy5xz4v3g7ck8ymd",
+      "videoId": "NhR_t31ZnTg",
+      "videoTitle": "돼지고기 목살은 고민하지 말고 여기서 드세요."
+    },
+    {
+      "spotId": "SS01kyhxg7qndh6fd4qk7gefk0tj",
+      "videoId": "KPXaJlslTB0",
+      "videoTitle": "홍대에 코스요리가 나오는 한식주점이 있다?"
+    },
+    {
+      "spotId": "SS01kyhxg7qp0ea1wdwwgbzzxdvp",
+      "videoId": "fihh77lJ4Rk",
+      "videoTitle": "15kg짜리 거대 다금바리를 먹어보았습니다."
+    },
+    {
+      "spotId": "SS01kyhxg7qre1mxee414dvm9g4q",
+      "videoId": "7lpgOuZ4fl4",
+      "videoTitle": "경상도 갈비 3대장! 한우갈비 맛집 TOP3 추천합니다."
+    },
+    {
+      "spotId": "SS01kyhxg7qs7b9kfr60yvtdyc1f",
+      "videoId": "7lpgOuZ4fl4",
+      "videoTitle": "경상도 갈비 3대장! 한우갈비 맛집 TOP3 추천합니다."
+    },
+    {
+      "spotId": "SS01kyhxg7qth3hh38p9cr51sv6b",
+      "videoId": "7lpgOuZ4fl4",
+      "videoTitle": "경상도 갈비 3대장! 한우갈비 맛집 TOP3 추천합니다."
+    },
+    {
+      "spotId": "SS01kyhxg7qwej2me2xmtetgeds0",
+      "videoId": "xnGc9Il7W7o",
+      "videoTitle": "고기가 들어간 파이? '뚝뜨'를 먹어보았습니다."
+    },
+    {
+      "spotId": "SS01kyhxg7qxdre2bhdf7jr65tvg",
+      "videoId": "tSoG6X0XfGY",
+      "videoTitle": "서울에서 잠깐 '프랑스' 다녀오는 방법?"
+    },
+    {
+      "spotId": "SS01kyhxg7qx6v3w0zzwa2aykve3",
+      "videoId": "I49Ary6aQZs",
+      "videoTitle": "1개에 5,000원인 군만두는 어떤 맛일까!?"
+    },
+    {
+      "spotId": "SS01kyhxg7qy46g4drrqg25h2zxd",
+      "videoId": "cbjuC1A1utQ",
+      "videoTitle": "한식?일식?양식? 어쨌든 맛있는 곳! 7th door에 다녀왔습니다! - 2부"
+    },
+    {
+      "spotId": "SS01kyhxg7r07jjjsd0ntxj7kqre",
+      "videoId": "ABfRMRTR4R4",
+      "videoTitle": "발효와 숙성의 최상의 맛! 7th door에 다녀왔습니다! - 1부"
+    },
+    {
+      "spotId": "SS01kyhxg7r1n72yyw50gmndfwwt",
+      "videoId": "Pb1P3fqEf3E",
+      "videoTitle": "냉부해 정호영쉐프의 미슐랭가이드 맛집, 카덴에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7r2dd5ef80s1k4kh8t5",
+      "videoId": "Pb1P3fqEf3E",
+      "videoTitle": "냉부해 정호영쉐프의 미슐랭가이드 맛집, 카덴에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhxg7rqcbmb4xk61c9px0gk",
+      "videoId": "5uYi_r1_Ec0",
+      "videoTitle": "[내 맛집을 소개합니다] 종로 원서동 한식공간ㅣ조희숙 셰프님의 섬세한 모던 한식ㅣ맛있는 한식은 물론 멋진 뷰까지!!"
+    },
+    {
+      "spotId": "SS01kyhxg7rrdy6ke6b9rpz4849j",
+      "videoId": "mhGBhzG86IY",
+      "videoTitle": "[내 맛집을 소개합니다] 예천 단골식당ㅣ여전히 맛있는 오징어 불고기ㅣ8년 만에 왔는데.. 좀.."
+    },
+    {
+      "spotId": "SS01kyhxg7rt7kx6djagtwmgzsyj",
+      "videoId": "mIjOK4WHQfo",
+      "videoTitle": "[내 맛집을 소개합니다] 부산 해운대 라호짬뽕ㅣ탕수육을 스리라차에?ㅣ볶음밥은 미쳤다"
+    },
+    {
+      "spotId": "SS01kyhxg7rve9k0abjchdqtgr3c",
+      "videoId": "pO2oHr5zM14",
+      "videoTitle": "[내 맛집을 소개합니다] 을지로 보석ㅣ요즘 가장 힙한 술집ㅣ예약해도 2달 기다려야 하는"
+    },
+    {
+      "spotId": "SS01kyhxg7rw68xkf8jzxa65fqx3",
+      "videoId": "51jlRo46lSI",
+      "videoTitle": "[내 맛집을 소개합니다] 이 곰치국을 200번 넘게 먹었습니다"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF/locations.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF/locations.json
@@ -1,0 +1,2715 @@
+{
+  "videos": [
+    {
+      "videoId": "KPXQuyz9j3Y",
+      "title": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕...",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "본앤브레드 해운대 파라다이스점",
+          "address": "대한민국 부산광역시 해운대구 해운대해변로 296 파라다이스호텔 본관 지하 1층",
+          "description": "본앤브레드 해운대 파라다이스점 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KPXQuyz9j3Y",
+          "latitude": 35.1599291,
+          "longitude": 129.1640967,
+          "googleMapsId": "ChIJX0bpTwSNaDUR94-w-hmpQHQ",
+          "googleMapsUri": "https://maps.google.com/?cid=8376881235954274295&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName 'Born and Bred Busan' != '본앤브레드 해운대 파라다이스점'; verify"
+        },
+        {
+          "name": "은해갈치",
+          "address": "대한민국 부산광역시 수영구 광안해변로295번길 4-7 1 층",
+          "description": "본앤브레드 해운대 파라다이스점 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KPXQuyz9j3Y",
+          "latitude": 35.1570265,
+          "longitude": 129.1259111,
+          "googleMapsId": "ChIJvT6_VovtaDURH50DzP97NhI",
+          "googleMapsUri": "https://maps.google.com/?cid=1312372679994744095&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "아저씨대구탕",
+          "address": "대한민국 부산광역시 해운대구 달맞이길62번가길 31",
+          "description": "본앤브레드 해운대 파라다이스점 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KPXQuyz9j3Y",
+          "latitude": 35.158668899999995,
+          "longitude": 129.1716198,
+          "googleMapsId": "ChIJQToAdmqNaDUR1y8t3HMFcUQ",
+          "googleMapsUri": "https://maps.google.com/?cid=4931729062120730583&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "부우사안",
+          "address": "대한민국 부산광역시 해운대구 해운대해변로209번나길 16",
+          "description": "본앤브레드 해운대 파라다이스점 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KPXQuyz9j3Y",
+          "latitude": 35.1601383,
+          "longitude": 129.1545085,
+          "googleMapsId": "ChIJs6MzKiqNaDURFfzBKKpneOo",
+          "googleMapsUri": "https://maps.google.com/?cid=16895367982606318613&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "포항물횟집",
+          "address": "대한민국 부산광역시 부산진구 새싹로29번길 14-7",
+          "description": "본앤브레드 해운대 파라다이스점 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KPXQuyz9j3Y",
+          "latitude": 35.1605564,
+          "longitude": 129.0563105,
+          "googleMapsId": "ChIJT57Hs27raDURvsALPT10Nrk",
+          "googleMapsUri": "https://maps.google.com/?cid=13345982352125051070&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "거대돼지국밥",
+          "address": "대한민국 부산광역시 해운대구 달맞이길 16-2",
+          "description": "본앤브레드 해운대 파라다이스점 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KPXQuyz9j3Y",
+          "latitude": 35.1619238,
+          "longitude": 129.1665543,
+          "googleMapsId": "ChIJaS-hgX-NaDURpmMZgKoNn_E",
+          "googleMapsUri": "https://maps.google.com/?cid=17410649710382375846&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "김해식당",
+          "address": "대한민국 부산광역시 중구 자갈치로 51-2",
+          "description": "본앤브레드 해운대 파라다이스점 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KPXQuyz9j3Y",
+          "latitude": 35.0974797,
+          "longitude": 129.0299436,
+          "googleMapsId": "ChIJfe6YaArpaDUR54aOEE5rRkc",
+          "googleMapsUri": "https://maps.google.com/?cid=5135910408092026599&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "_0uZEIemhlY",
+      "title": "공무원들만 몰래 가던 찐맛집🤫1만 원대 전국구 아구지리 (현지인 성지) | 대구 이방인횟집",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "이방인횟집",
+          "address": "대한민국 대구광역시",
+          "description": "이방인횟집 — 비밀이야 in 한국 영상에서 소개한 대구 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=_0uZEIemhlY",
+          "latitude": 35.8884987,
+          "longitude": 128.5820958,
+          "googleMapsId": "ChIJK-jG6mbhZTURSFGAqf8jgJA",
+          "googleMapsUri": "https://maps.google.com/?cid=10412361919447978312&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '이방인식당' != '이방인횟집'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "vOB8Km0yvys",
+      "title": "가성비 1등! 세월이 검증한 서울대입구 곱창집 (지금 가셔야 합니다) | 신기루황소곱창구이",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "신기루황소곱창구이",
+          "address": "대한민국 서울특별시 관악구 봉천동 관악로13길 25",
+          "description": "신기루황소곱창구이 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vOB8Km0yvys",
+          "latitude": 37.479192,
+          "longitude": 126.95068380000001,
+          "googleMapsId": "ChIJAQAAAI2ffDUR2EWPkKQSg2Y",
+          "googleMapsUri": "https://maps.google.com/?cid=7386768311826990552&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "SwKN0nERUHc",
+      "title": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌...",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "남경미락",
+          "address": "대한민국 제주특별자치도 서귀포시 안덕면 사계리 2032-3",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.2301979,
+          "longitude": 126.3089371,
+          "googleMapsId": "ChIJtSuY-apDDDURCWH9D2HEtIw",
+          "googleMapsUri": "https://maps.google.com/?cid=10138944582276964617&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "강풍해장국",
+          "address": "대한민국 서귀포시 안덕면 사계북로 1",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.2303079,
+          "longitude": 126.2920898,
+          "googleMapsId": "ChIJLYGTCFtCDDURjwUQ71CHIbQ",
+          "googleMapsUri": "https://maps.google.com/?cid=12979804382736418191&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "우동카덴",
+          "address": "대한민국 제주특별자치도 제주시 조천읍 교래리 550-1",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.435577099999996,
+          "longitude": 126.67963499999999,
+          "googleMapsId": "ChIJCxvU0HADDTURH07QGp6rSNw",
+          "googleMapsUri": "https://maps.google.com/?cid=15873125582210354719&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "김희선 제주 몸국",
+          "address": "대한민국 제주특별자치도 제주시 특별자치도 어영길 45-6",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.5185299,
+          "longitude": 126.49804100000001,
+          "googleMapsId": "ChIJd8uTObTlDDUR1mGsvyEw3Zc",
+          "googleMapsUri": "https://maps.google.com/?cid=10942955591087972822&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "동서지간",
+          "address": "대한민국 제주특별자치도 제주시 특별자치도 사라봉길 1",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.514539899999995,
+          "longitude": 126.53886379999999,
+          "googleMapsId": "ChIJQTVd_EXjDDURG-jn6mFqTjg",
+          "googleMapsUri": "https://maps.google.com/?cid=4057297283092834331&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "일통이반",
+          "address": "대한민국 제주특별자치도 제주시 삼도이동 중앙로2길 25",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.5170648,
+          "longitude": 126.5221484,
+          "googleMapsId": "ChIJEUDh1ankDDURfyhSLt_VJSA",
+          "googleMapsUri": "https://maps.google.com/?cid=2316492737883547775&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "제주미담",
+          "address": "대한민국 제주특별자치도 제주시 특별자치도, 가령로 19 KR",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.5023425,
+          "longitude": 126.53736250000001,
+          "googleMapsId": "ChIJgfQJrq_8DDURWSfualjW8rI",
+          "googleMapsUri": "https://maps.google.com/?cid=12894604358354610009&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "미친부엌",
+          "address": "대한민국 제주특별자치도 제주시 특별자치도, 연동4길 6-12 103호",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.4854226,
+          "longitude": 126.4868561,
+          "googleMapsId": "ChIJsxsIkSX7DDUR70XgN7S_Cb4",
+          "googleMapsUri": "https://maps.google.com/?cid=13693686922749167087&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "산지해장국",
+          "address": "대한민국 제주시 노형동 3788-9",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SwKN0nERUHc",
+          "latitude": 33.4833055,
+          "longitude": 126.47644,
+          "googleMapsId": "ChIJbX4UXVT6DDURB9YpkUWw79A",
+          "googleMapsUri": "https://maps.google.com/?cid=15055445892157527559&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "1ggSZsIoFPg",
+      "title": "마 이게 아구다! 해장 술을 부르는 부산 해장 절대강자 | 김해식당",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "김해식당",
+          "address": "대한민국 부산광역시 중구 자갈치로 51-2",
+          "description": "부산 자갈치시장에 위치한 아귀 식당 소개합니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1ggSZsIoFPg",
+          "latitude": 35.0974797,
+          "longitude": 129.0299436,
+          "googleMapsId": "ChIJfe6YaArpaDUR54aOEE5rRkc",
+          "googleMapsUri": "https://maps.google.com/?cid=5135910408092026599&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "1_uPaoNfaig",
+      "title": "부산 해장 무조건 여깁니다. 20년 다닌 1만 원대 또또또또간집 | 아저씨대구탕",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "아저씨대구탕",
+          "address": "대한민국 부산광역시 해운대구 달맞이길62번가길 31",
+          "description": "부산 해운대 미포항에 위치한 단골 대구탕 식당 소개합니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1_uPaoNfaig",
+          "latitude": 35.158668899999995,
+          "longitude": 129.1716198,
+          "googleMapsId": "ChIJQToAdmqNaDUR1y8t3HMFcUQ",
+          "googleMapsUri": "https://maps.google.com/?cid=4931729062120730583&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "kq0fq6wtrbg",
+      "title": "[EN]워크숍 또 가자는 직원들...🌊비밀이야의 속초 모음zip | 각두골, 당근마차, 춘선네, 동명항, 용바위식당",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "각두골",
+          "address": "대한민국 강원특별자치도 양양군 서면 설악로 1111-10",
+          "description": "각두골 — 비밀이야 in 한국 영상에서 소개한 강원 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kq0fq6wtrbg",
+          "latitude": 38.0750063,
+          "longitude": 128.4730938,
+          "googleMapsId": "ChIJwYT9z5en2F8RDnGFX12DZso",
+          "googleMapsUri": "https://maps.google.com/?cid=14584488880343707918&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "당근마차",
+          "address": "대한민국 강원특별자치도 속초시 영랑해안길 14",
+          "description": "각두골 — 비밀이야 in 한국 영상에서 소개한 강원 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kq0fq6wtrbg",
+          "latitude": 38.2128003,
+          "longitude": 128.60103139999998,
+          "googleMapsId": "ChIJGeYxDA682F8RRb9WnOY2n9g",
+          "googleMapsUri": "https://maps.google.com/?cid=15609255197582737221&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "춘선네",
+          "address": "대한민국 강원특별자치도 속초시 교동 664-102",
+          "description": "각두골 — 비밀이야 in 한국 영상에서 소개한 강원 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kq0fq6wtrbg",
+          "latitude": 38.1990382,
+          "longitude": 128.58296479999998,
+          "googleMapsId": "ChIJ7-zPa5K92F8RJGSgVPV9X7Y",
+          "googleMapsUri": "https://maps.google.com/?cid=13141360730330653732&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "동명항 활어회 센터",
+          "address": "대한민국 강원특별자치도 속초시 동명동 1-246",
+          "description": "각두골 — 비밀이야 in 한국 영상에서 소개한 강원 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kq0fq6wtrbg",
+          "latitude": 38.2104978,
+          "longitude": 128.60130139999998,
+          "googleMapsId": "ChIJMSdq0xy92F8RDZJACvWKhuk",
+          "googleMapsUri": "https://maps.google.com/?cid=16827289842760061453&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '동명활어센터' != '동명항 활어회 센터'; verify"
+        },
+        {
+          "name": "용바위식당",
+          "address": "대한민국 강원특별자치도 인제군 북면 용대리 71-3",
+          "description": "각두골 — 비밀이야 in 한국 영상에서 소개한 강원 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kq0fq6wtrbg",
+          "latitude": 38.223842999999995,
+          "longitude": 128.3675774,
+          "googleMapsId": "ChIJGfBSn-Cd2F8Rc7KuM4HhUc8",
+          "googleMapsUri": "https://maps.google.com/?cid=14938969383998763635&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "axj_gYyPeUg",
+      "title": "6.25 전쟁도 겪은 부산 중식당😲 비밀이야가 유튜브 초창기부터 꾸준히 찾는 화상의 맛 (feat. 비밀이야가 많이 받는 DM은?)[EN]ㅣ동화반점",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "3",
+          "address": "대한민국 부산광역시 중구 흑교로75번길 3",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=axj_gYyPeUg",
+          "latitude": 35.1057748,
+          "longitude": 129.0234585,
+          "googleMapsId": "ChIJK3U8JpnpaDUR2LKrkgDNRdc",
+          "googleMapsUri": "https://maps.google.com/?cid=15512029893891961560&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "9gwbNOTVTao",
+      "title": "인생 안심? 비밀이야의 인생 안창살을 만난 한우 노포집[EN]ㅣ뜨락",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "13-3",
+          "address": "대한민국 서울특별시 강남구 영동대로142길 13-3",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=9gwbNOTVTao",
+          "latitude": 37.5244137,
+          "longitude": 127.05555609999999,
+          "googleMapsId": "ChIJUQ4N-GOkfDURjrBHXX4JhH8",
+          "googleMapsUri": "https://maps.google.com/?cid=9188479578078163086&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "tPlWG3n6zu0",
+      "title": "제주 고급 생선을 제대로 만나볼 수 있는 횟집🎣오래 전부터 미식가를 불러 모으던 그 곳에 방문했습니다[EN]ㅣ남경미락",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "남경미락",
+          "address": "대한민국 제주특별자치도 서귀포시 안덕면 사계리 2032-3",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주특별자치도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tPlWG3n6zu0",
+          "latitude": 33.2301979,
+          "longitude": 126.3089371,
+          "googleMapsId": "ChIJtSuY-apDDDURCWH9D2HEtIw",
+          "googleMapsUri": "https://maps.google.com/?cid=10138944582276964617&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "enXrget-zXk",
+      "title": "거부할 수 없는 푸짐한 거부갈비! 비밀이야가 인정한 제주도 맛집 추천🌟",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "3",
+          "address": "대한민국 제주특별자치도 제주시 제원4길 3",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 제주특별자치도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=enXrget-zXk",
+          "latitude": 33.4863584,
+          "longitude": 126.48863989999998,
+          "googleMapsId": "ChIJQ9xHagb7DDURCOhT4zMuMBc",
+          "googleMapsUri": "https://maps.google.com/?cid=1670886262146590728&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "dn8OVfxevug",
+      "title": "한국인이 가장 좋아하는 맛은 직화맛? 볏짚 폼 미쳤다;; 웨이팅 어마무시한 서울 몽탄이 각잡고 제주로 내려가면 일어나는 일",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "83",
+          "address": "대한민국 제주특별자치도 제주시 구좌읍 동복로 83",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 제주특별자치도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=dn8OVfxevug",
+          "latitude": 33.5535127,
+          "longitude": 126.7151122,
+          "googleMapsId": "ChIJWzbXUCIZDTURDGhsbkVvqS8",
+          "googleMapsUri": "https://maps.google.com/?cid=3434398534842738700&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "wt-HmPcECb8",
+      "title": "점심 스시 오마카세 추천! 70만원 쓰고 갔던 유일한 오너 셰프의 스시집🍣[EN]ㅣ스시 시미즈",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "11-3",
+          "address": "대한민국 서울특별시 강남구 언주로152길 11-3",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=wt-HmPcECb8",
+          "latitude": 37.5229231,
+          "longitude": 127.034506,
+          "googleMapsId": "ChIJ9ddZqo6jfDURiIQeat0YnrI",
+          "googleMapsUri": "https://maps.google.com/?cid=12870752124318680200&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "g0Bwr7KN0_M",
+      "title": "슬슬 더워지는 날씨에 생각나는 미나리 삼겹살 + 화이트와인 조합이 극락인 이유🥓🍾[EN]ㅣ압구정 진주",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "압구정 진주",
+          "address": "대한민국 서울특별시 강남구 압구정동 압구정로46길 5-10",
+          "description": "압구정 진주 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=g0Bwr7KN0_M",
+          "latitude": 37.527865999999996,
+          "longitude": 127.0374797,
+          "googleMapsId": "ChIJMUJxOMyjfDURliaUuOQjWFU",
+          "googleMapsUri": "https://maps.google.com/?cid=6149704756430644886&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "wSYzoXXsF6o",
+      "title": "대표가 까주는 새우는 과연 맛있을까? 직원들과 10년차 단골집 방문! 속초의 밤은 이곳에서🌃ㅣ당근마차",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "당근마차",
+          "address": "대한민국 강원특별자치도 속초시 영랑해안길 14",
+          "description": "당근마차 — 비밀이야 in 한국 영상에서 소개한 강원도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=wSYzoXXsF6o",
+          "latitude": 38.2128003,
+          "longitude": 128.60103139999998,
+          "googleMapsId": "ChIJGeYxDA682F8RRb9WnOY2n9g",
+          "googleMapsUri": "https://maps.google.com/?cid=15609255197582737221&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "cFnpvr2tEY4",
+      "title": "남자분들 주목 👀 국내 최고 돈카츠 맛집은? 생맥주와 말이 필요 없는 극락 조합 🍺ㅣ고성 보배진",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "고성 보배진",
+          "address": "대한민국 강원특별자치도 고성군 토성면 천진리 21-16",
+          "description": "고성 보배진 — 비밀이야 in 한국 영상에서 소개한 강원도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=cFnpvr2tEY4",
+          "latitude": 38.2581876,
+          "longitude": 128.5585907,
+          "googleMapsId": "ChIJO80iY9C_2F8Rp7GJ_0BcO6w",
+          "googleMapsUri": "https://maps.google.com/?cid=12410614632384410023&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "PKALkw1k3bE",
+      "title": "한국 다이닝에서 볼 수 없었던 메뉴! 더욱 독창적인 퍼포먼스로 돌아온 최현석 셰프님의 쵸이닷[EN]ㅣ쵸이닷",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "쵸이닷",
+          "address": "대한민국 서울특별시 강남구 도산대로 457 앙스돔빌딩 3층",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=PKALkw1k3bE",
+          "latitude": 37.5243614,
+          "longitude": 127.04659009999999,
+          "googleMapsId": "ChIJYz_NPnqkfDURqEJ3EeoGY5Y",
+          "googleMapsUri": "https://maps.google.com/?cid=10836512730768687784&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Y0sW9mpcIN0",
+      "title": "프랑스보다 더 프랑스같은 맛과 코스를 경험하고 싶다면? 직원들 함박웃음 짓게 한 비밀이야 최애 프렌치 레스토랑 그리고 Krug [EN]ㅣ레스쁘아",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "16",
+          "address": "대한민국 서울특별시 강남구 도산대로59길 16",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Y0sW9mpcIN0",
+          "latitude": 37.52474730000001,
+          "longitude": 127.04238459999999,
+          "googleMapsId": "ChIJZzBgKXikfDURga-nrgmWhu4",
+          "googleMapsUri": "https://maps.google.com/?cid=17187589996235173761&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "GCOP8UPWkIo",
+      "title": "노량진 수산시장에서 모듬회 장르를 개척한 30년차 횟집! 돈이 줄줄세는 줄줄세트🐠 ㅣ더형제 강남",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "효성해링턴스퀘어",
+          "address": "대한민국 서울특별시 마포구 마포대로 92",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GCOP8UPWkIo",
+          "latitude": 37.5430115,
+          "longitude": 126.9511883,
+          "googleMapsId": "ChIJ0bRT60CZfDURir_NuZs5WUQ",
+          "googleMapsUri": "https://maps.google.com/?cid=4925031008506331018&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "JhphrHU6mXg",
+      "title": "미남직원들과 함께한 회식ㅣ손흥민 드리블급인 셰프님의 오마카세ㅣ키라메키 [EN]",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "키라메키 kirameki",
+          "address": "대한민국 서울특별시 강남구 도산대로28길 18",
+          "description": "키라메키 kirameki — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JhphrHU6mXg",
+          "latitude": 37.5180852,
+          "longitude": 127.02822139999999,
+          "googleMapsId": "ChIJpZ-yVWijfDURV5be7_jvKfY",
+          "googleMapsUri": "https://maps.google.com/?cid=17737972459830679127&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "429mYqmcqQU",
+      "title": "1년에 한번 귀한 와인을 갖고 모이는 디너 생일 파티 🎉ㅣ아시아 베스트 50 의 주목해야 할 레스토랑ㅣ톡톡 [EN]",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "청담 톡톡",
+          "address": "대한민국 서울특별시 강남구 청담동 69-5",
+          "description": "청담 톡톡 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=429mYqmcqQU",
+          "latitude": 37.522371199999995,
+          "longitude": 127.05429789999998,
+          "googleMapsId": "ChIJDRB8ZoijfDURnAHuRSEyC9I",
+          "googleMapsUri": "https://maps.google.com/?cid=15135246091197219228&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "1GisLCTWmn0",
+      "title": "이건 평범한 오마카세가 아닙니다 [EN]ㅣ본앤브레드",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "본앤브레드",
+          "address": "대한민국 서울특별시 성동구 마장로42길 1",
+          "description": "본앤브레드 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1GisLCTWmn0",
+          "latitude": 37.5667249,
+          "longitude": 127.0445221,
+          "googleMapsId": "ChIJ03uyyKqkfDURBP72STLlOHU",
+          "googleMapsUri": "https://maps.google.com/?cid=8446753105285414404&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "tHjfeQyMpM0",
+      "title": "여성 셰프님이어서 나오는 섬세한 포인트✨ 창덕궁과 창경궁뷰의 식사[EN]ㅣ더그린테이블",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "더그린테이블",
+          "address": "대한민국 서울특별시 종로구 율곡로 83 5층",
+          "description": "더그린테이블 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tHjfeQyMpM0",
+          "latitude": 37.577666199999996,
+          "longitude": 126.98856769999998,
+          "googleMapsId": "ChIJ_____6ChfDURiaRnah1hzUc",
+          "googleMapsUri": "https://maps.google.com/?cid=5173898325885691017&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "BEZ73zUcII0",
+      "title": "인당 55만원씩 내고 대관해 버린 연말 회식 스케일?![EN]ㅣ스시하네",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "스시하네",
+          "address": "대한민국 서울특별시 강남구 압구정동 언주로172길 14",
+          "description": "스시하네 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BEZ73zUcII0",
+          "latitude": 37.5275744,
+          "longitude": 127.0348666,
+          "googleMapsId": "ChIJ05Zoz1-jfDURNjPePpknw5k",
+          "googleMapsUri": "https://maps.google.com/?cid=11079743047399781174&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "zOTWRUw_jY4",
+      "title": "여긴 이전하기 전에 가보셔야 합니다. 새로움의 연속, 꼭 보여드리고 싶은 맛!ㅣ강민철 레스토랑 [EN]",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "강민철 레스토랑",
+          "address": "대한민국 서울특별시 강남구 도산대로63길 18 5F",
+          "description": "강민철 레스토랑 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zOTWRUw_jY4",
+          "latitude": 37.5249753,
+          "longitude": 127.04364450000001,
+          "googleMapsId": "ChIJX-lvM5WlfDURSDv31GaVe4g",
+          "googleMapsUri": "https://maps.google.com/?cid=9834618480185785160&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "iOPYW2RmXL4",
+      "title": "서울 한복판에 제대로 궁중 한옥에서 대접해 주는 고급 다이닝이 있다? 핫플 예고된 식당ㅣ한국의집 [EN]",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "한국의 집",
+          "address": "대한민국 서울특별시 중구 퇴계로36길 10",
+          "description": "한국의 집 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=iOPYW2RmXL4",
+          "latitude": 37.5602041,
+          "longitude": 126.9947198,
+          "googleMapsId": "ChIJ1ytmM5SifDURnsR4OoEvDFQ",
+          "googleMapsUri": "https://maps.google.com/?cid=6056267830984754334&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "M9cZIA6V3Sg",
+      "title": "더욱 업그레이드 되어 돌아온 모던 한식의 선두주자 [EN]ㅣ밍글스",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "밍글스",
+          "address": "대한민국 서울특별시 강남구 도산대로67길 19 힐탑빌딩 2층",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=M9cZIA6V3Sg",
+          "latitude": 37.5253386,
+          "longitude": 127.04414519999999,
+          "googleMapsId": "ChIJjXuM24mjfDURSwmouRnxNlM",
+          "googleMapsUri": "https://maps.google.com/?cid=5996245046681667915&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "v3X8Tpppy78",
+      "title": "[EN]한남 루프탑뷰가 이렇게 좋았나✨(데이트 코스로 강추) 계절마다 메뉴와 인테리어 컨셉이 변하는 이곳! l 쿡투게더한남",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "쿡투게더한남",
+          "address": "대한민국 서울특별시 용산구 한남동 이태원로54길 58-4 2층",
+          "description": "쿡투게더한남 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=v3X8Tpppy78",
+          "latitude": 37.5359091,
+          "longitude": 127.00086080000001,
+          "googleMapsId": "ChIJa9SP9XGjfDURnWY4j0pAb5U",
+          "googleMapsUri": "https://maps.google.com/?cid=10767895923040741021&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName 'CTG한남' != '쿡투게더한남'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "ULGt59R11w0",
+      "title": "[EN]사장님 말투가 너무 고급져요👨‍🍳 클래식 프렌치 레스토랑의 끝판왕ㅣ화이트크리스마스",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "청주화이트크리스마스",
+          "address": "대한민국 충청북도 청주시 흥덕구 비하로42번길 2",
+          "description": "청주화이트크리스마스 — 비밀이야 in 한국 영상에서 소개한 충청북도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ULGt59R11w0",
+          "latitude": 36.6308337,
+          "longitude": 127.42485669999999,
+          "googleMapsId": "ChIJoVoHN-QmZTURu8Ip0JwSuFw",
+          "googleMapsUri": "https://maps.google.com/?cid=6681110511920726715&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "eUuVmF5NFk8",
+      "title": "[EN] 한국인이라면 못참는 흰쌀밥+고추장불고기+냉면 조합🤤ㅣ편집하다 침샘 폭발한 곳💦ㅣ현구3대 원조불고기",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "현구원조3대불고기",
+          "address": "대한민국 김천시",
+          "description": "현구원조3대불고기 — 비밀이야 in 한국 영상에서 소개한 경북 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=eUuVmF5NFk8",
+          "latitude": 35.9876615,
+          "longitude": 128.02999549999998,
+          "googleMapsId": "ChIJgdG_vwWDZTURYe984y0gaNE",
+          "googleMapsUri": "https://maps.google.com/?cid=15089345932967079777&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "tJOJzWB94So",
+      "title": "[EN] 점심 따로 먹으라 해도 따라오는 직원들 (feat.피리부는 비밀이야)ㅣ면서울",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "면서울",
+          "address": "대한민국 서울특별시 강남구 선릉로 805",
+          "description": "면서울 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tJOJzWB94So",
+          "latitude": 37.5241658,
+          "longitude": 127.0390675,
+          "googleMapsId": "ChIJOY1bNEqjfDUR8pHYAdJ029M",
+          "googleMapsUri": "https://maps.google.com/?cid=15265923807225352690&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "a2g7UPH2opU",
+      "title": "[EN] 청담동의 미슐랭 원스타&아시아 대표 레스토랑!! 이 음식을 이렇게 조합한다고..?ㅣ세븐스도어",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "세븐스도어",
+          "address": "대한민국 서울특별시 강남구 학동로97길 41 4층",
+          "description": "세븐스도어 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=a2g7UPH2opU",
+          "latitude": 37.522371199999995,
+          "longitude": 127.05429789999998,
+          "googleMapsId": "ChIJJ1xm8n-lfDUR5AOAQSJ0oeM",
+          "googleMapsUri": "https://maps.google.com/?cid=16402519008336675812&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "PWIjDmYEjO4",
+      "title": "[EN] 여성 구독자와의 우연한 첫만남..?!🙊ㅣ무오키",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "무오키",
+          "address": "대한민국 서울특별시 강남구 학동로55길 12-12",
+          "description": "무오키 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=PWIjDmYEjO4",
+          "latitude": 37.5189698,
+          "longitude": 127.0422219,
+          "googleMapsId": "ChIJx08AyXWkfDURs2BBkP20hJo",
+          "googleMapsUri": "https://maps.google.com/?cid=11134223179906638003&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "bcbosOeLIXk",
+      "title": "[EN] 살살 녹는 닭꼬치ㅣ한국에서 찾기 힘든 야키토리 맛집!!ㅣ야키토리해공",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "야키토리 해공",
+          "address": "대한민국 부산광역시 수영구 민락본동로19번길 30-5",
+          "description": "야키토리 해공 — 비밀이야 in 한국 영상에서 소개한 부산광역시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bcbosOeLIXk",
+          "latitude": 35.1582344,
+          "longitude": 129.1271137,
+          "googleMapsId": "ChIJX79ClcySaDURNZyGN2ErUfU",
+          "googleMapsUri": "https://maps.google.com/?cid=17676957708949298229&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "H33H-4ei9sw",
+      "title": "(EN) 한우를 드라이에이징한 낯선 스테이크의 맛은 어떨까? l 본앤브레드",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "본앤브레드",
+          "address": "대한민국 부산광역시 해운대구 해운대해변로 296 파라다이스호텔 본관 지하 1층",
+          "description": "본앤브레드 — 비밀이야 in 한국 영상에서 소개한 부산시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=H33H-4ei9sw",
+          "latitude": 35.1599291,
+          "longitude": 129.1640967,
+          "googleMapsId": "ChIJX0bpTwSNaDUR94-w-hmpQHQ",
+          "googleMapsUri": "https://maps.google.com/?cid=8376881235954274295&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName 'Born and Bred Busan' != '본앤브레드'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "1KNVmLD0PF8",
+      "title": "(EN) 기대 안하고 갔다가 깜짝 놀란 부산의 베이징 덕!🍗 겉도 윤기 좔좔 흐르기 어려운데.. ㅣ부우사안",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "부우사안",
+          "address": "대한민국 부산광역시 해운대구 해운대해변로209번나길 16",
+          "description": "부우사안 — 비밀이야 in 한국 영상에서 소개한 부산광역시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1KNVmLD0PF8",
+          "latitude": 35.1601383,
+          "longitude": 129.1545085,
+          "googleMapsId": "ChIJs6MzKiqNaDURFfzBKKpneOo",
+          "googleMapsUri": "https://maps.google.com/?cid=16895367982606318613&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Pqb9y00bJDM",
+      "title": "(EN) 돼지고기 껍데기에 전통주를 온더락🥃으로? 제대로 즐기는 법!! (여름이었다🐷)ㅣ금돼지식당",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "금돼지식당",
+          "address": "대한민국 서울특별시 중구 다산로 149",
+          "description": "금돼지식당 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Pqb9y00bJDM",
+          "latitude": 37.5570994,
+          "longitude": 127.0116712,
+          "googleMapsId": "ChIJFRmIDRGjfDUR2nv7h8qMx2Y",
+          "googleMapsUri": "https://maps.google.com/?cid=7406042913726757850&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "bzzkH6OusXs",
+      "title": "(EN) 여름이니까 스태민어 코스의 매력에 빠져보자🎣 전복,소라,골뱅이,문어,새우,개불,해삼,옥돔,낚지볶음까지.. ㅣ 더형제",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "더형제",
+          "address": "대한민국 서울특별시 마포구 마포대로 92 효성 해링턴 스퀘어 B동 1층 14호",
+          "description": "더형제 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bzzkH6OusXs",
+          "latitude": 37.5424174,
+          "longitude": 126.95253509999999,
+          "googleMapsId": "ChIJY9uWAh6ZfDURhkqtHmR6lGo",
+          "googleMapsUri": "https://maps.google.com/?cid=7679897835003529862&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "DS8PwEMtE80",
+      "title": "(EN) 한국 파인 다이닝의 미래는 어떻게 될까? 무명이었을 때부터 25만원에 판매해 성공할 수 있었던 비결ㅣ솔밤",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "솔밤",
+          "address": "대한민국 서울특별시 강남구 논현동 학동로 231 백영센터 2층",
+          "description": "솔밤 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DS8PwEMtE80",
+          "latitude": 37.5157568,
+          "longitude": 127.03411089999999,
+          "googleMapsId": "ChIJL2hHUjujfDURbxzijlzZtxs",
+          "googleMapsUri": "https://maps.google.com/?cid=1997303951319506031&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "GPtli8Gaxek",
+      "title": "(EN) 국물이 시원하다고 느끼는 이유가 뭘까? 서울에 분점차리고 싶은 끝판왕 대구탕ㅣ아저씨대구탕",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "아저씨대구탕",
+          "address": "대한민국 부산광역시 해운대구 달맞이길62번가길 31",
+          "description": "아저씨대구탕 — 비밀이야 in 한국 영상에서 소개한 부산광역시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GPtli8Gaxek",
+          "latitude": 35.158668899999995,
+          "longitude": 129.1716198,
+          "googleMapsId": "ChIJQToAdmqNaDUR1y8t3HMFcUQ",
+          "googleMapsUri": "https://maps.google.com/?cid=4931729062120730583&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "CoyATC7Y-5o",
+      "title": "(EN) 영국 음식을 서울시청 근처에서 맛보자! | 플레눼",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "플레눼",
+          "address": "대한민국 서울특별시 중구 세종대로 135 코리아나호텔",
+          "description": "플레눼 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CoyATC7Y-5o",
+          "latitude": 37.5681809,
+          "longitude": 126.9765031,
+          "googleMapsId": "ChIJ63mWOO2ifDURntI7_YxBx-w",
+          "googleMapsUri": "https://maps.google.com/?cid=17061677787116196510&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '코리아나 호텔' != '플레눼'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "DvfNL6Z43Jc",
+      "title": "(EN) 가게 오픈할 때부터 즐겨 먹었던 단골집 | 화상손만두",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "화상손만두",
+          "address": "대한민국 서울특별시 마포구 와우산로25길 13 2층",
+          "description": "화상손만두 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DvfNL6Z43Jc",
+          "latitude": 37.553985999999995,
+          "longitude": 126.925831,
+          "googleMapsId": "ChIJDRkWr8iZfDURtiw15Hw_y2g",
+          "googleMapsUri": "https://maps.google.com/?cid=7551199005853953206&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "K_pcS_MI0zA",
+      "title": "(EN) 신경을 살려서 회를 썰고, 그 위에 캐비아를 올린🐙 | 셀렉트 구르메",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "셀렉트 구르메",
+          "address": "대한민국 서울특별시 강남구 테헤란로 610",
+          "description": "셀렉트 구르메 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=K_pcS_MI0zA",
+          "latitude": 37.50882500000001,
+          "longitude": 127.064533,
+          "googleMapsId": "ChIJiYrT8ECkfDURRAwIBdtcq5g",
+          "googleMapsUri": "https://maps.google.com/?cid=11000988610534575172&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '글래드 강남 코엑스센터' != '셀렉트 구르메'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "ycMAjic-ABc",
+      "title": "(EN) 시청자曰 \"제가 갔을 땐 이런 참치 없던데요?\" | 더 형제",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "더 형제",
+          "address": "대한민국 서울특별시 마포구 마포대로 92 효성 해링턴 스퀘어 B동 1층 14호",
+          "description": "더 형제 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ycMAjic-ABc",
+          "latitude": 37.5424174,
+          "longitude": 126.95253509999999,
+          "googleMapsId": "ChIJY9uWAh6ZfDURhkqtHmR6lGo",
+          "googleMapsUri": "https://maps.google.com/?cid=7679897835003529862&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "D1WBB86yL08",
+      "title": "(EN) 장어 안 좋아하는 사람도 봐야됨 | 영동장어",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "영동장어",
+          "address": "대한민국 서울특별시 강남구 언주로148길 8",
+          "description": "영동장어 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=D1WBB86yL08",
+          "latitude": 37.520317899999995,
+          "longitude": 127.0353355,
+          "googleMapsId": "ChIJd_1pAwCjfDURWcvQc4MZ-5M",
+          "googleMapsUri": "https://maps.google.com/?cid=10663144595104254809&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName 'Korean Restaurants Yeongdong Eel' != '영동장어'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "DhueGoWfuMU",
+      "title": "(EN) 이 날 먹은 와인 값이 차 한 대 값...? | 밍글스",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "밍글스",
+          "address": "대한민국 서울특별시 강남구 도산대로67길 19 힐탑빌딩 2층",
+          "description": "밍글스 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DhueGoWfuMU",
+          "latitude": 37.5253386,
+          "longitude": 127.04414519999999,
+          "googleMapsId": "ChIJjXuM24mjfDURSwmouRnxNlM",
+          "googleMapsUri": "https://maps.google.com/?cid=5996245046681667915&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Le88HtJ0kIk",
+      "title": "신화 이민우와 함께 맛본 튀김 오마카세🍤",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "덴푸라 키이로 tempura kiro",
+          "address": "대한민국 서울특별시 강남구 신사동 504-11 2 층 206 호",
+          "description": "덴푸라 키이로 tempura kiro — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Le88HtJ0kIk",
+          "latitude": 37.519456999999996,
+          "longitude": 127.01911869999999,
+          "googleMapsId": "ChIJpx1N4QSjfDURRONJpfw_H-o",
+          "googleMapsUri": "https://maps.google.com/?cid=16870273083490558788&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "JcbR__2GISI",
+      "title": "비밀曰 \"이곳이 물건만큼은 확실하다\"",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "배정철 어도",
+          "address": "대한민국 서울특별시 강남구 논현2동 언주로148길 14",
+          "description": "배정철 어도 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JcbR__2GISI",
+          "latitude": 37.5203955,
+          "longitude": 127.0354766,
+          "googleMapsId": "ChIJNcUkLoqjfDURbbDvqjDQb3Q",
+          "googleMapsUri": "https://maps.google.com/?cid=8390153538259365997&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "RZjCiWBmEHE",
+      "title": "울릉도로 오세요🌊",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "신비섬 횟집",
+          "address": "대한민국 경상북도 울릉군 울릉읍 사동리 592",
+          "description": "신비섬 횟집 — 비밀이야 in 한국 영상에서 소개한 경상북도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=RZjCiWBmEHE",
+          "latitude": 37.473431399999996,
+          "longitude": 130.8890755,
+          "googleMapsId": "ChIJtzjgRUBP4F8RZl97R41Ro38",
+          "googleMapsUri": "https://maps.google.com/?cid=9197284531252191078&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "다애식당",
+          "address": "대한민국 경상북도 울릉군 울릉읍 도동리 181-3",
+          "description": "신비섬 횟집 — 비밀이야 in 한국 영상에서 소개한 경상북도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=RZjCiWBmEHE",
+          "latitude": 37.484038,
+          "longitude": 130.90536889999998,
+          "googleMapsId": "ChIJIx8vYphP4F8RWD8DLNDZA_k",
+          "googleMapsUri": "https://maps.google.com/?cid=17943424828489023320&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "태양식당",
+          "address": "대한민국 경상북도 울릉군 서면 울릉순환로 1278 1층",
+          "description": "신비섬 횟집 — 비밀이야 in 한국 영상에서 소개한 경상북도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=RZjCiWBmEHE",
+          "latitude": 37.4665311,
+          "longitude": 130.83752909999998,
+          "googleMapsId": "ChIJWUpjRgdG4F8Ri7mAC1rA8cg",
+          "googleMapsUri": "https://maps.google.com/?cid=14479565769945430411&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "OudlvfCD8sU",
+      "title": "일반인들은 맛볼 수 없는 울릉도 숨은 맛집🤫",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "산마을식당",
+          "address": "대한민국 경상북도 울릉군 북면 나리 136-2",
+          "description": "산마을식당 — 비밀이야 in 한국 영상에서 소개한 경상북도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=OudlvfCD8sU",
+          "latitude": 37.5209306,
+          "longitude": 130.868969,
+          "googleMapsId": "ChIJte0WRNZE4F8REtNsETQX_M4",
+          "googleMapsUri": "https://maps.google.com/?cid=14914821578342322962&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "FlNpHNgIrBI",
+      "title": "대한민국에서 가장 비싼 숙소와 최고의 음식 퀄리티👍",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "힐링스테이 코스모스",
+          "address": "대한민국 경상북도 울릉군 북면 추산길 88-13",
+          "description": "힐링스테이 코스모스 — 비밀이야 in 한국 영상에서 소개한 경상북도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=FlNpHNgIrBI",
+          "latitude": 37.5338111,
+          "longitude": 130.8579625,
+          "googleMapsId": "ChIJJ3Etukpb4F8RA3fgTSwOyZw",
+          "googleMapsUri": "https://maps.google.com/?cid=11297576723683505923&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '코스모스 울릉도' != '힐링스테이 코스모스'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "5kb-BAzKrCo",
+      "title": "이번 컨셉은 '고려시대'라고 합니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "온지음",
+          "address": "대한민국 서울특별시 종로구 효자로 49 4층",
+          "description": "온지음 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5kb-BAzKrCo",
+          "latitude": 37.5804867,
+          "longitude": 126.97334880000001,
+          "googleMapsId": "ChIJk5DRDD2jfDURUA4aAk0Frx0",
+          "googleMapsUri": "https://maps.google.com/?cid=2138934176330157648&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "bS6q_NZrdZg",
+      "title": "독일 원스타 찍어 누르는 삼성동 레스토랑",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "삼성동 아티피크",
+          "address": "대한민국 서울특별시 강남구 삼성동 90",
+          "description": "삼성동 아티피크 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bS6q_NZrdZg",
+          "latitude": 37.5167226,
+          "longitude": 127.05938499999999,
+          "googleMapsId": "ChIJ9eF2SnmlfDURDilbs1hGnzk",
+          "googleMapsUri": "https://maps.google.com/?cid=4152114728239048974&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '아티피크(atypique)' != '삼성동 아티피크'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "oXxLuTlqyso",
+      "title": "홍어 삭히지 않아도 맛있습니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "홍어명가 본점",
+          "address": "대한민국 서울특별시 영등포구 신길로 200-20",
+          "description": "홍어명가 본점 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=oXxLuTlqyso",
+          "latitude": 37.510582299999996,
+          "longitude": 126.91159210000001,
+          "googleMapsId": "ChIJHTRO2QGffDURNFwQ9L-84io",
+          "googleMapsUri": "https://maps.google.com/?cid=3090239826949069876&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "o-ZzOkoFo2I",
+      "title": "이제 닭 요리 하면 이 집밖에 떠오르지 않습니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "원조장수통닭",
+          "address": "대한민국 전라남도 해남군 해남읍 연동리 433-6",
+          "description": "원조장수통닭 — 비밀이야 in 한국 영상에서 소개한 전라남도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=o-ZzOkoFo2I",
+          "latitude": 34.5405593,
+          "longitude": 126.61272220000001,
+          "googleMapsId": "ChIJbaTFduX_cjURHbn8iY16bkQ",
+          "googleMapsUri": "https://maps.google.com/?cid=4931013390341290269&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "bN3yTHwDlUE",
+      "title": "국적, 장르에 구애받지 않는 비범한 퓨전 한식집!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "수퍼판 (Superpan)",
+          "address": "대한민국 서울특별시 강남구 논현로167길 15",
+          "description": "수퍼판 (Superpan) — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bN3yTHwDlUE",
+          "latitude": 37.5244107,
+          "longitude": 127.02683429999998,
+          "googleMapsId": "ChIJ9QXk2PahfDURzJji8cjz_d0",
+          "googleMapsUri": "https://maps.google.com/?cid=15996209495867037900&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "PlI-YPpsj0c",
+      "title": "여기는 무조건 가보셔야 합니다. 청파동의 자랑, 화상중식당 정!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "청파로47나길 4 2층",
+          "address": "대한민국 서울특별시 용산구 청파로47나길 4 2층",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=PlI-YPpsj0c",
+          "latitude": 37.545049399999996,
+          "longitude": 126.96706839999999,
+          "googleMapsId": "EkIy7Li1LCA0IENoZW9uZ3BhLXJvIDQ3bmEtZ2lsLCBZb25nc2FuIERpc3RyaWN0LCBTZW91bCwgU291dGggS29yZWEiIBoeChYKFAoSCbdyeAdtonw1EczJfFNaEcR7EgQy7Li1",
+          "googleMapsUri": "https://maps.google.com/?q=%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD+%EC%84%9C%EC%9A%B8%ED%8A%B9%EB%B3%84%EC%8B%9C+%EC%9A%A9%EC%82%B0%EA%B5%AC+%EC%B2%AD%ED%8C%8C%EB%A1%9C47%EB%82%98%EA%B8%B8+4+2%EC%B8%B5&ftid=0x357ca26d077872b7:0x229e6bbc6119abfb&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "FFX5Kjqwmqw",
+      "title": "고기 퀄 1등 냉동삼겹살 집?! 순두부찌개랑 후식 볶음밥까지 완벽한 K-냉삼코스 ⭐️",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "대삼식당",
+          "address": "대한민국 서울특별시 강남구 학동로41길 23 인현빌딩 1층",
+          "description": "대삼식당 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=FFX5Kjqwmqw",
+          "latitude": 37.5174802,
+          "longitude": 127.03618279999999,
+          "googleMapsId": "ChIJ_dI1m4qjfDURfJISmo4YRF4",
+          "googleMapsUri": "https://maps.google.com/?cid=6792581138730881660&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "5N6c1lWDGlA",
+      "title": "프라이빗한 룸에서 즐기는 최고급 파인다이닝",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "쿡투게더",
+          "address": "대한민국 서울특별시 용산구 한남동 이태원로54길 58-4 2층",
+          "description": "쿡투게더 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5N6c1lWDGlA",
+          "latitude": 37.5359091,
+          "longitude": 127.00086080000001,
+          "googleMapsId": "ChIJa9SP9XGjfDURnWY4j0pAb5U",
+          "googleMapsUri": "https://maps.google.com/?cid=10767895923040741021&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName 'CTG한남' != '쿡투게더'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "9Mv-0wckp_4",
+      "title": "선지와 고기를 듬뿍 넣은 국밥계의 최고봉!🥘 해장하러 갔다가 술 마시고 온다는 달래해장에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "달래해장",
+          "address": "대한민국 서울특별시 강남구 압구정로2길 46",
+          "description": "달래해장 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=9Mv-0wckp_4",
+          "latitude": 37.518904899999995,
+          "longitude": 127.02077059999999,
+          "googleMapsId": "ChIJbX0iRG6jfDURJESbZewEnuk",
+          "googleMapsUri": "https://maps.google.com/?cid=16833897870520960036&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "GyE6P3C0bbs",
+      "title": "현지에도 없는 전설의 와인?🍷 파스타와 와인에 진심인 이탈리안 레스토랑, 압구정 몽고네에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "몽고네",
+          "address": "대한민국 서울특별시 강남구 선릉로155길 5",
+          "description": "몽고네 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GyE6P3C0bbs",
+          "latitude": 37.5251096,
+          "longitude": 127.03908679999999,
+          "googleMapsId": "ChIJ-xmSEYijfDUR8ZeTjXmg00Q",
+          "googleMapsUri": "https://maps.google.com/?cid=4959484058591795185&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "zM5v9W65TME",
+      "title": "놀라운 풍미의 숙성 돼지고기!🥩 솥뚜껑에 고기를 구워 먹는 마포 월화식당에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "월화식당",
+          "address": "대한민국 서울특별시 마포구 도화길 ２９",
+          "description": "월화식당 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zM5v9W65TME",
+          "latitude": 37.540887399999995,
+          "longitude": 126.94915459999999,
+          "googleMapsId": "ChIJE2LrptaZfDURF3lUFnAoIM4",
+          "googleMapsUri": "https://maps.google.com/?cid=14852916032943978775&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "-6f9apDerjQ",
+      "title": "세계 최고 고기 전문가의 한우 코스 요리?🥩 다리오 체키니x본앤브레드 갈라 디너에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "다리오 체키니 x 본앤브레드",
+          "address": "대한민국 인천광역시 중구 영종해안남로321번길 186",
+          "description": "다리오 체키니 x 본앤브레드 — 비밀이야 in 한국 영상에서 소개한 인천 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-6f9apDerjQ",
+          "latitude": 37.4373338,
+          "longitude": 126.4558604,
+          "googleMapsId": "ChIJpVxgEOybezURxtwahZfhvz8",
+          "googleMapsUri": "https://maps.google.com/?cid=4593638185830636742&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '파라다이스시티' != '다리오 체키니 x 본앤브레드'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "YJRJmb4MCBg",
+      "title": "3만원 대에 즐기는 고퀄리티 스시 오마카세🍣 엄청난 경쟁률의 '스강신청'을 뚫고 아루히에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "아루히",
+          "address": "대한민국 서울특별시 영등포구 여의나루로 42 2 층",
+          "description": "아루히 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YJRJmb4MCBg",
+          "latitude": 37.521355899999996,
+          "longitude": 126.9249795,
+          "googleMapsId": "ChIJi-BCYCuffDURWmXyROcwyGk",
+          "googleMapsUri": "https://maps.google.com/?cid=7622396139176879450&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "buWff5isJ6k",
+      "title": "현대적으로 풀어낸 K-파인다이닝🍽 전복 & 칡소 밀푀유, 봄나물 플레이트 등 정성스럽고 독창적인 요리들을 소개합니다!",
+      "concept": "조선",
+      "locations": [
+        {
+          "name": "이타닉 가든",
+          "address": "조선 팰리스(센터필드 웨스트 타워 231, 테헤란로 강남구 서울특별시 대한민국",
+          "description": "이타닉 가든 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=buWff5isJ6k",
+          "latitude": 37.5030426,
+          "longitude": 127.04158799999998,
+          "googleMapsId": "ChIJKWHZw3alfDUR5A5F61Oqj5I",
+          "googleMapsUri": "https://maps.google.com/?cid=10560846928613281508&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "V5apja-6ibk",
+      "title": "한식과 프렌치 다이닝의 만남!🍴 극찬할 수밖에 없는 컨템포러리 레스토랑 임프레션에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "임프레션",
+          "address": "대한민국 서울특별시 강남구 언주로164길 24 아크로스빌딩 5층",
+          "description": "임프레션 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=V5apja-6ibk",
+          "latitude": 37.5254118,
+          "longitude": 127.0354751,
+          "googleMapsId": "ChIJcbkq34ujfDURIXMQBD5ajSA",
+          "googleMapsUri": "https://maps.google.com/?cid=2345630203332555553&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '오페라갤러리' != '임프레션'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "sky7MJvlLg0",
+      "title": "맛과 재료에 대한 장인 정신으로 미슐랭 스타를 받은 식당?⭐ 최고의 식재료로 구성된 독창적인 다이닝, 윤서울에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "윤서울",
+          "address": "대한민국 서울특별시 강남구 선릉로 805",
+          "description": "윤서울 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sky7MJvlLg0",
+          "latitude": 37.5241019,
+          "longitude": 127.0390343,
+          "googleMapsId": "ChIJT4iUTU6ZfDURTYMMNDveRLo",
+          "googleMapsUri": "https://maps.google.com/?cid=13422097135328592717&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "GZk8D24XmUs",
+      "title": "70년 전통의 부산 원조 양대창🥢 현지인도 인정한 부산 옛날오막집에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "옛날오막집",
+          "address": "대한민국 부산광역시 서구 구덕로274번길 14",
+          "description": "옛날오막집 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GZk8D24XmUs",
+          "latitude": 35.1090401,
+          "longitude": 129.01983769999998,
+          "googleMapsId": "ChIJjZWH8JnpaDUR39d3UN-d1NA",
+          "googleMapsUri": "https://maps.google.com/?cid=15047825837404968927&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "RMvBBd4hf9c",
+      "title": "최고의 재료로 선보이는 고급 튀김 오마카세!🍤 일식 덴푸라의 정점, 모퉁이우 덴푸라랩에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "모퉁이우 덴푸라랩",
+          "address": "대한민국 서울특별시 강남구 테헤란로 231 East동 2층",
+          "description": "모퉁이우 덴푸라랩 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=RMvBBd4hf9c",
+          "latitude": 37.5030426,
+          "longitude": 127.04158799999998,
+          "googleMapsId": "ChIJfQ-3AQ-lfDURwQLtsP99xd0",
+          "googleMapsUri": "https://maps.google.com/?cid=15980317389932528321&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '모퉁이우 LAP' != '모퉁이우 덴푸라랩'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "MoKj7rr_y18",
+      "title": "한식 파인 다이닝의 정수🍽 청담동에서 핫한 셰프님의 레스토랑에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "한상 더 테이블",
+          "address": "대한민국 서울특별시 강남구 청담동 선릉로148길 28 3층",
+          "description": "한상 더 테이블 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=MoKj7rr_y18",
+          "latitude": 37.5225636,
+          "longitude": 127.04183769999999,
+          "googleMapsId": "ChIJVSG3wKalfDURHmn_ief_JeU",
+          "googleMapsUri": "https://maps.google.com/?cid=16511884978741537054&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "y7IYTEl5lok",
+      "title": "한우 ++ 채끝살을 11개월 숙성한 밀랍 에이징 스테이크🥩 독특한 그릴 방식의 숙성 스테이크 끝판왕 레스토랑에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "엘픽 (청담)",
+          "address": "대한민국 서울특별시 강남구 청담동 11-12",
+          "description": "엘픽 (청담) — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=y7IYTEl5lok",
+          "latitude": 37.522294099999996,
+          "longitude": 127.04660609999999,
+          "googleMapsId": "ChIJUbDlEV6lfDURWTHYOyweWpQ",
+          "googleMapsUri": "https://maps.google.com/?cid=10689889840848712025&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "qxbRusRriwU",
+      "title": "투플러스 한우만 나오는 압구정 명품 오마카세🥩 예약이 전쟁이라는 이속우화 천공에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "이속우화 천공",
+          "address": "대한민국 서울특별시 강남구 논현로 857",
+          "description": "이속우화 천공 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=qxbRusRriwU",
+          "latitude": 37.5252994,
+          "longitude": 127.028074,
+          "googleMapsId": "ChIJt-wZuv2jfDURQJDHmNXIcDk",
+          "googleMapsUri": "https://maps.google.com/?cid=4139028877270290496&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Rgsb9S3PNSA",
+      "title": "🍖살살 녹는 동파육과 해삼주스 등 중국 본토의 맛 그대로 재현한 고급 중식당 계향각에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "계향각",
+          "address": "대한민국 서울특별시 종로구 동숭길 86",
+          "description": "계향각 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Rgsb9S3PNSA",
+          "latitude": 37.582043299999995,
+          "longitude": 127.00427739999999,
+          "googleMapsId": "ChIJA4VTNVCjfDUR3wCSv36B_qY",
+          "googleMapsUri": "https://maps.google.com/?cid=12033197635760423135&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "816WnjDFVf4",
+      "title": "26만원짜리 고급 한식 다이닝 코스?!🍽 미슐랭 3스타, 한국을 대표하는 식당 중 하나인 가온에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "가온",
+          "address": "대한민국 서울특별시 강남구 선릉로148길 48",
+          "description": "가온 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=816WnjDFVf4",
+          "latitude": 37.522844,
+          "longitude": 127.0434009,
+          "googleMapsId": "ChIJa1q-n3qkfDURTpuIGCW7_bA",
+          "googleMapsUri": "https://maps.google.com/?cid=12753555487782902606&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '레스토랑 온' != '가온'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "XmrnNH3YtBk",
+      "title": "홍콩 미쉐린 원 스타 중식당이 서울에?! 베이징 덕부터 디저트까지 총 26가지 메뉴 먹고 왔습니다!!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "신반포로 176 2f",
+          "address": "대한민국 서울특별시 서초구 신반포로 176 2f",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XmrnNH3YtBk",
+          "latitude": 37.5043637,
+          "longitude": 127.0036211,
+          "googleMapsId": "EjgyZiwgMTc2IFNpbmJhbnBvLXJvLCBTZW9jaG8gRGlzdHJpY3QsIFNlb3VsLCBTb3V0aCBLb3JlYSIeGhwKFgoUChIJI_BuLXqhfDURyLmEl4IAi7ISAjJm",
+          "googleMapsUri": "https://maps.google.com/?q=%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD+%EC%84%9C%EC%9A%B8%ED%8A%B9%EB%B3%84%EC%8B%9C+%EC%84%9C%EC%B4%88%EA%B5%AC+%EC%8B%A0%EB%B0%98%ED%8F%AC%EB%A1%9C+176+2f&ftid=0x357ca17a2d6ef023:0x567f5bab5d4d9966&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "joq90fyFDwk",
+      "title": "겨울에 땀 흘리며 먹는 전국 5대 짬뽕 도장깨기 2탄🔥 해물 가득, 찐한 국물의 역대급 짬뽕으로 유명한 중식당들만 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "군산 복성루",
+          "address": "대한민국 전북특별자치도 군산시 월명로 382",
+          "description": "군산 복성루 — 비밀이야 in 한국 영상에서 소개한 전북 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=joq90fyFDwk",
+          "latitude": 35.978199599999996,
+          "longitude": 126.71577149999999,
+          "googleMapsId": "ChIJySnRMA1ccDURtxHaIkCBV98",
+          "googleMapsUri": "https://maps.google.com/?cid=16093473905894363575&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "공주 동해원",
+          "address": "대한민국 충청남도 공주시 소학동 납다리길 22",
+          "description": "군산 복성루 — 비밀이야 in 한국 영상에서 소개한 전북 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=joq90fyFDwk",
+          "latitude": 36.4503086,
+          "longitude": 127.1478998,
+          "googleMapsId": "ChIJqx2wmv18LxUROnobqX_WlXc",
+          "googleMapsUri": "https://maps.google.com/?cid=8617029305829653050&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "-c3WDwRlgR4",
+      "title": "추운 날엔 전국 5대 짬뽕집 도장깨기🔥 얼큰칼칼 인생 짬뽕으로 유명한 중식당들만 모아 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "평택 영빈루",
+          "address": "대한민국 경기도 평택시 신장1동 탄현로 341",
+          "description": "평택 영빈루 — 비밀이야 in 한국 영상에서 소개한 경기도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-c3WDwRlgR4",
+          "latitude": 37.0827703,
+          "longitude": 127.0566166,
+          "googleMapsId": "ChIJMavS1CY5ezURnmNjjuLtY4k",
+          "googleMapsUri": "https://maps.google.com/?cid=9900017963197752222&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "강릉 교동반점",
+          "address": "대한민국 강원특별자치도 강릉시 강릉대로 205",
+          "description": "평택 영빈루 — 비밀이야 in 한국 영상에서 소개한 경기도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-c3WDwRlgR4",
+          "latitude": 37.758351,
+          "longitude": 128.8930428,
+          "googleMapsId": "ChIJm7moHPDlYTURZ3BFpb9MP8I",
+          "googleMapsUri": "https://maps.google.com/?cid=13996990552886046823&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "대구 진흥반점",
+          "address": "대한민국 대구광역시 남구 이천동 이천로28길 43-2",
+          "description": "평택 영빈루 — 비밀이야 in 한국 영상에서 소개한 경기도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-c3WDwRlgR4",
+          "latitude": 35.854814,
+          "longitude": 128.60052389999998,
+          "googleMapsId": "ChIJnzAg6fPjZTURiH9Wbw1h9xo",
+          "googleMapsUri": "https://maps.google.com/?cid=1943128474564067208&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Kz5DzbFptTw",
+      "title": "강원도 가면 꼭 들러야할 막국수집! 시원한 동치미 국물 + 투박한 메밀면의 조화가 일품인 강원도 고성 막국수집을 소개합니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "동루골 막국수",
+          "address": "대한민국 강원특별자치도 고성군 토성면 성대로 188 KR",
+          "description": "동루골 막국수 — 비밀이야 in 한국 영상에서 소개한 강원 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Kz5DzbFptTw",
+          "latitude": 38.2547172,
+          "longitude": 128.50948119999998,
+          "googleMapsId": "ChIJzY8l2wyW2F8RssvaVD5Y35A",
+          "googleMapsUri": "https://maps.google.com/?cid=10439159486002940850&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "X10ElovyR3Q",
+      "title": "서비스, 맛, 뷰 세 가지 다 잡은 중식당! 시그니처 북경오리 부터 해삼, 전복, 우럭찜, 맛있는 디저트까지! 대성공이었던 호텔 중식당을 여러분께 소개합니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "웨이루",
+          "address": "대한민국 서울특별시 강남구 삼성1동 영동대로 521 34층",
+          "description": "웨이루 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=X10ElovyR3Q",
+          "latitude": 37.5091322,
+          "longitude": 127.0608511,
+          "googleMapsId": "ChIJPewesGqkfDURRjO7ipzCe8U",
+          "googleMapsUri": "https://maps.google.com/?cid=14230181425205424966&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Fw3Gt0q0Jt4",
+      "title": "온갖 해산물이 다~ 나온다는 부산 로컬 횟집! 🐟 해삼과 전복부터 갯장어회, 줄가자미회, 추어탕에 튀김과 후식까지! 바다를 통째로 대접하는 찐맛집을 소개합니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "동백섬횟집",
+          "address": "대한민국 부산광역시 해운대구 해운대해변로209번나길 17",
+          "description": "동백섬횟집 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Fw3Gt0q0Jt4",
+          "latitude": 35.160415199999996,
+          "longitude": 129.1546803,
+          "googleMapsId": "ChIJy5ldq1iNaDURabM32dxJl_I",
+          "googleMapsUri": "https://maps.google.com/?cid=17480521691547808617&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "YPXPzy5Yzas",
+      "title": "고소한 회의 대표주자, 붕장어회 찐 맛집! 부산 무진장횟집",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "무진장횟집",
+          "address": "대한민국 부산광역시 기장군 기장읍 연화1길 137",
+          "description": "무진장횟집 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YPXPzy5Yzas",
+          "latitude": 35.2170742,
+          "longitude": 129.22612300000003,
+          "googleMapsId": "ChIJva8oOwCPaDURh9ta-sCJVk8",
+          "googleMapsUri": "https://maps.google.com/?cid=5716908238920407943&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "TSgUFZaOllY",
+      "title": "인생 갈치 맛집! 부산 가면 무조건, 국내 원탑 갈치요리 맛집을 찾아가봤습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "은해갈치",
+          "address": "대한민국 부산광역시 수영구 광안해변로295번길 4-7 1 층",
+          "description": "은해갈치 — 비밀이야 in 한국 영상에서 소개한 부산 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=TSgUFZaOllY",
+          "latitude": 35.1570265,
+          "longitude": 129.1259111,
+          "googleMapsId": "ChIJvT6_VovtaDURH50DzP97NhI",
+          "googleMapsUri": "https://maps.google.com/?cid=1312372679994744095&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "vdIHjpGFuL8",
+      "title": "1인 19만원의 광동식 프리미엄 중식당 더 그레이트 홍연, 과연 그 퀄리티는?",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "더 그레이트 홍연",
+          "address": "대한민국 서울특별시 강남구 테헤란로 231 조선 팰리스 36F",
+          "description": "더 그레이트 홍연 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vdIHjpGFuL8",
+          "latitude": 37.5030846,
+          "longitude": 127.04150159999998,
+          "googleMapsId": "ChIJeZSs-xulfDURzOfgmViQDFU",
+          "googleMapsUri": "https://maps.google.com/?cid=6128431903157577676&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "fVmHKwLv-TM",
+      "title": "정갈하고 세련된 전통 한식, 제철 식재료로 한식 파인다이닝을 선보이는 미슐랭 원스타 한식 레스토랑 온지음!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "온지음",
+          "address": "대한민국 서울특별시 종로구 효자로 49 4층",
+          "description": "온지음 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=fVmHKwLv-TM",
+          "latitude": 37.5804867,
+          "longitude": 126.97334880000001,
+          "googleMapsId": "ChIJk5DRDD2jfDURUA4aAk0Frx0",
+          "googleMapsUri": "https://maps.google.com/?cid=2138934176330157648&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "YKCqPgscTco",
+      "title": "이 가격에 이 맛이 가능하다고...?! 신라호텔 '팔선' 출신 셰프가 보여주는 중식 요리의 끝판왕! 이름값 제대로 하는 '진미'에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "진미",
+          "address": "대한민국 서울특별시 서대문구 연희맛로 36",
+          "description": "진미 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YKCqPgscTco",
+          "latitude": 37.567939599999995,
+          "longitude": 126.93101979999999,
+          "googleMapsId": "ChIJaQV-kgqZfDURGZ8NI605IAA",
+          "googleMapsUri": "https://maps.google.com/?cid=9070615034961689&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "tXufbXlZMUQ",
+      "title": "보양식 끝판왕 민어를 먹으러 노량진을 다녀왔습니다! 민어회, 민어전, 민어알전, 민어탕 등 민어의 향연(?)을 보여드립니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "노량진 수산시장",
+          "address": "대한민국 서울특별시 동작구 노들로 674",
+          "description": "노량진 수산시장 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tXufbXlZMUQ",
+          "latitude": 37.5149717,
+          "longitude": 126.93863420000001,
+          "googleMapsId": "ChIJOTEaKmiffDURNTst1Jzcm_c",
+          "googleMapsUri": "https://maps.google.com/?cid=17842096914891094837&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "h73yl8VKssc",
+      "title": "한우의 끝판왕! 온갖 부위 총출동하는 한우 오마카세를 소개합니다! (Feat. 아시아 탑50 레스토랑)",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "본앤브레드",
+          "address": "대한민국 서울특별시 성동구 마장로42길 1",
+          "description": "본앤브레드 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=h73yl8VKssc",
+          "latitude": 37.5667249,
+          "longitude": 127.0445221,
+          "googleMapsId": "ChIJ03uyyKqkfDURBP72STLlOHU",
+          "googleMapsUri": "https://maps.google.com/?cid=8446753105285414404&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "4D7r65Pp5oU",
+      "title": "갓벽한 파인다이닝 레스토랑, 독창적인 요리로 특별한 경험을 선사하는 최현석 셰프님의 쵸이닷에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "쵸이닷",
+          "address": "대한민국 서울특별시 강남구 도산대로 457 앙스돔빌딩 3층",
+          "description": "쵸이닷 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=4D7r65Pp5oU",
+          "latitude": 37.5243614,
+          "longitude": 127.04659009999999,
+          "googleMapsId": "ChIJYz_NPnqkfDURqEJ3EeoGY5Y",
+          "googleMapsUri": "https://maps.google.com/?cid=10836512730768687784&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "3Aq-UnJ_kNw",
+      "title": "곧 핫해질 신상 파스타 맛집?! 오픈과 동시에 예약이 치열한 가성비 좋은 레스토랑 소개합니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "페리지",
+          "address": "대한민국 서울특별시 강남구 봉은사로68길 6-5 1층",
+          "description": "페리지 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=3Aq-UnJ_kNw",
+          "latitude": 37.5112619,
+          "longitude": 127.04949069999999,
+          "googleMapsId": "ChIJGc7HIKOlfDUR8CD_FNhLaEQ",
+          "googleMapsUri": "https://maps.google.com/?cid=4929273183594291440&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "v2EG4EOw2Hs",
+      "title": "프랑스 미슐랭 2스타 출신 셰프의 시그니처 메뉴는?! 입문용으로 좋은 프렌치 레스토랑 소개해드립니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "오와이(OY)",
+          "address": "대한민국 서울특별시 강남구 청담동 19-13",
+          "description": "오와이(OY) — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=v2EG4EOw2Hs",
+          "latitude": 37.5221993,
+          "longitude": 127.04329919999999,
+          "googleMapsId": "ChIJR1GiswGlfDURukx-bP-iXiw",
+          "googleMapsUri": "https://maps.google.com/?cid=3197172003400207546&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '레스토랑 오와이' != '오와이(OY)'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "XW7KJlOAWlo",
+      "title": "술 없이는 못 배기는 역대급 가성비 가맥집! 을지로 신중부시장에 꼭꼭 숨어있는 보물 같은 찐맛집 다녀왔습니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "지하식당",
+          "address": "대한민국 서울특별시 중구 을지로32길 24",
+          "description": "지하식당 — 비밀이야 in 한국 영상에서 소개한 서울특별시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XW7KJlOAWlo",
+          "latitude": 37.565621199999995,
+          "longitude": 126.99993239999999,
+          "googleMapsId": "ChIJ06rKw7yjfDURVEVkhT8sqvY",
+          "googleMapsUri": "https://maps.google.com/?cid=17774067530703586644&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "lONALAWayq0",
+      "title": "제주 바다 경치 보면서 먹는 흑돼지 삼겹살! 여행 가면 무조건 가봐야 하는 제주도 찐 로컬 맛집을 소개합니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "바다사랑 그리고 추억",
+          "address": "대한민국 제주시",
+          "description": "바다사랑 그리고 추억 — 비밀이야 in 한국 영상에서 소개한 제주특별자치도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=lONALAWayq0",
+          "latitude": 33.487540700000004,
+          "longitude": 126.3906007,
+          "googleMapsId": "ChIJA4kHzifxDDURNy62gv_Fals",
+          "googleMapsUri": "https://maps.google.com/?cid=6587295106183081527&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "CL-R1SOkXjk",
+      "title": "1인분에 35,000원인 오겹살 정식이 있다?! 전라도식 역대급 상차림을 보면 납득이 가는 숨겨진 찐맛집!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "사랑채",
+          "address": "대한민국 서울특별시 도봉구 방학동 696-13",
+          "description": "사랑채 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CL-R1SOkXjk",
+          "latitude": 37.6652754,
+          "longitude": 127.03688679999999,
+          "googleMapsId": "ChIJk6Soe8q-fDUR8Z-_YZ2o7Bk",
+          "googleMapsUri": "https://maps.google.com/?cid=1868053339355193329&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "aFXSdqpBd08",
+      "title": "100% 메밀면 막국수에 손이 계속 가는 감자옹심이는 덤, 속초에 가면 무조건 가야 되는 숨겨진 막국수 맛집 알려드립니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "청대리막국수",
+          "address": "대한민국 강원특별자치도 속초시 청대마을길 37",
+          "description": "청대리막국수 — 비밀이야 in 한국 영상에서 소개한 강원 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=aFXSdqpBd08",
+          "latitude": 38.1861554,
+          "longitude": 128.57127,
+          "googleMapsId": "ChIJhSDVDGG72F8R0ijodcZQzfI",
+          "googleMapsUri": "https://maps.google.com/?cid=17495728940716140754&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "HrcehmBmN9U",
+      "title": "국내 삼겹살은 바로 여기! 풍미가 일품인 두툼한 숙성 삽겹살과 목살, 고추장찌개의 맛.없.없 조합!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "두툼",
+          "address": "대한민국 서울특별시 중구 중림로 10",
+          "description": "두툼 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=HrcehmBmN9U",
+          "latitude": 37.558348099999996,
+          "longitude": 126.96626599999999,
+          "googleMapsId": "ChIJGTNESWOifDUR6rXqMfLuJ6g",
+          "googleMapsUri": "https://maps.google.com/?cid=12116916046450570730&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "P9iTNwRl2NE",
+      "title": "술꾼들의 성지, '이모카세'하면 빠질 수 없는 을지로에서 가장 핫한 노포집, 나드리식품에 다녀왔습니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "나드리식품",
+          "address": "대한민국 서울특별시 중구 주교동 208",
+          "description": "나드리식품 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=P9iTNwRl2NE",
+          "latitude": 37.567360099999995,
+          "longitude": 126.998485,
+          "googleMapsId": "ChIJ10VnS2mjfDURhl274CZJWj4",
+          "googleMapsUri": "https://maps.google.com/?cid=4492984009583451526&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "k_zGFWz_bLQ",
+      "title": "기가 막히는 고소함과 담백함, 소맥이 땡기는 마성의 소곱창집! 곱창계 탑티어, 독보적인 퀄리티의 곱창집을 소개합니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "황소곱창",
+          "address": "대한민국 서울특별시 관악구 관악로15길 39",
+          "description": "황소곱창 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=k_zGFWz_bLQ",
+          "latitude": 37.48031840000001,
+          "longitude": 126.9501562,
+          "googleMapsId": "ChIJed82aImffDURhDrohrdfLsM",
+          "googleMapsUri": "https://maps.google.com/?cid=14064283928171657860&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "OEJ6aZO1adA",
+      "title": "서울에서 가장 핫한 생면 파스타 바! 입소문 덕에 극강의 예약 난이도를 자랑하는 파스타의 성지에 다녀왔습니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "바위파스타바",
+          "address": "대한민국 서울특별시 성동구 뚝섬로15길 27 1층",
+          "description": "바위파스타바 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=OEJ6aZO1adA",
+          "latitude": 37.5390966,
+          "longitude": 127.0615447,
+          "googleMapsId": "ChIJHamttkulfDURzuUBJv_q9zc",
+          "googleMapsUri": "https://maps.google.com/?cid=4032950372908787150&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Z6QAEI3NQB4",
+      "title": "1인 55만원의 중식 보양식은 어떻게 나올까? 샥스핀, 불도장, 건전복과 건해삼 등 최고의 식재료로 만든 중국 코스요리 끝판왕!!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "다이닝마",
+          "address": "대한민국 서울특별시 강남구 신사동 630-12 번지 유일빌딩",
+          "description": "다이닝마 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Z6QAEI3NQB4",
+          "latitude": 37.5224604,
+          "longitude": 127.0342548,
+          "googleMapsId": "ChIJDdo1BIyjfDURydvP4pu-KmI",
+          "googleMapsUri": "https://maps.google.com/?cid=7073675741473266633&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "CeA59CKY0s0",
+      "title": "4년 연속 아시아 베스트 레스토랑 50의 영광, 최애 셰프님들 중 한 분인 김대천 셰프님의 가심비 훌륭한  국내 탑티어 프렌치 레스토랑",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "톡톡",
+          "address": "대한민국 서울특별시 강남구 청담동 69-5",
+          "description": "톡톡 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CeA59CKY0s0",
+          "latitude": 37.522371199999995,
+          "longitude": 127.05429789999998,
+          "googleMapsId": "ChIJDRB8ZoijfDURnAHuRSEyC9I",
+          "googleMapsUri": "https://maps.google.com/?cid=15135246091197219228&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "bkTjH5wRSb4",
+      "title": "감칠맛 폭발 대표 밥도둑들의 향연!! 50년 내공의 오징어볶음, 제육볶음, 삼겹살, 부대찌개 전문 덕수궁 맛집, 한 번 가면 단골됩니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "덕수정",
+          "address": "대한민국 서울특별시 중구 정동길 41",
+          "description": "덕수정 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bkTjH5wRSb4",
+          "latitude": 37.5658718,
+          "longitude": 126.9725764,
+          "googleMapsId": "ChIJ1Rr8U4yifDUR86FqeRsdDWA",
+          "googleMapsUri": "https://maps.google.com/?cid=6921220206176674291&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "aOKKm_3e4HU",
+      "title": "극강의 풍미, 밀랍 에이징 스테이크 - 세계 TOP 5 레스토랑 출신 셰프가 선사하는 스테이크의 정점",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "엘픽",
+          "address": "대한민국 제주특별자치도 제주시 특별자치도, 이도이동 번지 B 1946-7 KR동 101호 이도해든빌",
+          "description": "엘픽 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=aOKKm_3e4HU",
+          "latitude": 33.4939227,
+          "longitude": 126.54440699999999,
+          "googleMapsId": "ChIJeev34Lf8DDURZMmerU2ZpM4",
+          "googleMapsUri": "https://maps.google.com/?cid=14890194826898098532&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '엘코테' != '엘픽'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "5U7Ii_DL1IA",
+      "title": "서울에서 맛보는 통영 해산물 코스 요리? 통영 제철 해산물을 고급스럽게 풀어낸 실비집! 신선한 통영의 맛을 그대로 옮겨놓았습니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "네기실비",
+          "address": "대한민국 서울특별시 사직동 새문안로2길 10",
+          "description": "네기실비 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5U7Ii_DL1IA",
+          "latitude": 37.56867,
+          "longitude": 126.9719913,
+          "googleMapsId": "ChIJgQ0c33KjfDURI38F56rkDW8",
+          "googleMapsUri": "https://maps.google.com/?cid=8002303535578709795&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "JrUue6fuz1Q",
+      "title": "신라호텔에 있는 국내 최고의 프렌치 레스토랑?! 파리 샹젤리제에 온 듯한 완벽한 식사를 즐길 수 있는 곳 알려드립니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "콘티넨탈",
+          "address": "대한민국 서울특별시 중구 장충동 동호로 249 23층",
+          "description": "콘티넨탈 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JrUue6fuz1Q",
+          "latitude": 37.5555698,
+          "longitude": 127.0053793,
+          "googleMapsId": "ChIJ6xPyuhqjfDURdwrynnNFQIE",
+          "googleMapsUri": "https://maps.google.com/?cid=9313520392292403831&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "b3QLNrlMWe0",
+      "title": "시골집 분위기에서 먹는 가성비 좋은 한우 등심! 돌판 된장찌개와 푸짐한 반찬까지! 강원도 양양 찐맛집 알려드립니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "산촌생등심",
+          "address": "대한민국 강원특별자치도 양양군 강현면 안골로 58",
+          "description": "산촌생등심 — 비밀이야 in 한국 영상에서 소개한 강원 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=b3QLNrlMWe0",
+          "latitude": 38.1195493,
+          "longitude": 128.6212543,
+          "googleMapsId": "ChIJPf9c0Yqv2F8R4xM2K-q6mSs",
+          "googleMapsUri": "https://maps.google.com/?cid=3141747729977709539&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "UyGAcSzeE_Y",
+      "title": "유명 맛집 블로거가 작정하고 식당을 열었더니 벌어진 일!? 성수동에서 곧 떠오를 핫플 미리 좌표 찍어드립니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "탐광",
+          "address": "대한민국 서울특별시 성동구 연무장5가길 26",
+          "description": "탐광 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=UyGAcSzeE_Y",
+          "latitude": 37.543174799999996,
+          "longitude": 127.0554194,
+          "googleMapsId": "ChIJqwYQP7GlfDURUf45ubqmupE",
+          "googleMapsUri": "https://maps.google.com/?cid=10500888802069446225&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "bvQzXbZx1_c",
+      "title": "백종원님도 찾아온다는 서울 한복판의 숨은 맛집! 일단 들어와서 앉으면 술이 술술 들어와서 맨정신에 절대 못 나가는 민물 매운탕 맛집",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "남한강민물매운탕",
+          "address": "대한민국 서울특별시 광진구 동일로 150",
+          "description": "남한강민물매운탕",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bvQzXbZx1_c",
+          "latitude": 37.545624,
+          "longitude": 127.06623479999999,
+          "googleMapsId": "ChIJo8BOg8GkfDURYiKyJ4h6rbw",
+          "googleMapsUri": "https://maps.google.com/?cid=13595657575301522018&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "LA-2LRALV6Y",
+      "title": "고기 먹으러 가는 칼국수 가게가 있다!? 서울에서 한복판에서 술이 쭉쭉 들어가는 40년 된 찐 맛집",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "한성칼국수",
+          "address": "대한민국 서울특별시 강남구 언주로148길 14",
+          "description": "한성칼국수 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=LA-2LRALV6Y",
+          "latitude": 37.5204277,
+          "longitude": 127.0355263,
+          "googleMapsId": "ChIJZxEZioyjfDURaXYvWpn5HoY",
+          "googleMapsUri": "https://maps.google.com/?cid=9664436287422035561&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "uwucfKp_tDU",
+      "title": "돼지고기 항정살 가브리살 먹을때 좌표 찍어드립니다. 최자로드에서도 강추했던 그 식당! 고기 1타 강사가 추천하는 서울 찐맛집!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "남영돈",
+          "address": "대한민국 서울특별시 용산구 한강대로80길 17",
+          "description": "남영돈 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=uwucfKp_tDU",
+          "latitude": 37.5427516,
+          "longitude": 126.9737792,
+          "googleMapsId": "ChIJP6v5WGqifDURqzEHpjw0aSA",
+          "googleMapsUri": "https://maps.google.com/?cid=2335455316856484267&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "NPTKG-99lDY",
+      "title": "코리아에서 먹는 재팬+차이나!? 특급 호텔 출신 셰프가 만드는 국경을 넘나드는 콜라보! 몇 달을 기다리더라도 또 갈만한 서울의 중식+일식 찐맛집",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "코자차",
+          "address": "대한민국 서울특별시 강남구 학동로97길 17 코자차 1층",
+          "description": "코자차 — 비밀이야 in 한국 영상에서 소개한 서울시 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=NPTKG-99lDY",
+          "latitude": 37.5208304,
+          "longitude": 127.05519749999999,
+          "googleMapsId": "ChIJA9AuSt6nfDUREwYp8ug55jQ",
+          "googleMapsUri": "https://maps.google.com/?cid=3811797807273674259&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "UC__68w0Ohs",
+      "title": "호불호 끝판왕! 홍어로 논문 쓴 사람이 요리하면 어떤 음식이 만들어질까? 서울에서 찾기 힘든 홍어 제대로 하는 곳, 술 안 먹고 버틸 수 없는 찐맛집",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "흑산도홍어",
+          "address": "대한민국 서울특별시 서초구 방배천로 40-2 1층",
+          "description": "흑산도홍어 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=UC__68w0Ohs",
+          "latitude": 37.4801625,
+          "longitude": 126.98266100000001,
+          "googleMapsId": "ChIJ6dOX7kygfDURpajP-GSfmUE",
+          "googleMapsUri": "https://maps.google.com/?cid=4726984539921950885&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "ECpmFVpTWMA",
+      "title": "맛, 가격, 분위기 모두 잡은 소고기! 저렴하면 허름하다!? 편견을 깬 서울 가성비 맛집 소개합니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "청기와타운",
+          "address": "대한민국 서울특별시 영등포구 영중로10길 32-4",
+          "description": "청기와타운 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ECpmFVpTWMA",
+          "latitude": 37.5184131,
+          "longitude": 126.90841129999998,
+          "googleMapsId": "ChIJgSEdlLyffDURO00NoDEUt1M",
+          "googleMapsUri": "https://maps.google.com/?cid=6032312429257248059&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "G_lKwwiQAp0",
+      "title": "술 한잔 달라고 했더니, 술잔 40개 꺼내주는 곳!? 술잔뿐 아니라 음식도 다채로운 일식집! 강남에서 요즘 제대로 핫한 오마카세에 다녀왔습니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "모노로그",
+          "address": "대한민국 서울특별시 강남구 논현동 논현로149길 31",
+          "description": "모노로그 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=G_lKwwiQAp0",
+          "latitude": 37.5176805,
+          "longitude": 127.0260498,
+          "googleMapsId": "ChIJI3SWN-yjfDURn1o04NAbqv8",
+          "googleMapsUri": "https://maps.google.com/?cid=18422567809641110175&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "0ZzX_AAC4HM",
+      "title": "12만원짜리 튀김은 도대체 어떤 맛일까!? 미슐랭 가이드에 선정된 튀김! 청담동에 있는 꼬치 튀김 오마카세에 다녀왔습니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "쿠시아게진",
+          "address": "대한민국 서울특별시 강남구 선릉로148길 52-10 4층",
+          "description": "쿠시아게진 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0ZzX_AAC4HM",
+          "latitude": 37.5223831,
+          "longitude": 127.0436851,
+          "googleMapsId": "ChIJLyL4QselfDURVJtQTiK3xBQ",
+          "googleMapsUri": "https://maps.google.com/?cid=1496522334164523860&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "DYuqqnMKM60",
+      "title": "맛, 가격 둘 다 잡은 동해안 1위 자연산 횟집, 누구에게나 추천하는 가성비 좋은 횟집 알려드립니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "돌바우횟집",
+          "address": "대한민국 강원특별자치도 양양군 현남면 남애리 73",
+          "description": "돌바우횟집 — 비밀이야 in 한국 영상에서 소개한 강원도 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DYuqqnMKM60",
+          "latitude": 37.9397222,
+          "longitude": 128.78777780000001,
+          "googleMapsId": "ChIJt1NqCtRX318RhX4aEw_AlRk",
+          "googleMapsUri": "https://maps.google.com/?cid=1843590793455632005&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Wn1r8bWmeUA",
+      "title": "제주도 가면 흑돼지, 회도 좋지만 여기 가보는 건 어때요? 그동안 숨겨져있던 제대로 된 맛집 공개합니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "삼강식당",
+          "address": "대한민국 제주특별자치도 서귀포시 서호동 1148-13",
+          "description": "삼강식당 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Wn1r8bWmeUA",
+          "latitude": 33.259458099999996,
+          "longitude": 126.51184459999999,
+          "googleMapsId": "ChIJaQEKdGhRDDURXXAtfnpMaQQ",
+          "googleMapsUri": "https://maps.google.com/?cid=317869337692958813&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "qxkYbEmQVj4",
+      "title": "지금 꼭 먹어야 하는 회!? 노량진 수산시장에서 가장 믿을 수 있는 20년 단골집 공개합니다. 수산시장 어려우면 그냥 여기서 드세요.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "형제상회",
+          "address": "대한민국 서울특별시 동작구 노들로 674",
+          "description": "형제상회 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=qxkYbEmQVj4",
+          "latitude": 37.514742,
+          "longitude": 126.93778839999999,
+          "googleMapsId": "ChIJCe4nHvqffDURAMbnXmtutsc",
+          "googleMapsUri": "https://maps.google.com/?cid=14390811066741802496&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "4J0OM2n3M8o",
+      "title": "곧 비싸질 곳입니다. 저렴하게 소고기 먹으려면 빨리 가세요. 어렵게 찾은 가성비 한우 오마카세!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "우화",
+          "address": "대한민국 경기도 성남시 분당구 동판교로177번길 25",
+          "description": "우화 — 비밀이야 in 한국 영상에서 소개한 경기 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=4J0OM2n3M8o",
+          "latitude": 37.3972827,
+          "longitude": 127.11353310000001,
+          "googleMapsId": "ChIJteK8E3ZZezURvmLS5XtUvWY",
+          "googleMapsUri": "https://maps.google.com/?cid=7403166253580444350&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "bE0P3hvYjrM",
+      "title": "전라도 목포에 가면 가야할 횟집 TOP2! 민어vs홍어?? 둘 중에 고민하지 말고 그냥 둘 다 가세요.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "영란회집",
+          "address": "대한민국 전라남도 목포시 번화로 42-1",
+          "description": "영란회집 — 비밀이야 in 한국 영상에서 소개한 전남 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bE0P3hvYjrM",
+          "latitude": 34.786139299999995,
+          "longitude": 126.38408969999999,
+          "googleMapsId": "ChIJn2Fco9GkczURizxqbXUr-P0",
+          "googleMapsUri": "https://maps.google.com/?cid=18300424869166857355&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '영란횟집' != '영란회집'; verify"
+        },
+        {
+          "name": "금메달식당",
+          "address": "대한민국 경기도 수원시 영통구 광교중앙로25번길 108",
+          "description": "영란회집 — 비밀이야 in 한국 영상에서 소개한 전남 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bE0P3hvYjrM",
+          "latitude": 37.277491999999995,
+          "longitude": 127.0504408,
+          "googleMapsId": "ChIJFy7bHgBbezUREpmemC3l2wk",
+          "googleMapsUri": "https://maps.google.com/?cid=710413350237804818&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "ry3DwbV982U",
+      "title": "이거 된장찌개 아닙니다. 청국장도 아닙니다. 예멘 난민 출신 셰프가 만드는 리얼 아랍 음식입니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "와르다레스토랑",
+          "address": "대한민국 제주특별자치도 제주시 관덕로8길 24-1",
+          "description": "와르다레스토랑 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ry3DwbV982U",
+          "latitude": 33.5110433,
+          "longitude": 126.52311669999999,
+          "googleMapsId": "ChIJrRc-m4LjDDURgGLY3LPdjE0",
+          "googleMapsUri": "https://maps.google.com/?cid=5588085002233995904&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "yl0-vdm_UWE",
+      "title": "내장,껍질까지 다 털어(?)먹는 30만원짜리 회! 제주도까지 갔으면 그냥 여기서 드세요.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "남경미락",
+          "address": "대한민국 제주특별자치도 서귀포시 안덕면 사계리 2032-3",
+          "description": "남경미락 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=yl0-vdm_UWE",
+          "latitude": 33.2301979,
+          "longitude": 126.3089371,
+          "googleMapsId": "ChIJtSuY-apDDDURCWH9D2HEtIw",
+          "googleMapsUri": "https://maps.google.com/?cid=10138944582276964617&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "v8eVP8yIT7Y",
+      "title": "일본 북해도에 더 이상 여행을 가지 않아도 되는 이유, \"서울 용산을 침략한 징기스칸\"",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "야스노야 지로",
+          "address": "대한민국 서울특별시 용산구 후암로 8-1 1층",
+          "description": "야스노야 지로 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=v8eVP8yIT7Y",
+          "latitude": 37.546686199999996,
+          "longitude": 126.978394,
+          "googleMapsId": "ChIJSbjWNuWjfDURWnNsN5FeBPw",
+          "googleMapsUri": "https://maps.google.com/?cid=18159743575257805658&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '야스노야 본점' != '야스노야 지로'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "AtN8zdqv_GU",
+      "title": "가성비 최고인 미슐랭 파인다이닝 알려드립니다. 특히 런치는 갓성비!!!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "테이블포포",
+          "address": "대한민국 서울특별시 서초구 사평대로14길 11 명빌딩 2층",
+          "description": "테이블포포 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=AtN8zdqv_GU",
+          "latitude": 37.4977466,
+          "longitude": 126.99444119999998,
+          "googleMapsId": "ChIJbY8gfgChfDURNJ3dt_gtrD0",
+          "googleMapsUri": "https://maps.google.com/?cid=4443977478567730484&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "8tRknqMN62A",
+      "title": "10년간 순대를 연구하면 만들어지는 순대 코스요리??",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "순대실록",
+          "address": "대한민국 서울특별시 종로구 동숭길 113 스타벅스 동숭로 아트점 맞은편 1층",
+          "description": "순대실록 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=8tRknqMN62A",
+          "latitude": 37.5829777,
+          "longitude": 127.00365839999999,
+          "googleMapsId": "ChIJe1KSjyyjfDURjZzF2YW58Q4",
+          "googleMapsUri": "https://maps.google.com/?cid=1076845770453654669&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "nNsC7LceKJI",
+      "title": "국밥으로 책 쓴 사람이 추천하는 소고기 국밥 TOP2!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "옥야식당",
+          "address": "대한민국 경상북도 안동시 중앙시장2길 46",
+          "description": "옥야식당 — 비밀이야 in 한국 영상에서 소개한 경북 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=nNsC7LceKJI",
+          "latitude": 36.5638614,
+          "longitude": 128.7232269,
+          "googleMapsId": "ChIJVwJBhE-hZjURpaMERSWmLgE",
+          "googleMapsUri": "https://maps.google.com/?cid=85188121968550821&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "종로식당",
+          "address": "대한민국 경상남도 의령군 의령읍 중동리 340-1",
+          "description": "옥야식당 — 비밀이야 in 한국 영상에서 소개한 경북 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=nNsC7LceKJI",
+          "latitude": 35.320245199999995,
+          "longitude": 128.2615751,
+          "googleMapsId": "ChIJ3QSv1sUZbzURyeZVKXcPdN4",
+          "googleMapsUri": "https://maps.google.com/?cid=16029453978187458249&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "XVthK_PAeE0",
+      "title": "내가 여수에 갔던 이유! 10년 단골 횟집 공개합니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "미로횟집",
+          "address": "대한민국 전라남도 여수시 시청서3길 18 KR",
+          "description": "미로횟집 — 비밀이야 in 한국 영상에서 소개한 전남 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XVthK_PAeE0",
+          "latitude": 34.7576472,
+          "longitude": 127.65676020000001,
+          "googleMapsId": "ChIJqbZhx0rebTURjJetLwo1nA0",
+          "googleMapsUri": "https://maps.google.com/?cid=980717136725776268&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "NhR_t31ZnTg",
+      "title": "돼지고기 목살은 고민하지 말고 여기서 드세요.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "월화고기 보라매점",
+          "address": "대한민국 서울특별시 관악구 보라매로3길 16",
+          "description": "월화고기 보라매점 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=NhR_t31ZnTg",
+          "latitude": 37.4915849,
+          "longitude": 126.9262895,
+          "googleMapsId": "ChIJjxNXJYSffDUReYRP76rkI78",
+          "googleMapsUri": "https://maps.google.com/?cid=13773103508239647865&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "KPXaJlslTB0",
+      "title": "홍대에 코스요리가 나오는 한식주점이 있다?",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "윤서울",
+          "address": "대한민국 서울특별시 강남구 선릉로 805",
+          "description": "윤서울 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KPXaJlslTB0",
+          "latitude": 37.5241019,
+          "longitude": 127.0390343,
+          "googleMapsId": "ChIJT4iUTU6ZfDURTYMMNDveRLo",
+          "googleMapsUri": "https://maps.google.com/?cid=13422097135328592717&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "fihh77lJ4Rk",
+      "title": "15kg짜리 거대 다금바리를 먹어보았습니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "진미명가",
+          "address": "대한민국 제주특별자치도 서귀포시 특별자치도, 안덕면 사계리 2072",
+          "description": "진미명가 — 비밀이야 in 한국 영상에서 소개한 제주 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=fihh77lJ4Rk",
+          "latitude": 33.2282947,
+          "longitude": 126.30764549999999,
+          "googleMapsId": "ChIJXd3oQqtDDDUR6hpyDvZTaqw",
+          "googleMapsUri": "https://maps.google.com/?cid=12423834838324353770&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "7lpgOuZ4fl4",
+      "title": "경상도 갈비 3대장! 한우갈비 맛집 TOP3 추천합니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "안동 거창숯불갈비",
+          "address": "대한민국 경상북도 안동시 음식의길 10",
+          "description": "안동 거창숯불갈비",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=7lpgOuZ4fl4",
+          "latitude": 36.5635453,
+          "longitude": 128.73197299999998,
+          "googleMapsId": "ChIJA-9NHQChZjURBPg4puCtQUQ",
+          "googleMapsUri": "https://maps.google.com/?cid=4918403448438323204&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '거창갈비' != '안동 거창숯불갈비'; verify"
+        },
+        {
+          "name": "경주 영양숯불갈비",
+          "address": "대한민국 경상북도 경주시 중부동 봉황로 79",
+          "description": "안동 거창숯불갈비",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=7lpgOuZ4fl4",
+          "latitude": 35.8466002,
+          "longitude": 129.209979,
+          "googleMapsId": "ChIJU32P60ZOZjURbaGUpXNJr3o",
+          "googleMapsUri": "https://maps.google.com/?cid=8840365354599620973&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "대구 성주숯불갈비",
+          "address": "대한민국 대구광역시 중구 서성로 72",
+          "description": "안동 거창숯불갈비",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=7lpgOuZ4fl4",
+          "latitude": 35.87287,
+          "longitude": 128.58778329999998,
+          "googleMapsId": "ChIJr0PcHuzjZTURZEf_3LpN2DQ",
+          "googleMapsUri": "https://maps.google.com/?cid=3807878949908727652&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '성주숯불갈비식당' != '대구 성주숯불갈비'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "xnGc9Il7W7o",
+      "title": "고기가 들어간 파이? '뚝뜨'를 먹어보았습니다.",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "쏠레이",
+          "address": "대한민국 서울특별시 강남구 도산대로70길 9",
+          "description": "쏠레이 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xnGc9Il7W7o",
+          "latitude": 37.5230112,
+          "longitude": 127.0452519,
+          "googleMapsId": "ChIJ_fozoDelfDUR7cnj-YzUg4I",
+          "googleMapsUri": "https://maps.google.com/?cid=9404594148832692717&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "tSoG6X0XfGY",
+      "title": "서울에서 잠깐 '프랑스' 다녀오는 방법?",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "쏠레이",
+          "address": "대한민국 서울특별시 강남구 도산대로70길 9",
+          "description": "쏠레이 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tSoG6X0XfGY",
+          "latitude": 37.5230112,
+          "longitude": 127.0452519,
+          "googleMapsId": "ChIJ_fozoDelfDUR7cnj-YzUg4I",
+          "googleMapsUri": "https://maps.google.com/?cid=9404594148832692717&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "I49Ary6aQZs",
+      "title": "1개에 5,000원인 군만두는 어떤 맛일까!?",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "팔선",
+          "address": "대한민국 서울특별시 중구 장충동 동호로 249 서울신라호텔 2층",
+          "description": "팔선 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=I49Ary6aQZs",
+          "latitude": 37.5561036,
+          "longitude": 127.0052196,
+          "googleMapsId": "ChIJNVgZxRqjfDURWvKbkSRzZa4",
+          "googleMapsUri": "https://maps.google.com/?cid=12566576936146170458&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "cbjuC1A1utQ",
+      "title": "한식?일식?양식? 어쨌든 맛있는 곳! 7th door에 다녀왔습니다! - 2부",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "세븐스도어",
+          "address": "대한민국 서울특별시 강남구 학동로97길 41 4층",
+          "description": "세븐스도어 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=cbjuC1A1utQ",
+          "latitude": 37.522371199999995,
+          "longitude": 127.05429789999998,
+          "googleMapsId": "ChIJJ1xm8n-lfDUR5AOAQSJ0oeM",
+          "googleMapsUri": "https://maps.google.com/?cid=16402519008336675812&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "ABfRMRTR4R4",
+      "title": "발효와 숙성의 최상의 맛! 7th door에 다녀왔습니다! - 1부",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "세븐스도어",
+          "address": "대한민국 서울특별시 강남구 학동로97길 41 4층",
+          "description": "세븐스도어 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ABfRMRTR4R4",
+          "latitude": 37.522371199999995,
+          "longitude": 127.05429789999998,
+          "googleMapsId": "ChIJJ1xm8n-lfDUR5AOAQSJ0oeM",
+          "googleMapsUri": "https://maps.google.com/?cid=16402519008336675812&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Pb1P3fqEf3E",
+      "title": "냉부해 정호영쉐프의 미슐랭가이드 맛집, 카덴에 다녀왔습니다!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "1) 카덴",
+          "address": "대한민국 서울특별시 서대문구 연희로 173",
+          "description": "2) 비스트로카덴",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Pb1P3fqEf3E",
+          "latitude": 37.5725045,
+          "longitude": 126.9350565,
+          "googleMapsId": "ChIJifoygYqYfDURgmK0deX_niU",
+          "googleMapsUri": "https://maps.google.com/?cid=2710885386710966914&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "2) 비스트로카덴",
+          "address": "대한민국 서울특별시 서대문구 연희로25길 12",
+          "description": "2) 비스트로카덴",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Pb1P3fqEf3E",
+          "latitude": 37.5727291,
+          "longitude": 126.9346971,
+          "googleMapsId": "ChIJQY6VKB2ZfDURGHUg6L2Rah8",
+          "googleMapsUri": "https://maps.google.com/?cid=2263782007536383256&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "K-PIrdvtS-I",
+      "title": "[내 맛집을 소개합니다] 주옥ㅣ더 플라자 호텔ㅣ모던 한식ㅣ신창호 셰프ㅣ최애하는 식당 중 하나ㅣ뷰 맛집(feat. 집회와 시위)ㅣ외모와 다른 셰프님의 섬세함ㅋ",
+      "concept": "대한민국",
+      "locations": []
+    },
+    {
+      "videoId": "SYClED7ExoA",
+      "title": "[내 맛집을 소개합니다] 포항 죽도동 동창생ㅣ45,000원 맡김 차림ㅣ기본 찬만으로 소주 3병 가능!!ㅣ다 맛있지만 김치가 예술!ㅣ자연산 전복죽도 예술!ㅣ그냥 다 예술!",
+      "concept": "대한민국",
+      "locations": []
+    },
+    {
+      "videoId": "5uYi_r1_Ec0",
+      "title": "[내 맛집을 소개합니다] 종로 원서동 한식공간ㅣ조희숙 셰프님의 섬세한 모던 한식ㅣ맛있는 한식은 물론 멋진 뷰까지!!",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "한식공간",
+          "address": "대한민국 서울특별시 종로구 원서동 219",
+          "description": "한식 셰프들의 스승 조희숙 셰프님이 계신 종로의 한식공간!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5uYi_r1_Ec0",
+          "latitude": 37.5775971,
+          "longitude": 126.98843260000001,
+          "googleMapsId": "ChIJWZ_5kZejfDURD88MGrunOCA",
+          "googleMapsUri": "https://maps.google.com/?cid=2321790029947260687&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName '공간사옥' != '한식공간'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "mhGBhzG86IY",
+      "title": "[내 맛집을 소개합니다] 예천 단골식당ㅣ여전히 맛있는 오징어 불고기ㅣ8년 만에 왔는데.. 좀..",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "단골식당",
+          "address": "대한민국 경상북도 예천군 용궁면 용궁시장길 30",
+          "description": "서울 올라가다가 들니 8년 만에 와본 경북 예천에 있는 단골 식당~",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=mhGBhzG86IY",
+          "latitude": 36.607036099999995,
+          "longitude": 128.27766620000003,
+          "googleMapsId": "ChIJg9bLGtlAZDURK2e1N8t56c8",
+          "googleMapsUri": "https://maps.google.com/?cid=14981639549144622891&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "mIjOK4WHQfo",
+      "title": "[내 맛집을 소개합니다] 부산 해운대 라호짬뽕ㅣ탕수육을 스리라차에?ㅣ볶음밥은 미쳤다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "라호짬뽕",
+          "address": "대한민국 부산광역시 해운대구 마린시티1로 137",
+          "description": "부산 중식 투어 세 번째 집은 전통과 요즘 트렌드가 잘 어우러진 라호짬뽕!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=mIjOK4WHQfo",
+          "latitude": 35.1559991,
+          "longitude": 129.1469275,
+          "googleMapsId": "ChIJHQCcdqSTaDUReolEr6bdOZw",
+          "googleMapsUri": "https://maps.google.com/?cid=11257272451564079482&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "pO2oHr5zM14",
+      "title": "[내 맛집을 소개합니다] 을지로 보석ㅣ요즘 가장 힙한 술집ㅣ예약해도 2달 기다려야 하는",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "을지로 보석",
+          "address": "대한민국 서울특별시 중구 마른내로 11-10 3층",
+          "description": "요즘 을지로에서 제일 힙하고 핫한 가게인 을지로 보석!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=pO2oHr5zM14",
+          "latitude": 37.565127100000005,
+          "longitude": 126.98923269999999,
+          "googleMapsId": "ChIJF6DlJFWjfDURkT5x0J2gnuY",
+          "googleMapsUri": "https://maps.google.com/?cid=16617896274711101073&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "51jlRo46lSI",
+      "title": "[내 맛집을 소개합니다] 이 곰치국을 200번 넘게 먹었습니다",
+      "concept": "대한민국",
+      "locations": [
+        {
+          "name": "춘선네(구 옥미식당)",
+          "address": "대한민국 강원특별자치도 속초시 교동 664-102",
+          "description": "시원하고 깔끔하고 개운하고 고소한 맛까지 더해진 속초 춘선네 곰치국!!",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=51jlRo46lSI",
+          "latitude": 38.1990382,
+          "longitude": 128.58296479999998,
+          "googleMapsId": "ChIJ7-zPa5K92F8RJGSgVPV9X7Y",
+          "googleMapsUri": "https://maps.google.com/?cid=13141360730330653732&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF/video_info.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF/video_info.json
@@ -1,0 +1,1369 @@
+{
+  "type": "playlist",
+  "id": "PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF",
+  "title": "비밀이야 in 한국 🍚",
+  "description": "",
+  "url": "https://www.youtube.com/playlist?list=PLkmBZE3qxSdGkIxhowBQ3WfsHNPoErCNF",
+  "channelName": "비밀이야 bimirya",
+  "channel": {
+    "id": "UCaKQ7_GT0k8u_sL0nE2tgkA",
+    "title": "비밀이야 bimirya",
+    "handle": "@bimirya",
+    "url": "https://www.youtube.com/@bimirya",
+    "description": "먹자! 마시자! 놀러 다니자!\n\n🍕 비즈니스 문의 : bimiryabdr@naver.com\n🍷 인스타그램 : www.instagram.com/bimirya\n🥪 네이버 블로그 : blog.naver.com/mardukas\n",
+    "thumbnailUrl": "https://yt3.ggpht.com/xTnhjCg0_h3Qdsy7Ar2B8AM8150MF0v-_CkRyCwRz6AK4-ZGEZVjYtWViSy6_9uxal7v1rHJKA=s800-c-k-c0x00ffffff-no-rj"
+  },
+  "selectedVideos": [
+    {
+      "videoId": "KPXQuyz9j3Y",
+      "title": "아침부터 소주 까는 레전드 워크숍ㄷㄷ🐳비밀이야의 부산 원기옥 | 은해갈치, 본앤브레드, 부우사안, 아저씨대구탕...",
+      "channelName": "비밀이야 bimirya",
+      "position": 0,
+      "url": "https://www.youtube.com/watch?v=KPXQuyz9j3Y"
+    },
+    {
+      "videoId": "_0uZEIemhlY",
+      "title": "공무원들만 몰래 가던 찐맛집🤫1만 원대 전국구 아구지리 (현지인 성지) | 대구 이방인횟집",
+      "channelName": "비밀이야 bimirya",
+      "position": 1,
+      "url": "https://www.youtube.com/watch?v=_0uZEIemhlY"
+    },
+    {
+      "videoId": "vOB8Km0yvys",
+      "title": "가성비 1등! 세월이 검증한 서울대입구 곱창집 (지금 가셔야 합니다) | 신기루황소곱창구이",
+      "channelName": "비밀이야 bimirya",
+      "position": 2,
+      "url": "https://www.youtube.com/watch?v=vOB8Km0yvys"
+    },
+    {
+      "videoId": "SwKN0nERUHc",
+      "title": "돌아온 워크샵! 비밀이야의 제주 보석함💎 | 남경미락, 우동 카덴, 김희선몸국, 동서지간, 일통이반, 미담국수, 미친부엌...",
+      "channelName": "비밀이야 bimirya",
+      "position": 3,
+      "url": "https://www.youtube.com/watch?v=SwKN0nERUHc"
+    },
+    {
+      "videoId": "1ggSZsIoFPg",
+      "title": "마 이게 아구다! 해장 술을 부르는 부산 해장 절대강자 | 김해식당",
+      "channelName": "비밀이야 bimirya",
+      "position": 4,
+      "url": "https://www.youtube.com/watch?v=1ggSZsIoFPg"
+    },
+    {
+      "videoId": "1_uPaoNfaig",
+      "title": "부산 해장 무조건 여깁니다. 20년 다닌 1만 원대 또또또또간집 | 아저씨대구탕",
+      "channelName": "비밀이야 bimirya",
+      "position": 5,
+      "url": "https://www.youtube.com/watch?v=1_uPaoNfaig"
+    },
+    {
+      "videoId": "kq0fq6wtrbg",
+      "title": "[EN]워크숍 또 가자는 직원들...🌊비밀이야의 속초 모음zip | 각두골, 당근마차, 춘선네, 동명항, 용바위식당",
+      "channelName": "비밀이야 bimirya",
+      "position": 6,
+      "url": "https://www.youtube.com/watch?v=kq0fq6wtrbg"
+    },
+    {
+      "videoId": "axj_gYyPeUg",
+      "title": "6.25 전쟁도 겪은 부산 중식당😲 비밀이야가 유튜브 초창기부터 꾸준히 찾는 화상의 맛 (feat. 비밀이야가 많이 받는 DM은?)[EN]ㅣ동화반점",
+      "channelName": "비밀이야 bimirya",
+      "position": 7,
+      "url": "https://www.youtube.com/watch?v=axj_gYyPeUg"
+    },
+    {
+      "videoId": "srdS3Ty1L54",
+      "title": "[EN]비밀이야 부티크 해산물 회식🫧비밀이야의 단골집 추억이 방울방울ㅣ블루 바이 필레터",
+      "channelName": "비밀이야 bimirya",
+      "position": 8,
+      "url": "https://www.youtube.com/watch?v=srdS3Ty1L54"
+    },
+    {
+      "videoId": "9gwbNOTVTao",
+      "title": "인생 안심? 비밀이야의 인생 안창살을 만난 한우 노포집[EN]ㅣ뜨락",
+      "channelName": "비밀이야 bimirya",
+      "position": 9,
+      "url": "https://www.youtube.com/watch?v=9gwbNOTVTao"
+    },
+    {
+      "videoId": "BrE4ZitRP0Q",
+      "title": "회식비 걸고 직원과 내기하는 대표 #shorts",
+      "channelName": "비밀이야 bimirya",
+      "position": 10,
+      "url": "https://www.youtube.com/watch?v=BrE4ZitRP0Q"
+    },
+    {
+      "videoId": "ZiVBQndlM8I",
+      "title": "한국에서 프랑스 양고기 못 먹는 이유 #shorts",
+      "channelName": "비밀이야 bimirya",
+      "position": 11,
+      "url": "https://www.youtube.com/watch?v=ZiVBQndlM8I"
+    },
+    {
+      "videoId": "k4MuEqMx46U",
+      "title": "브뤼의 원조 뽀므리 샴페인과 Kaviari 가 만나다! 둘의 궁합은? 야심차게 준비한 비밀이야 부티크 행사🍾[EN]ㅣ뽀므리디너",
+      "channelName": "비밀이야 bimirya",
+      "position": 12,
+      "url": "https://www.youtube.com/watch?v=k4MuEqMx46U"
+    },
+    {
+      "videoId": "tPlWG3n6zu0",
+      "title": "제주 고급 생선을 제대로 만나볼 수 있는 횟집🎣오래 전부터 미식가를 불러 모으던 그 곳에 방문했습니다[EN]ㅣ남경미락",
+      "channelName": "비밀이야 bimirya",
+      "position": 13,
+      "url": "https://www.youtube.com/watch?v=tPlWG3n6zu0"
+    },
+    {
+      "videoId": "enXrget-zXk",
+      "title": "거부할 수 없는 푸짐한 거부갈비! 비밀이야가 인정한 제주도 맛집 추천🌟",
+      "channelName": "비밀이야 bimirya",
+      "position": 14,
+      "url": "https://www.youtube.com/watch?v=enXrget-zXk"
+    },
+    {
+      "videoId": "dn8OVfxevug",
+      "title": "한국인이 가장 좋아하는 맛은 직화맛? 볏짚 폼 미쳤다;; 웨이팅 어마무시한 서울 몽탄이 각잡고 제주로 내려가면 일어나는 일",
+      "channelName": "비밀이야 bimirya",
+      "position": 15,
+      "url": "https://www.youtube.com/watch?v=dn8OVfxevug"
+    },
+    {
+      "videoId": "wt-HmPcECb8",
+      "title": "점심 스시 오마카세 추천! 70만원 쓰고 갔던 유일한 오너 셰프의 스시집🍣[EN]ㅣ스시 시미즈",
+      "channelName": "비밀이야 bimirya",
+      "position": 16,
+      "url": "https://www.youtube.com/watch?v=wt-HmPcECb8"
+    },
+    {
+      "videoId": "nyKPQqu6674",
+      "title": "드디어 광태가 쏜 비밀이야 회식! 🎇 강남에서 제대로 맛본 프랑스[EN]ㅣ꼼모아 강남",
+      "channelName": "비밀이야 bimirya",
+      "position": 17,
+      "url": "https://www.youtube.com/watch?v=nyKPQqu6674"
+    },
+    {
+      "videoId": "g0Bwr7KN0_M",
+      "title": "슬슬 더워지는 날씨에 생각나는 미나리 삼겹살 + 화이트와인 조합이 극락인 이유🥓🍾[EN]ㅣ압구정 진주",
+      "channelName": "비밀이야 bimirya",
+      "position": 18,
+      "url": "https://www.youtube.com/watch?v=g0Bwr7KN0_M"
+    },
+    {
+      "videoId": "wSYzoXXsF6o",
+      "title": "대표가 까주는 새우는 과연 맛있을까? 직원들과 10년차 단골집 방문! 속초의 밤은 이곳에서🌃ㅣ당근마차",
+      "channelName": "비밀이야 bimirya",
+      "position": 19,
+      "url": "https://www.youtube.com/watch?v=wSYzoXXsF6o"
+    },
+    {
+      "videoId": "cFnpvr2tEY4",
+      "title": "남자분들 주목 👀 국내 최고 돈카츠 맛집은? 생맥주와 말이 필요 없는 극락 조합 🍺ㅣ고성 보배진",
+      "channelName": "비밀이야 bimirya",
+      "position": 20,
+      "url": "https://www.youtube.com/watch?v=cFnpvr2tEY4"
+    },
+    {
+      "videoId": "PKALkw1k3bE",
+      "title": "한국 다이닝에서 볼 수 없었던 메뉴! 더욱 독창적인 퍼포먼스로 돌아온 최현석 셰프님의 쵸이닷[EN]ㅣ쵸이닷",
+      "channelName": "비밀이야 bimirya",
+      "position": 21,
+      "url": "https://www.youtube.com/watch?v=PKALkw1k3bE"
+    },
+    {
+      "videoId": "TfcOP2J4soM",
+      "title": "아시아 50 베스트 레스토랑이 한국에서 열리다! 선정된 한국 식당 보러가기 🏆 비밀이야가 애정하는 쉐프들과의 만남 [EN]",
+      "channelName": "비밀이야 bimirya",
+      "position": 22,
+      "url": "https://www.youtube.com/watch?v=TfcOP2J4soM"
+    },
+    {
+      "videoId": "Y0sW9mpcIN0",
+      "title": "프랑스보다 더 프랑스같은 맛과 코스를 경험하고 싶다면? 직원들 함박웃음 짓게 한 비밀이야 최애 프렌치 레스토랑 그리고 Krug [EN]ㅣ레스쁘아",
+      "channelName": "비밀이야 bimirya",
+      "position": 23,
+      "url": "https://www.youtube.com/watch?v=Y0sW9mpcIN0"
+    },
+    {
+      "videoId": "GCOP8UPWkIo",
+      "title": "노량진 수산시장에서 모듬회 장르를 개척한 30년차 횟집! 돈이 줄줄세는 줄줄세트🐠 ㅣ더형제 강남",
+      "channelName": "비밀이야 bimirya",
+      "position": 24,
+      "url": "https://www.youtube.com/watch?v=GCOP8UPWkIo"
+    },
+    {
+      "videoId": "JhphrHU6mXg",
+      "title": "미남직원들과 함께한 회식ㅣ손흥민 드리블급인 셰프님의 오마카세ㅣ키라메키 [EN]",
+      "channelName": "비밀이야 bimirya",
+      "position": 25,
+      "url": "https://www.youtube.com/watch?v=JhphrHU6mXg"
+    },
+    {
+      "videoId": "429mYqmcqQU",
+      "title": "1년에 한번 귀한 와인을 갖고 모이는 디너 생일 파티 🎉ㅣ아시아 베스트 50 의 주목해야 할 레스토랑ㅣ톡톡 [EN]",
+      "channelName": "비밀이야 bimirya",
+      "position": 26,
+      "url": "https://www.youtube.com/watch?v=429mYqmcqQU"
+    },
+    {
+      "videoId": "1GisLCTWmn0",
+      "title": "이건 평범한 오마카세가 아닙니다 [EN]ㅣ본앤브레드",
+      "channelName": "비밀이야 bimirya",
+      "position": 27,
+      "url": "https://www.youtube.com/watch?v=1GisLCTWmn0"
+    },
+    {
+      "videoId": "1GisLCTWmn0",
+      "title": "이건 평범한 오마카세가 아닙니다 [EN]ㅣ본앤브레드",
+      "channelName": "비밀이야 bimirya",
+      "position": 28,
+      "url": "https://www.youtube.com/watch?v=1GisLCTWmn0"
+    },
+    {
+      "videoId": "tHjfeQyMpM0",
+      "title": "여성 셰프님이어서 나오는 섬세한 포인트✨ 창덕궁과 창경궁뷰의 식사[EN]ㅣ더그린테이블",
+      "channelName": "비밀이야 bimirya",
+      "position": 29,
+      "url": "https://www.youtube.com/watch?v=tHjfeQyMpM0"
+    },
+    {
+      "videoId": "BEZ73zUcII0",
+      "title": "인당 55만원씩 내고 대관해 버린 연말 회식 스케일?![EN]ㅣ스시하네",
+      "channelName": "비밀이야 bimirya",
+      "position": 30,
+      "url": "https://www.youtube.com/watch?v=BEZ73zUcII0"
+    },
+    {
+      "videoId": "s1w9XPHkNkY",
+      "title": "휴가 떠난 동안 미슐랭 별을 받아버린 비법🪄[EN]ㅣ윤서울",
+      "channelName": "비밀이야 bimirya",
+      "position": 31,
+      "url": "https://www.youtube.com/watch?v=s1w9XPHkNkY"
+    },
+    {
+      "videoId": "zOTWRUw_jY4",
+      "title": "여긴 이전하기 전에 가보셔야 합니다. 새로움의 연속, 꼭 보여드리고 싶은 맛!ㅣ강민철 레스토랑 [EN]",
+      "channelName": "비밀이야 bimirya",
+      "position": 32,
+      "url": "https://www.youtube.com/watch?v=zOTWRUw_jY4"
+    },
+    {
+      "videoId": "iOPYW2RmXL4",
+      "title": "서울 한복판에 제대로 궁중 한옥에서 대접해 주는 고급 다이닝이 있다? 핫플 예고된 식당ㅣ한국의집 [EN]",
+      "channelName": "비밀이야 bimirya",
+      "position": 33,
+      "url": "https://www.youtube.com/watch?v=iOPYW2RmXL4"
+    },
+    {
+      "videoId": "M9cZIA6V3Sg",
+      "title": "더욱 업그레이드 되어 돌아온 모던 한식의 선두주자 [EN]ㅣ밍글스",
+      "channelName": "비밀이야 bimirya",
+      "position": 34,
+      "url": "https://www.youtube.com/watch?v=M9cZIA6V3Sg"
+    },
+    {
+      "videoId": "v3X8Tpppy78",
+      "title": "[EN]한남 루프탑뷰가 이렇게 좋았나✨(데이트 코스로 강추) 계절마다 메뉴와 인테리어 컨셉이 변하는 이곳! l 쿡투게더한남",
+      "channelName": "비밀이야 bimirya",
+      "position": 35,
+      "url": "https://www.youtube.com/watch?v=v3X8Tpppy78"
+    },
+    {
+      "videoId": "ULGt59R11w0",
+      "title": "[EN]사장님 말투가 너무 고급져요👨‍🍳 클래식 프렌치 레스토랑의 끝판왕ㅣ화이트크리스마스",
+      "channelName": "비밀이야 bimirya",
+      "position": 36,
+      "url": "https://www.youtube.com/watch?v=ULGt59R11w0"
+    },
+    {
+      "videoId": "eUuVmF5NFk8",
+      "title": "[EN] 한국인이라면 못참는 흰쌀밥+고추장불고기+냉면 조합🤤ㅣ편집하다 침샘 폭발한 곳💦ㅣ현구3대 원조불고기",
+      "channelName": "비밀이야 bimirya",
+      "position": 37,
+      "url": "https://www.youtube.com/watch?v=eUuVmF5NFk8"
+    },
+    {
+      "videoId": "tJOJzWB94So",
+      "title": "[EN] 점심 따로 먹으라 해도 따라오는 직원들 (feat.피리부는 비밀이야)ㅣ면서울",
+      "channelName": "비밀이야 bimirya",
+      "position": 38,
+      "url": "https://www.youtube.com/watch?v=tJOJzWB94So"
+    },
+    {
+      "videoId": "a2g7UPH2opU",
+      "title": "[EN] 청담동의 미슐랭 원스타&아시아 대표 레스토랑!! 이 음식을 이렇게 조합한다고..?ㅣ세븐스도어",
+      "channelName": "비밀이야 bimirya",
+      "position": 39,
+      "url": "https://www.youtube.com/watch?v=a2g7UPH2opU"
+    },
+    {
+      "videoId": "PWIjDmYEjO4",
+      "title": "[EN] 여성 구독자와의 우연한 첫만남..?!🙊ㅣ무오키",
+      "channelName": "비밀이야 bimirya",
+      "position": 40,
+      "url": "https://www.youtube.com/watch?v=PWIjDmYEjO4"
+    },
+    {
+      "videoId": "bcbosOeLIXk",
+      "title": "[EN] 살살 녹는 닭꼬치ㅣ한국에서 찾기 힘든 야키토리 맛집!!ㅣ야키토리해공",
+      "channelName": "비밀이야 bimirya",
+      "position": 41,
+      "url": "https://www.youtube.com/watch?v=bcbosOeLIXk"
+    },
+    {
+      "videoId": "H33H-4ei9sw",
+      "title": "(EN) 한우를 드라이에이징한 낯선 스테이크의 맛은 어떨까? l 본앤브레드",
+      "channelName": "비밀이야 bimirya",
+      "position": 42,
+      "url": "https://www.youtube.com/watch?v=H33H-4ei9sw"
+    },
+    {
+      "videoId": "1KNVmLD0PF8",
+      "title": "(EN) 기대 안하고 갔다가 깜짝 놀란 부산의 베이징 덕!🍗 겉도 윤기 좔좔 흐르기 어려운데.. ㅣ부우사안",
+      "channelName": "비밀이야 bimirya",
+      "position": 43,
+      "url": "https://www.youtube.com/watch?v=1KNVmLD0PF8"
+    },
+    {
+      "videoId": "Pqb9y00bJDM",
+      "title": "(EN) 돼지고기 껍데기에 전통주를 온더락🥃으로? 제대로 즐기는 법!! (여름이었다🐷)ㅣ금돼지식당",
+      "channelName": "비밀이야 bimirya",
+      "position": 44,
+      "url": "https://www.youtube.com/watch?v=Pqb9y00bJDM"
+    },
+    {
+      "videoId": "3egSwkTc0g0",
+      "title": "(EN) ※회식 스케일 주의※ 비밀이야 와인 창고 공개? 셰프님 모셔 캐비아 파티 열었습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 45,
+      "url": "https://www.youtube.com/watch?v=3egSwkTc0g0"
+    },
+    {
+      "videoId": "bzzkH6OusXs",
+      "title": "(EN) 여름이니까 스태민어 코스의 매력에 빠져보자🎣 전복,소라,골뱅이,문어,새우,개불,해삼,옥돔,낚지볶음까지.. ㅣ 더형제",
+      "channelName": "비밀이야 bimirya",
+      "position": 46,
+      "url": "https://www.youtube.com/watch?v=bzzkH6OusXs"
+    },
+    {
+      "videoId": "DS8PwEMtE80",
+      "title": "(EN) 한국 파인 다이닝의 미래는 어떻게 될까? 무명이었을 때부터 25만원에 판매해 성공할 수 있었던 비결ㅣ솔밤",
+      "channelName": "비밀이야 bimirya",
+      "position": 47,
+      "url": "https://www.youtube.com/watch?v=DS8PwEMtE80"
+    },
+    {
+      "videoId": "GPtli8Gaxek",
+      "title": "(EN) 국물이 시원하다고 느끼는 이유가 뭘까? 서울에 분점차리고 싶은 끝판왕 대구탕ㅣ아저씨대구탕",
+      "channelName": "비밀이야 bimirya",
+      "position": 48,
+      "url": "https://www.youtube.com/watch?v=GPtli8Gaxek"
+    },
+    {
+      "videoId": "CoyATC7Y-5o",
+      "title": "(EN) 영국 음식을 서울시청 근처에서 맛보자! | 플레눼",
+      "channelName": "비밀이야 bimirya",
+      "position": 49,
+      "url": "https://www.youtube.com/watch?v=CoyATC7Y-5o"
+    },
+    {
+      "videoId": "DvfNL6Z43Jc",
+      "title": "(EN) 가게 오픈할 때부터 즐겨 먹었던 단골집 | 화상손만두",
+      "channelName": "비밀이야 bimirya",
+      "position": 50,
+      "url": "https://www.youtube.com/watch?v=DvfNL6Z43Jc"
+    },
+    {
+      "videoId": "K_pcS_MI0zA",
+      "title": "(EN) 신경을 살려서 회를 썰고, 그 위에 캐비아를 올린🐙 | 셀렉트 구르메",
+      "channelName": "비밀이야 bimirya",
+      "position": 51,
+      "url": "https://www.youtube.com/watch?v=K_pcS_MI0zA"
+    },
+    {
+      "videoId": "ycMAjic-ABc",
+      "title": "(EN) 시청자曰 \"제가 갔을 땐 이런 참치 없던데요?\" | 더 형제",
+      "channelName": "비밀이야 bimirya",
+      "position": 52,
+      "url": "https://www.youtube.com/watch?v=ycMAjic-ABc"
+    },
+    {
+      "videoId": "D1WBB86yL08",
+      "title": "(EN) 장어 안 좋아하는 사람도 봐야됨 | 영동장어",
+      "channelName": "비밀이야 bimirya",
+      "position": 53,
+      "url": "https://www.youtube.com/watch?v=D1WBB86yL08"
+    },
+    {
+      "videoId": "DhueGoWfuMU",
+      "title": "(EN) 이 날 먹은 와인 값이 차 한 대 값...? | 밍글스",
+      "channelName": "비밀이야 bimirya",
+      "position": 54,
+      "url": "https://www.youtube.com/watch?v=DhueGoWfuMU"
+    },
+    {
+      "videoId": "Le88HtJ0kIk",
+      "title": "신화 이민우와 함께 맛본 튀김 오마카세🍤",
+      "channelName": "비밀이야 bimirya",
+      "position": 55,
+      "url": "https://www.youtube.com/watch?v=Le88HtJ0kIk"
+    },
+    {
+      "videoId": "JcbR__2GISI",
+      "title": "비밀曰 \"이곳이 물건만큼은 확실하다\"",
+      "channelName": "비밀이야 bimirya",
+      "position": 56,
+      "url": "https://www.youtube.com/watch?v=JcbR__2GISI"
+    },
+    {
+      "videoId": "RZjCiWBmEHE",
+      "title": "울릉도로 오세요🌊",
+      "channelName": "비밀이야 bimirya",
+      "position": 57,
+      "url": "https://www.youtube.com/watch?v=RZjCiWBmEHE"
+    },
+    {
+      "videoId": "OudlvfCD8sU",
+      "title": "일반인들은 맛볼 수 없는 울릉도 숨은 맛집🤫",
+      "channelName": "비밀이야 bimirya",
+      "position": 58,
+      "url": "https://www.youtube.com/watch?v=OudlvfCD8sU"
+    },
+    {
+      "videoId": "FlNpHNgIrBI",
+      "title": "대한민국에서 가장 비싼 숙소와 최고의 음식 퀄리티👍",
+      "channelName": "비밀이야 bimirya",
+      "position": 59,
+      "url": "https://www.youtube.com/watch?v=FlNpHNgIrBI"
+    },
+    {
+      "videoId": "5kb-BAzKrCo",
+      "title": "이번 컨셉은 '고려시대'라고 합니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 60,
+      "url": "https://www.youtube.com/watch?v=5kb-BAzKrCo"
+    },
+    {
+      "videoId": "bS6q_NZrdZg",
+      "title": "독일 원스타 찍어 누르는 삼성동 레스토랑",
+      "channelName": "비밀이야 bimirya",
+      "position": 61,
+      "url": "https://www.youtube.com/watch?v=bS6q_NZrdZg"
+    },
+    {
+      "videoId": "oXxLuTlqyso",
+      "title": "홍어 삭히지 않아도 맛있습니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 62,
+      "url": "https://www.youtube.com/watch?v=oXxLuTlqyso"
+    },
+    {
+      "videoId": "o-ZzOkoFo2I",
+      "title": "이제 닭 요리 하면 이 집밖에 떠오르지 않습니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 63,
+      "url": "https://www.youtube.com/watch?v=o-ZzOkoFo2I"
+    },
+    {
+      "videoId": "bN3yTHwDlUE",
+      "title": "국적, 장르에 구애받지 않는 비범한 퓨전 한식집!",
+      "channelName": "비밀이야 bimirya",
+      "position": 64,
+      "url": "https://www.youtube.com/watch?v=bN3yTHwDlUE"
+    },
+    {
+      "videoId": "PlI-YPpsj0c",
+      "title": "여기는 무조건 가보셔야 합니다. 청파동의 자랑, 화상중식당 정!",
+      "channelName": "비밀이야 bimirya",
+      "position": 65,
+      "url": "https://www.youtube.com/watch?v=PlI-YPpsj0c"
+    },
+    {
+      "videoId": "FFX5Kjqwmqw",
+      "title": "고기 퀄 1등 냉동삼겹살 집?! 순두부찌개랑 후식 볶음밥까지 완벽한 K-냉삼코스 ⭐️",
+      "channelName": "비밀이야 bimirya",
+      "position": 66,
+      "url": "https://www.youtube.com/watch?v=FFX5Kjqwmqw"
+    },
+    {
+      "videoId": "5N6c1lWDGlA",
+      "title": "프라이빗한 룸에서 즐기는 최고급 파인다이닝",
+      "channelName": "비밀이야 bimirya",
+      "position": 67,
+      "url": "https://www.youtube.com/watch?v=5N6c1lWDGlA"
+    },
+    {
+      "videoId": "9Mv-0wckp_4",
+      "title": "선지와 고기를 듬뿍 넣은 국밥계의 최고봉!🥘 해장하러 갔다가 술 마시고 온다는 달래해장에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 68,
+      "url": "https://www.youtube.com/watch?v=9Mv-0wckp_4"
+    },
+    {
+      "videoId": "GyE6P3C0bbs",
+      "title": "현지에도 없는 전설의 와인?🍷 파스타와 와인에 진심인 이탈리안 레스토랑, 압구정 몽고네에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 69,
+      "url": "https://www.youtube.com/watch?v=GyE6P3C0bbs"
+    },
+    {
+      "videoId": "zM5v9W65TME",
+      "title": "놀라운 풍미의 숙성 돼지고기!🥩 솥뚜껑에 고기를 구워 먹는 마포 월화식당에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 70,
+      "url": "https://www.youtube.com/watch?v=zM5v9W65TME"
+    },
+    {
+      "videoId": "-6f9apDerjQ",
+      "title": "세계 최고 고기 전문가의 한우 코스 요리?🥩 다리오 체키니x본앤브레드 갈라 디너에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 71,
+      "url": "https://www.youtube.com/watch?v=-6f9apDerjQ"
+    },
+    {
+      "videoId": "YJRJmb4MCBg",
+      "title": "3만원 대에 즐기는 고퀄리티 스시 오마카세🍣 엄청난 경쟁률의 '스강신청'을 뚫고 아루히에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 72,
+      "url": "https://www.youtube.com/watch?v=YJRJmb4MCBg"
+    },
+    {
+      "videoId": "buWff5isJ6k",
+      "title": "현대적으로 풀어낸 K-파인다이닝🍽 전복 & 칡소 밀푀유, 봄나물 플레이트 등 정성스럽고 독창적인 요리들을 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 73,
+      "url": "https://www.youtube.com/watch?v=buWff5isJ6k"
+    },
+    {
+      "videoId": "V5apja-6ibk",
+      "title": "한식과 프렌치 다이닝의 만남!🍴 극찬할 수밖에 없는 컨템포러리 레스토랑 임프레션에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 74,
+      "url": "https://www.youtube.com/watch?v=V5apja-6ibk"
+    },
+    {
+      "videoId": "sky7MJvlLg0",
+      "title": "맛과 재료에 대한 장인 정신으로 미슐랭 스타를 받은 식당?⭐ 최고의 식재료로 구성된 독창적인 다이닝, 윤서울에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 75,
+      "url": "https://www.youtube.com/watch?v=sky7MJvlLg0"
+    },
+    {
+      "videoId": "GZk8D24XmUs",
+      "title": "70년 전통의 부산 원조 양대창🥢 현지인도 인정한 부산 옛날오막집에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 76,
+      "url": "https://www.youtube.com/watch?v=GZk8D24XmUs"
+    },
+    {
+      "videoId": "RMvBBd4hf9c",
+      "title": "최고의 재료로 선보이는 고급 튀김 오마카세!🍤 일식 덴푸라의 정점, 모퉁이우 덴푸라랩에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 77,
+      "url": "https://www.youtube.com/watch?v=RMvBBd4hf9c"
+    },
+    {
+      "videoId": "MoKj7rr_y18",
+      "title": "한식 파인 다이닝의 정수🍽 청담동에서 핫한 셰프님의 레스토랑에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 78,
+      "url": "https://www.youtube.com/watch?v=MoKj7rr_y18"
+    },
+    {
+      "videoId": "y7IYTEl5lok",
+      "title": "한우 ++ 채끝살을 11개월 숙성한 밀랍 에이징 스테이크🥩 독특한 그릴 방식의 숙성 스테이크 끝판왕 레스토랑에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 79,
+      "url": "https://www.youtube.com/watch?v=y7IYTEl5lok"
+    },
+    {
+      "videoId": "qxbRusRriwU",
+      "title": "투플러스 한우만 나오는 압구정 명품 오마카세🥩 예약이 전쟁이라는 이속우화 천공에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 80,
+      "url": "https://www.youtube.com/watch?v=qxbRusRriwU"
+    },
+    {
+      "videoId": "Rgsb9S3PNSA",
+      "title": "🍖살살 녹는 동파육과 해삼주스 등 중국 본토의 맛 그대로 재현한 고급 중식당 계향각에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 81,
+      "url": "https://www.youtube.com/watch?v=Rgsb9S3PNSA"
+    },
+    {
+      "videoId": "816WnjDFVf4",
+      "title": "26만원짜리 고급 한식 다이닝 코스?!🍽 미슐랭 3스타, 한국을 대표하는 식당 중 하나인 가온에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 82,
+      "url": "https://www.youtube.com/watch?v=816WnjDFVf4"
+    },
+    {
+      "videoId": "XmrnNH3YtBk",
+      "title": "홍콩 미쉐린 원 스타 중식당이 서울에?! 베이징 덕부터 디저트까지 총 26가지 메뉴 먹고 왔습니다!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 83,
+      "url": "https://www.youtube.com/watch?v=XmrnNH3YtBk"
+    },
+    {
+      "videoId": "joq90fyFDwk",
+      "title": "겨울에 땀 흘리며 먹는 전국 5대 짬뽕 도장깨기 2탄🔥 해물 가득, 찐한 국물의 역대급 짬뽕으로 유명한 중식당들만 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 84,
+      "url": "https://www.youtube.com/watch?v=joq90fyFDwk"
+    },
+    {
+      "videoId": "-c3WDwRlgR4",
+      "title": "추운 날엔 전국 5대 짬뽕집 도장깨기🔥 얼큰칼칼 인생 짬뽕으로 유명한 중식당들만 모아 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 85,
+      "url": "https://www.youtube.com/watch?v=-c3WDwRlgR4"
+    },
+    {
+      "videoId": "Kz5DzbFptTw",
+      "title": "강원도 가면 꼭 들러야할 막국수집! 시원한 동치미 국물 + 투박한 메밀면의 조화가 일품인 강원도 고성 막국수집을 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 86,
+      "url": "https://www.youtube.com/watch?v=Kz5DzbFptTw"
+    },
+    {
+      "videoId": "X10ElovyR3Q",
+      "title": "서비스, 맛, 뷰 세 가지 다 잡은 중식당! 시그니처 북경오리 부터 해삼, 전복, 우럭찜, 맛있는 디저트까지! 대성공이었던 호텔 중식당을 여러분께 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 87,
+      "url": "https://www.youtube.com/watch?v=X10ElovyR3Q"
+    },
+    {
+      "videoId": "Fw3Gt0q0Jt4",
+      "title": "온갖 해산물이 다~ 나온다는 부산 로컬 횟집! 🐟 해삼과 전복부터 갯장어회, 줄가자미회, 추어탕에 튀김과 후식까지! 바다를 통째로 대접하는 찐맛집을 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 88,
+      "url": "https://www.youtube.com/watch?v=Fw3Gt0q0Jt4"
+    },
+    {
+      "videoId": "YPXPzy5Yzas",
+      "title": "고소한 회의 대표주자, 붕장어회 찐 맛집! 부산 무진장횟집",
+      "channelName": "비밀이야 bimirya",
+      "position": 89,
+      "url": "https://www.youtube.com/watch?v=YPXPzy5Yzas"
+    },
+    {
+      "videoId": "TSgUFZaOllY",
+      "title": "인생 갈치 맛집! 부산 가면 무조건, 국내 원탑 갈치요리 맛집을 찾아가봤습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 90,
+      "url": "https://www.youtube.com/watch?v=TSgUFZaOllY"
+    },
+    {
+      "videoId": "vdIHjpGFuL8",
+      "title": "1인 19만원의 광동식 프리미엄 중식당 더 그레이트 홍연, 과연 그 퀄리티는?",
+      "channelName": "비밀이야 bimirya",
+      "position": 91,
+      "url": "https://www.youtube.com/watch?v=vdIHjpGFuL8"
+    },
+    {
+      "videoId": "fVmHKwLv-TM",
+      "title": "정갈하고 세련된 전통 한식, 제철 식재료로 한식 파인다이닝을 선보이는 미슐랭 원스타 한식 레스토랑 온지음!",
+      "channelName": "비밀이야 bimirya",
+      "position": 92,
+      "url": "https://www.youtube.com/watch?v=fVmHKwLv-TM"
+    },
+    {
+      "videoId": "YKCqPgscTco",
+      "title": "이 가격에 이 맛이 가능하다고...?! 신라호텔 '팔선' 출신 셰프가 보여주는 중식 요리의 끝판왕! 이름값 제대로 하는 '진미'에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 93,
+      "url": "https://www.youtube.com/watch?v=YKCqPgscTco"
+    },
+    {
+      "videoId": "tXufbXlZMUQ",
+      "title": "보양식 끝판왕 민어를 먹으러 노량진을 다녀왔습니다! 민어회, 민어전, 민어알전, 민어탕 등 민어의 향연(?)을 보여드립니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 94,
+      "url": "https://www.youtube.com/watch?v=tXufbXlZMUQ"
+    },
+    {
+      "videoId": "h73yl8VKssc",
+      "title": "한우의 끝판왕! 온갖 부위 총출동하는 한우 오마카세를 소개합니다! (Feat. 아시아 탑50 레스토랑)",
+      "channelName": "비밀이야 bimirya",
+      "position": 95,
+      "url": "https://www.youtube.com/watch?v=h73yl8VKssc"
+    },
+    {
+      "videoId": "4D7r65Pp5oU",
+      "title": "갓벽한 파인다이닝 레스토랑, 독창적인 요리로 특별한 경험을 선사하는 최현석 셰프님의 쵸이닷에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 96,
+      "url": "https://www.youtube.com/watch?v=4D7r65Pp5oU"
+    },
+    {
+      "videoId": "3Aq-UnJ_kNw",
+      "title": "곧 핫해질 신상 파스타 맛집?! 오픈과 동시에 예약이 치열한 가성비 좋은 레스토랑 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 97,
+      "url": "https://www.youtube.com/watch?v=3Aq-UnJ_kNw"
+    },
+    {
+      "videoId": "v2EG4EOw2Hs",
+      "title": "프랑스 미슐랭 2스타 출신 셰프의 시그니처 메뉴는?! 입문용으로 좋은 프렌치 레스토랑 소개해드립니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 98,
+      "url": "https://www.youtube.com/watch?v=v2EG4EOw2Hs"
+    },
+    {
+      "videoId": "XW7KJlOAWlo",
+      "title": "술 없이는 못 배기는 역대급 가성비 가맥집! 을지로 신중부시장에 꼭꼭 숨어있는 보물 같은 찐맛집 다녀왔습니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 99,
+      "url": "https://www.youtube.com/watch?v=XW7KJlOAWlo"
+    },
+    {
+      "videoId": "lONALAWayq0",
+      "title": "제주 바다 경치 보면서 먹는 흑돼지 삼겹살! 여행 가면 무조건 가봐야 하는 제주도 찐 로컬 맛집을 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 100,
+      "url": "https://www.youtube.com/watch?v=lONALAWayq0"
+    },
+    {
+      "videoId": "CL-R1SOkXjk",
+      "title": "1인분에 35,000원인 오겹살 정식이 있다?! 전라도식 역대급 상차림을 보면 납득이 가는 숨겨진 찐맛집!",
+      "channelName": "비밀이야 bimirya",
+      "position": 101,
+      "url": "https://www.youtube.com/watch?v=CL-R1SOkXjk"
+    },
+    {
+      "videoId": "aFXSdqpBd08",
+      "title": "100% 메밀면 막국수에 손이 계속 가는 감자옹심이는 덤, 속초에 가면 무조건 가야 되는 숨겨진 막국수 맛집 알려드립니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 102,
+      "url": "https://www.youtube.com/watch?v=aFXSdqpBd08"
+    },
+    {
+      "videoId": "HrcehmBmN9U",
+      "title": "국내 삼겹살은 바로 여기! 풍미가 일품인 두툼한 숙성 삽겹살과 목살, 고추장찌개의 맛.없.없 조합!",
+      "channelName": "비밀이야 bimirya",
+      "position": 103,
+      "url": "https://www.youtube.com/watch?v=HrcehmBmN9U"
+    },
+    {
+      "videoId": "P9iTNwRl2NE",
+      "title": "술꾼들의 성지, '이모카세'하면 빠질 수 없는 을지로에서 가장 핫한 노포집, 나드리식품에 다녀왔습니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 104,
+      "url": "https://www.youtube.com/watch?v=P9iTNwRl2NE"
+    },
+    {
+      "videoId": "k_zGFWz_bLQ",
+      "title": "기가 막히는 고소함과 담백함, 소맥이 땡기는 마성의 소곱창집! 곱창계 탑티어, 독보적인 퀄리티의 곱창집을 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 105,
+      "url": "https://www.youtube.com/watch?v=k_zGFWz_bLQ"
+    },
+    {
+      "videoId": "OEJ6aZO1adA",
+      "title": "서울에서 가장 핫한 생면 파스타 바! 입소문 덕에 극강의 예약 난이도를 자랑하는 파스타의 성지에 다녀왔습니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 106,
+      "url": "https://www.youtube.com/watch?v=OEJ6aZO1adA"
+    },
+    {
+      "videoId": "Z6QAEI3NQB4",
+      "title": "1인 55만원의 중식 보양식은 어떻게 나올까? 샥스핀, 불도장, 건전복과 건해삼 등 최고의 식재료로 만든 중국 코스요리 끝판왕!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 107,
+      "url": "https://www.youtube.com/watch?v=Z6QAEI3NQB4"
+    },
+    {
+      "videoId": "CeA59CKY0s0",
+      "title": "4년 연속 아시아 베스트 레스토랑 50의 영광, 최애 셰프님들 중 한 분인 김대천 셰프님의 가심비 훌륭한  국내 탑티어 프렌치 레스토랑",
+      "channelName": "비밀이야 bimirya",
+      "position": 108,
+      "url": "https://www.youtube.com/watch?v=CeA59CKY0s0"
+    },
+    {
+      "videoId": "bkTjH5wRSb4",
+      "title": "감칠맛 폭발 대표 밥도둑들의 향연!! 50년 내공의 오징어볶음, 제육볶음, 삼겹살, 부대찌개 전문 덕수궁 맛집, 한 번 가면 단골됩니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 109,
+      "url": "https://www.youtube.com/watch?v=bkTjH5wRSb4"
+    },
+    {
+      "videoId": "aOKKm_3e4HU",
+      "title": "극강의 풍미, 밀랍 에이징 스테이크 - 세계 TOP 5 레스토랑 출신 셰프가 선사하는 스테이크의 정점",
+      "channelName": "비밀이야 bimirya",
+      "position": 110,
+      "url": "https://www.youtube.com/watch?v=aOKKm_3e4HU"
+    },
+    {
+      "videoId": "5U7Ii_DL1IA",
+      "title": "서울에서 맛보는 통영 해산물 코스 요리? 통영 제철 해산물을 고급스럽게 풀어낸 실비집! 신선한 통영의 맛을 그대로 옮겨놓았습니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 111,
+      "url": "https://www.youtube.com/watch?v=5U7Ii_DL1IA"
+    },
+    {
+      "videoId": "JrUue6fuz1Q",
+      "title": "신라호텔에 있는 국내 최고의 프렌치 레스토랑?! 파리 샹젤리제에 온 듯한 완벽한 식사를 즐길 수 있는 곳 알려드립니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 112,
+      "url": "https://www.youtube.com/watch?v=JrUue6fuz1Q"
+    },
+    {
+      "videoId": "b3QLNrlMWe0",
+      "title": "시골집 분위기에서 먹는 가성비 좋은 한우 등심! 돌판 된장찌개와 푸짐한 반찬까지! 강원도 양양 찐맛집 알려드립니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 113,
+      "url": "https://www.youtube.com/watch?v=b3QLNrlMWe0"
+    },
+    {
+      "videoId": "UyGAcSzeE_Y",
+      "title": "유명 맛집 블로거가 작정하고 식당을 열었더니 벌어진 일!? 성수동에서 곧 떠오를 핫플 미리 좌표 찍어드립니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 114,
+      "url": "https://www.youtube.com/watch?v=UyGAcSzeE_Y"
+    },
+    {
+      "videoId": "bvQzXbZx1_c",
+      "title": "백종원님도 찾아온다는 서울 한복판의 숨은 맛집! 일단 들어와서 앉으면 술이 술술 들어와서 맨정신에 절대 못 나가는 민물 매운탕 맛집",
+      "channelName": "비밀이야 bimirya",
+      "position": 115,
+      "url": "https://www.youtube.com/watch?v=bvQzXbZx1_c"
+    },
+    {
+      "videoId": "LA-2LRALV6Y",
+      "title": "고기 먹으러 가는 칼국수 가게가 있다!? 서울에서 한복판에서 술이 쭉쭉 들어가는 40년 된 찐 맛집",
+      "channelName": "비밀이야 bimirya",
+      "position": 116,
+      "url": "https://www.youtube.com/watch?v=LA-2LRALV6Y"
+    },
+    {
+      "videoId": "uwucfKp_tDU",
+      "title": "돼지고기 항정살 가브리살 먹을때 좌표 찍어드립니다. 최자로드에서도 강추했던 그 식당! 고기 1타 강사가 추천하는 서울 찐맛집!",
+      "channelName": "비밀이야 bimirya",
+      "position": 117,
+      "url": "https://www.youtube.com/watch?v=uwucfKp_tDU"
+    },
+    {
+      "videoId": "NPTKG-99lDY",
+      "title": "코리아에서 먹는 재팬+차이나!? 특급 호텔 출신 셰프가 만드는 국경을 넘나드는 콜라보! 몇 달을 기다리더라도 또 갈만한 서울의 중식+일식 찐맛집",
+      "channelName": "비밀이야 bimirya",
+      "position": 118,
+      "url": "https://www.youtube.com/watch?v=NPTKG-99lDY"
+    },
+    {
+      "videoId": "UC__68w0Ohs",
+      "title": "호불호 끝판왕! 홍어로 논문 쓴 사람이 요리하면 어떤 음식이 만들어질까? 서울에서 찾기 힘든 홍어 제대로 하는 곳, 술 안 먹고 버틸 수 없는 찐맛집",
+      "channelName": "비밀이야 bimirya",
+      "position": 119,
+      "url": "https://www.youtube.com/watch?v=UC__68w0Ohs"
+    },
+    {
+      "videoId": "ECpmFVpTWMA",
+      "title": "맛, 가격, 분위기 모두 잡은 소고기! 저렴하면 허름하다!? 편견을 깬 서울 가성비 맛집 소개합니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 120,
+      "url": "https://www.youtube.com/watch?v=ECpmFVpTWMA"
+    },
+    {
+      "videoId": "G_lKwwiQAp0",
+      "title": "술 한잔 달라고 했더니, 술잔 40개 꺼내주는 곳!? 술잔뿐 아니라 음식도 다채로운 일식집! 강남에서 요즘 제대로 핫한 오마카세에 다녀왔습니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 121,
+      "url": "https://www.youtube.com/watch?v=G_lKwwiQAp0"
+    },
+    {
+      "videoId": "0ZzX_AAC4HM",
+      "title": "12만원짜리 튀김은 도대체 어떤 맛일까!? 미슐랭 가이드에 선정된 튀김! 청담동에 있는 꼬치 튀김 오마카세에 다녀왔습니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 122,
+      "url": "https://www.youtube.com/watch?v=0ZzX_AAC4HM"
+    },
+    {
+      "videoId": "DYuqqnMKM60",
+      "title": "맛, 가격 둘 다 잡은 동해안 1위 자연산 횟집, 누구에게나 추천하는 가성비 좋은 횟집 알려드립니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 123,
+      "url": "https://www.youtube.com/watch?v=DYuqqnMKM60"
+    },
+    {
+      "videoId": "Wn1r8bWmeUA",
+      "title": "제주도 가면 흑돼지, 회도 좋지만 여기 가보는 건 어때요? 그동안 숨겨져있던 제대로 된 맛집 공개합니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 124,
+      "url": "https://www.youtube.com/watch?v=Wn1r8bWmeUA"
+    },
+    {
+      "videoId": "qxkYbEmQVj4",
+      "title": "지금 꼭 먹어야 하는 회!? 노량진 수산시장에서 가장 믿을 수 있는 20년 단골집 공개합니다. 수산시장 어려우면 그냥 여기서 드세요.",
+      "channelName": "비밀이야 bimirya",
+      "position": 125,
+      "url": "https://www.youtube.com/watch?v=qxkYbEmQVj4"
+    },
+    {
+      "videoId": "4J0OM2n3M8o",
+      "title": "곧 비싸질 곳입니다. 저렴하게 소고기 먹으려면 빨리 가세요. 어렵게 찾은 가성비 한우 오마카세!",
+      "channelName": "비밀이야 bimirya",
+      "position": 126,
+      "url": "https://www.youtube.com/watch?v=4J0OM2n3M8o"
+    },
+    {
+      "videoId": "bE0P3hvYjrM",
+      "title": "전라도 목포에 가면 가야할 횟집 TOP2! 민어vs홍어?? 둘 중에 고민하지 말고 그냥 둘 다 가세요.",
+      "channelName": "비밀이야 bimirya",
+      "position": 127,
+      "url": "https://www.youtube.com/watch?v=bE0P3hvYjrM"
+    },
+    {
+      "videoId": "UGqKI5FASP8",
+      "title": "서울에서 제대로 된 연탄구이 찾았습니다. 고기부터 양 대창까지 빈틈없는 새로운 맛집!",
+      "channelName": "비밀이야 bimirya",
+      "position": 128,
+      "url": "https://www.youtube.com/watch?v=UGqKI5FASP8"
+    },
+    {
+      "videoId": "ry3DwbV982U",
+      "title": "이거 된장찌개 아닙니다. 청국장도 아닙니다. 예멘 난민 출신 셰프가 만드는 리얼 아랍 음식입니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 129,
+      "url": "https://www.youtube.com/watch?v=ry3DwbV982U"
+    },
+    {
+      "videoId": "yl0-vdm_UWE",
+      "title": "내장,껍질까지 다 털어(?)먹는 30만원짜리 회! 제주도까지 갔으면 그냥 여기서 드세요.",
+      "channelName": "비밀이야 bimirya",
+      "position": 130,
+      "url": "https://www.youtube.com/watch?v=yl0-vdm_UWE"
+    },
+    {
+      "videoId": "v8eVP8yIT7Y",
+      "title": "일본 북해도에 더 이상 여행을 가지 않아도 되는 이유, \"서울 용산을 침략한 징기스칸\"",
+      "channelName": "비밀이야 bimirya",
+      "position": 131,
+      "url": "https://www.youtube.com/watch?v=v8eVP8yIT7Y"
+    },
+    {
+      "videoId": "AtN8zdqv_GU",
+      "title": "가성비 최고인 미슐랭 파인다이닝 알려드립니다. 특히 런치는 갓성비!!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 132,
+      "url": "https://www.youtube.com/watch?v=AtN8zdqv_GU"
+    },
+    {
+      "videoId": "8tRknqMN62A",
+      "title": "10년간 순대를 연구하면 만들어지는 순대 코스요리??",
+      "channelName": "비밀이야 bimirya",
+      "position": 133,
+      "url": "https://www.youtube.com/watch?v=8tRknqMN62A"
+    },
+    {
+      "videoId": "cbkEmkZIWC4",
+      "title": "고기 끝판왕과 집밥 끝판왕이 만나면 생기는 일!? 다니엘 오마카세 X 본앤브레드",
+      "channelName": "비밀이야 bimirya",
+      "position": 134,
+      "url": "https://www.youtube.com/watch?v=cbkEmkZIWC4"
+    },
+    {
+      "videoId": "nNsC7LceKJI",
+      "title": "국밥으로 책 쓴 사람이 추천하는 소고기 국밥 TOP2!",
+      "channelName": "비밀이야 bimirya",
+      "position": 135,
+      "url": "https://www.youtube.com/watch?v=nNsC7LceKJI"
+    },
+    {
+      "videoId": "XVthK_PAeE0",
+      "title": "내가 여수에 갔던 이유! 10년 단골 횟집 공개합니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 136,
+      "url": "https://www.youtube.com/watch?v=XVthK_PAeE0"
+    },
+    {
+      "videoId": "NhR_t31ZnTg",
+      "title": "돼지고기 목살은 고민하지 말고 여기서 드세요.",
+      "channelName": "비밀이야 bimirya",
+      "position": 137,
+      "url": "https://www.youtube.com/watch?v=NhR_t31ZnTg"
+    },
+    {
+      "videoId": "KPXaJlslTB0",
+      "title": "홍대에 코스요리가 나오는 한식주점이 있다?",
+      "channelName": "비밀이야 bimirya",
+      "position": 138,
+      "url": "https://www.youtube.com/watch?v=KPXaJlslTB0"
+    },
+    {
+      "videoId": "fihh77lJ4Rk",
+      "title": "15kg짜리 거대 다금바리를 먹어보았습니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 139,
+      "url": "https://www.youtube.com/watch?v=fihh77lJ4Rk"
+    },
+    {
+      "videoId": "7lpgOuZ4fl4",
+      "title": "경상도 갈비 3대장! 한우갈비 맛집 TOP3 추천합니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 140,
+      "url": "https://www.youtube.com/watch?v=7lpgOuZ4fl4"
+    },
+    {
+      "videoId": "xnGc9Il7W7o",
+      "title": "고기가 들어간 파이? '뚝뜨'를 먹어보았습니다.",
+      "channelName": "비밀이야 bimirya",
+      "position": 141,
+      "url": "https://www.youtube.com/watch?v=xnGc9Il7W7o"
+    },
+    {
+      "videoId": "tSoG6X0XfGY",
+      "title": "서울에서 잠깐 '프랑스' 다녀오는 방법?",
+      "channelName": "비밀이야 bimirya",
+      "position": 142,
+      "url": "https://www.youtube.com/watch?v=tSoG6X0XfGY"
+    },
+    {
+      "videoId": "I49Ary6aQZs",
+      "title": "1개에 5,000원인 군만두는 어떤 맛일까!?",
+      "channelName": "비밀이야 bimirya",
+      "position": 143,
+      "url": "https://www.youtube.com/watch?v=I49Ary6aQZs"
+    },
+    {
+      "videoId": "cbjuC1A1utQ",
+      "title": "한식?일식?양식? 어쨌든 맛있는 곳! 7th door에 다녀왔습니다! - 2부",
+      "channelName": "비밀이야 bimirya",
+      "position": 144,
+      "url": "https://www.youtube.com/watch?v=cbjuC1A1utQ"
+    },
+    {
+      "videoId": "ABfRMRTR4R4",
+      "title": "발효와 숙성의 최상의 맛! 7th door에 다녀왔습니다! - 1부",
+      "channelName": "비밀이야 bimirya",
+      "position": 145,
+      "url": "https://www.youtube.com/watch?v=ABfRMRTR4R4"
+    },
+    {
+      "videoId": "Pb1P3fqEf3E",
+      "title": "냉부해 정호영쉐프의 미슐랭가이드 맛집, 카덴에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 146,
+      "url": "https://www.youtube.com/watch?v=Pb1P3fqEf3E"
+    },
+    {
+      "videoId": "K-PIrdvtS-I",
+      "title": "[내 맛집을 소개합니다] 주옥ㅣ더 플라자 호텔ㅣ모던 한식ㅣ신창호 셰프ㅣ최애하는 식당 중 하나ㅣ뷰 맛집(feat. 집회와 시위)ㅣ외모와 다른 셰프님의 섬세함ㅋ",
+      "channelName": "비밀이야 bimirya",
+      "position": 147,
+      "url": "https://www.youtube.com/watch?v=K-PIrdvtS-I"
+    },
+    {
+      "videoId": "fSXZON7EnzQ",
+      "title": "[내 맛집을 소개합니다] 레스쁘아 뒤 이부ㅣ청담동ㅣ프렌치ㅣ임기학 셰프ㅣ최애하는 프렌치 레스토랑ㅣ파리 감성ㅣ점심인데 알딸딸~",
+      "channelName": "비밀이야 bimirya",
+      "position": 148,
+      "url": "https://www.youtube.com/watch?v=fSXZON7EnzQ"
+    },
+    {
+      "videoId": "K0mqlDy9G4w",
+      "title": "[내 맛집을 소개합니다] 쵸이닷ㅣ청담동ㅣ이탈리안ㅣ최현석 셰프ㅣ오랜만에 보는 소금 뿌리기 신공ㅣ셰프들의 수다(feat. 김대천, 신창호, 이유석)",
+      "channelName": "비밀이야 bimirya",
+      "position": 149,
+      "url": "https://www.youtube.com/watch?v=K0mqlDy9G4w"
+    },
+    {
+      "videoId": "fQWLWN_jars",
+      "title": "[내 맛집을 소개합니다] 쵸이닷ㅣ청담동ㅣ이탈리안ㅣ최현석 셰프ㅣ초심이 담긴 디너 코스ㅣ정말 먹고 싶었던 최현석표 봉골레ㅣ마법 물약도 있음ㅋ",
+      "channelName": "비밀이야 bimirya",
+      "position": 150,
+      "url": "https://www.youtube.com/watch?v=fQWLWN_jars"
+    },
+    {
+      "videoId": "rZ54pFaB5Jk",
+      "title": "[내 맛집을 소개합니다] 권숙수ㅣ청담동ㅣ모던 한식ㅣ미쉐린 2스타ㅣ권우중 셰프ㅣ20만 원 디너 코스ㅣ메인 요리 3개ㅣ말이 안 나오는 디저트 카트!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 151,
+      "url": "https://www.youtube.com/watch?v=rZ54pFaB5Jk"
+    },
+    {
+      "videoId": "VprcGD2-TYk",
+      "title": "[내 맛집을 소개합니다] 권숙수ㅣ청담동ㅣ모던 한식ㅣ미쉐린 2스타ㅣ권우중 셰프ㅣ20만 원 디너 코스ㅣ조선시대 선비된 기분~",
+      "channelName": "비밀이야 bimirya",
+      "position": 152,
+      "url": "https://www.youtube.com/watch?v=VprcGD2-TYk"
+    },
+    {
+      "videoId": "VXOXaoGjiZ8",
+      "title": "[내 맛집을 소개합니다] 밍글스ㅣ청담동ㅣ모던 한식의 선두주자ㅣ미쉐린 2스타ㅣ강민구 셰프ㅣ다 맛있지만 양고기가 최고!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 153,
+      "url": "https://www.youtube.com/watch?v=VXOXaoGjiZ8"
+    },
+    {
+      "videoId": "mXQW0N2XBhM",
+      "title": "[내 맛집을 소개합니다] 용강식당ㅣ을지로ㅣLA갈비 골목 원조 맛집ㅣ김과 비빔밥의 조합은 역시!ㅣ합동 생일 파티(feat. JYTOUR)",
+      "channelName": "비밀이야 bimirya",
+      "position": 154,
+      "url": "https://www.youtube.com/watch?v=mXQW0N2XBhM"
+    },
+    {
+      "videoId": "VvlMUFxa5PA",
+      "title": "[내 맛집을 소개합니다] 몽고네ㅣ압구정동ㅣ이탈리안 레스토랑ㅣ파스타 맛집ㅣ화려한 라인업을 자랑하는 디제스티프ㅣ어마무시한 디저트",
+      "channelName": "비밀이야 bimirya",
+      "position": 155,
+      "url": "https://www.youtube.com/watch?v=VvlMUFxa5PA"
+    },
+    {
+      "videoId": "Tw27gD6GCyI",
+      "title": "[내 맛집을 소개합니다] 본 앤 브레드 x 다니엘 오마카세(2)ㅣ어디서도 보기 힘든 참신한 요리!ㅣ비주얼 보다는 맛!ㅣ배부름 주의!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 156,
+      "url": "https://www.youtube.com/watch?v=Tw27gD6GCyI"
+    },
+    {
+      "videoId": "wTTuqVAnmd0",
+      "title": "[내 맛집을 소개합니다] 본 앤 브레드 x 다니엘 오마카세(1)ㅣ지금까지 이런 조합은 없었다ㅣ매우 희귀템!!ㅣ뉴욕 2스타 셰프님도 손님으로~ㅣ뭘 상상하든 그 이상!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 157,
+      "url": "https://www.youtube.com/watch?v=wTTuqVAnmd0"
+    },
+    {
+      "videoId": "Q9iFhrLB4Do",
+      "title": "[내 맛집을 소개합니다] 부우사안(BUSAN)ㅣ부산 해운대구ㅣ부티크 중식당ㅣ베이징 덕ㅣ딤섬ㅣ1층부터 4층까지 중식당ㅣ중식당 전문 사장님이 운영",
+      "channelName": "비밀이야 bimirya",
+      "position": 158,
+      "url": "https://www.youtube.com/watch?v=Q9iFhrLB4Do"
+    },
+    {
+      "videoId": "6prm1nXFDF8",
+      "title": "[내 맛집을 소개합니다] 다니엘 오마카세ㅣ집밥 다선생ㅣ최고급 재료로 만든 요리들ㅣ캐비아부터 화이트 트러플ㅣ아무나 못 가는 곳!!ㅣ최애 맛집!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 159,
+      "url": "https://www.youtube.com/watch?v=6prm1nXFDF8"
+    },
+    {
+      "videoId": "SYClED7ExoA",
+      "title": "[내 맛집을 소개합니다] 포항 죽도동 동창생ㅣ45,000원 맡김 차림ㅣ기본 찬만으로 소주 3병 가능!!ㅣ다 맛있지만 김치가 예술!ㅣ자연산 전복죽도 예술!ㅣ그냥 다 예술!",
+      "channelName": "비밀이야 bimirya",
+      "position": 160,
+      "url": "https://www.youtube.com/watch?v=SYClED7ExoA"
+    },
+    {
+      "videoId": "LN9FFR3EUE0",
+      "title": "[내 맛집을 소개합니다] 마장동 본 앤 브레드 스피크이지(Born & Bred Speakeasy)(2)ㅣ비밀이야 투어ㅣ소 한 마리 해체쇼ㅣ짜파구리 원조!!ㅣ처음 먹어본 소화제",
+      "channelName": "비밀이야 bimirya",
+      "position": 161,
+      "url": "https://www.youtube.com/watch?v=LN9FFR3EUE0"
+    },
+    {
+      "videoId": "q44MazZCY6w",
+      "title": "[내 맛집을 소개합니다] 마장동 본 앤 브레드 스피크이지(Born & Bred Speakeasy)(1)ㅣ비밀이야 투어ㅣ즉석에서 발골한 고기를 먹을 수 있는..ㅣ소고기로 배 터진다",
+      "channelName": "비밀이야 bimirya",
+      "position": 162,
+      "url": "https://www.youtube.com/watch?v=q44MazZCY6w"
+    },
+    {
+      "videoId": "V0ldZecOBLI",
+      "title": "[내 맛집을 소개합니다] 일산 백석동 바다향기ㅣ자연산 회ㅣ차원이 다른 해산물ㅣ엄청 큰 보리새우ㅣ최애템 돌장어ㅣ간의 최고봉 노랑 가오리 간ㅣ쭉쭉 들어가는 더덕주",
+      "channelName": "비밀이야 bimirya",
+      "position": 163,
+      "url": "https://www.youtube.com/watch?v=V0ldZecOBLI"
+    },
+    {
+      "videoId": "6iY7Bzc6mWc",
+      "title": "[내 맛집을 소개합니다] 신당동 은화계ㅣ프리미엄한 닭고기 숯불구이 전문점ㅣ닭의 퀄리티가 다릅니다ㅣ힙한 분위기와 음악은 덤(feat. 옆집 사람)",
+      "channelName": "비밀이야 bimirya",
+      "position": 164,
+      "url": "https://www.youtube.com/watch?v=6iY7Bzc6mWc"
+    },
+    {
+      "videoId": "dcaG4owW8yE",
+      "title": "[내 맛집을 소개합니다] 강남구 신사동 고료리 켄ㅣ애정하는 창작 요리집ㅣ일식인가? 양식인가?ㅣ연예인 닮은(?) 셰프가 요리합니다(feat. 김건 셰프)",
+      "channelName": "비밀이야 bimirya",
+      "position": 165,
+      "url": "https://www.youtube.com/watch?v=dcaG4owW8yE"
+    },
+    {
+      "videoId": "6UqtYN0D8AQ",
+      "title": "[내 맛집을 소개합니다] 강남구 신사동 텐쇼(天匠)ㅣ덴뿌라 전문점ㅣ튀김으로 입호강ㅣ미남 셰프 때문에 눈호강(feat. 최지영 셰프)",
+      "channelName": "비밀이야 bimirya",
+      "position": 166,
+      "url": "https://www.youtube.com/watch?v=6UqtYN0D8AQ"
+    },
+    {
+      "videoId": "_S9R0I2xw08",
+      "title": "[내 맛집을 소개합니다] 관악구 봉천동 만양순대국ㅣ제일 자주가는 순대국집ㅣ착한 가격ㅣ말이 필요없는 모둠수육과 편육",
+      "channelName": "비밀이야 bimirya",
+      "position": 167,
+      "url": "https://www.youtube.com/watch?v=_S9R0I2xw08"
+    },
+    {
+      "videoId": "fbdyN8RgttI",
+      "title": "[내 맛집을 소개합니다] 강남구 청담동 갓포산ㅣ양식의 터치가 가미된 갓포 요리ㅣ오늘은 지대로 탕진잼!!(feat. 안샘 캐비아, 화이트 트러플, 블랙 트러플)",
+      "channelName": "비밀이야 bimirya",
+      "position": 168,
+      "url": "https://www.youtube.com/watch?v=fbdyN8RgttI"
+    },
+    {
+      "videoId": "TH0QyLjaiAA",
+      "title": "[내 맛집을 소개합니다] 인천 중구 경동 용화반점ㅣ이게 진짜 한국식 중식이쥐~ㅣ서울에 이런 느낌의 식당이 생겼으면 좋겠습니다!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 169,
+      "url": "https://www.youtube.com/watch?v=TH0QyLjaiAA"
+    },
+    {
+      "videoId": "FVRkzUzw0WI",
+      "title": "[내 맛집을 소개합니다] 청담동 텐지몽ㅣ톡톡의 김대천 셰프와 도쿄 덴의 하세가와 셰프의 만남ㅣ솥밥 끝판왕",
+      "channelName": "비밀이야 bimirya",
+      "position": 170,
+      "url": "https://www.youtube.com/watch?v=FVRkzUzw0WI"
+    },
+    {
+      "videoId": "gknNgp0pLW4",
+      "title": "[내 맛집을 소개합니다] 을지로 다전식당ㅣ비가 와도 야장!!(feat. JYTOUR)",
+      "channelName": "비밀이야 bimirya",
+      "position": 171,
+      "url": "https://www.youtube.com/watch?v=gknNgp0pLW4"
+    },
+    {
+      "videoId": "5uYi_r1_Ec0",
+      "title": "[내 맛집을 소개합니다] 종로 원서동 한식공간ㅣ조희숙 셰프님의 섬세한 모던 한식ㅣ맛있는 한식은 물론 멋진 뷰까지!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 172,
+      "url": "https://www.youtube.com/watch?v=5uYi_r1_Ec0"
+    },
+    {
+      "videoId": "mhGBhzG86IY",
+      "title": "[내 맛집을 소개합니다] 예천 단골식당ㅣ여전히 맛있는 오징어 불고기ㅣ8년 만에 왔는데.. 좀..",
+      "channelName": "비밀이야 bimirya",
+      "position": 173,
+      "url": "https://www.youtube.com/watch?v=mhGBhzG86IY"
+    },
+    {
+      "videoId": "mIjOK4WHQfo",
+      "title": "[내 맛집을 소개합니다] 부산 해운대 라호짬뽕ㅣ탕수육을 스리라차에?ㅣ볶음밥은 미쳤다",
+      "channelName": "비밀이야 bimirya",
+      "position": 174,
+      "url": "https://www.youtube.com/watch?v=mIjOK4WHQfo"
+    },
+    {
+      "videoId": "Vw4ku6PEQrc",
+      "title": "[내 맛집을 소개합니다] 부산 동광동 화국반점ㅣ튀김 요리가 일품ㅣ여기서 맥콜을 보다니..",
+      "channelName": "비밀이야 bimirya",
+      "position": 175,
+      "url": "https://www.youtube.com/watch?v=Vw4ku6PEQrc"
+    },
+    {
+      "videoId": "haGPE45EmcQ",
+      "title": "[내 맛집을 소개합니다] 부산 보수동 동화반점ㅣ유니짜장 맛집ㅣ반갑다 계란 프라이~",
+      "channelName": "비밀이야 bimirya",
+      "position": 176,
+      "url": "https://www.youtube.com/watch?v=haGPE45EmcQ"
+    },
+    {
+      "videoId": "8WhDEN_hP4w",
+      "title": "[내 맛집을 소개합니다] 충북 괴산 괴강 매운탕(50년 할머니집)ㅣ궁극의 쏘가리 조림",
+      "channelName": "비밀이야 bimirya",
+      "position": 177,
+      "url": "https://www.youtube.com/watch?v=8WhDEN_hP4w"
+    },
+    {
+      "videoId": "X1z6sGwgAGQ",
+      "title": "[내 맛집을 소개합니다] 방배동 송강(2)ㅣ1.5kg이 넘는 갯벌장어ㅣ맛과 식감 모두 만족ㅣ와인 대참사",
+      "channelName": "비밀이야 bimirya",
+      "position": 178,
+      "url": "https://www.youtube.com/watch?v=X1z6sGwgAGQ"
+    },
+    {
+      "videoId": "BOBhx_QCGZs",
+      "title": "[내 맛집을 소개합니다] 방배동 송강(1)ㅣ복어와 장어를 함께ㅣ비밀이야 코스",
+      "channelName": "비밀이야 bimirya",
+      "position": 179,
+      "url": "https://www.youtube.com/watch?v=BOBhx_QCGZs"
+    },
+    {
+      "videoId": "pO2oHr5zM14",
+      "title": "[내 맛집을 소개합니다] 을지로 보석ㅣ요즘 가장 힙한 술집ㅣ예약해도 2달 기다려야 하는",
+      "channelName": "비밀이야 bimirya",
+      "position": 180,
+      "url": "https://www.youtube.com/watch?v=pO2oHr5zM14"
+    },
+    {
+      "videoId": "aLo57_gMo2Y",
+      "title": "[내 맛집을 소개합니다] 홍대 빠넬로(Panello)ㅣ피자와 파스타 그리고 트러플(feat. 와인 3병)",
+      "channelName": "비밀이야 bimirya",
+      "position": 181,
+      "url": "https://www.youtube.com/watch?v=aLo57_gMo2Y"
+    },
+    {
+      "videoId": "L-oy6emhJIs",
+      "title": "[내 맛집을 소개합니다] 가네끼 스시ㅣ민어 갈라 디너(feat. 최주용 셰프)",
+      "channelName": "비밀이야 bimirya",
+      "position": 182,
+      "url": "https://www.youtube.com/watch?v=L-oy6emhJIs"
+    },
+    {
+      "videoId": "jfFIovTJcDk",
+      "title": "[비밀이야 음식 이야기] 오프레 이지원 셰프와 함께 하는 솔직한 음식 수다(2)",
+      "channelName": "비밀이야 bimirya",
+      "position": 183,
+      "url": "https://www.youtube.com/watch?v=jfFIovTJcDk"
+    },
+    {
+      "videoId": "guuThOINFW4",
+      "title": "[비밀이야 음식 이야기] 오프레 이지원 셰프와 함께 하는 솔직한 음식 수다(1)",
+      "channelName": "비밀이야 bimirya",
+      "position": 184,
+      "url": "https://www.youtube.com/watch?v=guuThOINFW4"
+    },
+    {
+      "videoId": "PVOxXiMIV2U",
+      "title": "[내 맛집을 소개합니다] 오프레(Aupres)ㅣ클래식한 프렌치 레스토랑(feat. 이지원 셰프)",
+      "channelName": "비밀이야 bimirya",
+      "position": 185,
+      "url": "https://www.youtube.com/watch?v=PVOxXiMIV2U"
+    },
+    {
+      "videoId": "NFd2JEmlvBw",
+      "title": "[내 맛집을 소개합니다] 말이 필요 없는 토종닭 능이 백숙(feat. 야관문주)",
+      "channelName": "비밀이야 bimirya",
+      "position": 186,
+      "url": "https://www.youtube.com/watch?v=NFd2JEmlvBw"
+    },
+    {
+      "videoId": "cYupJu6qUV4",
+      "title": "[내 맛집을 소개합니다] 배가 불러도 계속 먹을 수 있습니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 187,
+      "url": "https://www.youtube.com/watch?v=cYupJu6qUV4"
+    },
+    {
+      "videoId": "Ne7sSIE34NI",
+      "title": "[내 맛집을 소개합니다] 속초와서 여기를 안 갈 수는 없죠!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 188,
+      "url": "https://www.youtube.com/watch?v=Ne7sSIE34NI"
+    },
+    {
+      "videoId": "b-0yxZr4J3U",
+      "title": "[내 맛집을 소개합니다] 자연산 회를 만날 수 있는 곳, 가성비도 최고!!",
+      "channelName": "비밀이야 bimirya",
+      "position": 189,
+      "url": "https://www.youtube.com/watch?v=b-0yxZr4J3U"
+    },
+    {
+      "videoId": "NqtLQaGfW7I",
+      "title": "[내 맛집을 소개합니다] 두부계의 에르메스, 차원이 다른 두부의 맛",
+      "channelName": "비밀이야 bimirya",
+      "position": 190,
+      "url": "https://www.youtube.com/watch?v=NqtLQaGfW7I"
+    },
+    {
+      "videoId": "51jlRo46lSI",
+      "title": "[내 맛집을 소개합니다] 이 곰치국을 200번 넘게 먹었습니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 191,
+      "url": "https://www.youtube.com/watch?v=51jlRo46lSI"
+    },
+    {
+      "videoId": "-RaG0yYhERo",
+      "title": "Private video",
+      "channelName": "비밀이야 bimirya",
+      "position": 192,
+      "url": "https://www.youtube.com/watch?v=-RaG0yYhERo"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdH0bvPK3Fn4pY7jrcWKIX5J/_create_manifest.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdH0bvPK3Fn4pY7jrcWKIX5J/_create_manifest.json
@@ -1,0 +1,326 @@
+{
+  "sunreiId": "SR01kyhw8vv345x6ywas7my5p8te",
+  "sourceId": "SRC01kyhw8vq7ze5mry327y36vrwd",
+  "spots": [
+    {
+      "spotId": "SS01kyhw8vw3cark4q7vhahv2cd0",
+      "videoId": "55L8utAPik8",
+      "videoTitle": "(EN) ※역대급 주의※ 이탈리아 NO.1 와인 셀러"
+    },
+    {
+      "spotId": "SS01kyhw8vw8pknf5sf5v3sc68mn",
+      "videoId": "XiRHPQVB8dg",
+      "videoTitle": "꼭꼭 숨겨둔 소믈리에 창고로 들어갔더니..🍾 주문하는 대로 나오는 미지의 공간 [EN]ㅣ Golden View Firenze"
+    },
+    {
+      "spotId": "SS01kyhw8vwadxmdh0mzdpwt00qj",
+      "videoId": "F_dIt526c6M",
+      "videoTitle": "지역 전통 와인을 곁들인 피렌체식 스테이크🥩 + 파스타🍝 피렌체 현지 찐맛집 TOP3를 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhw8vwdy8vx1wfjham367yd",
+      "videoId": "F_dIt526c6M",
+      "videoTitle": "지역 전통 와인을 곁들인 피렌체식 스테이크🥩 + 파스타🍝 피렌체 현지 찐맛집 TOP3를 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhw8vwg9cby5ev5bj6sgcyk",
+      "videoId": "F_dIt526c6M",
+      "videoTitle": "지역 전통 와인을 곁들인 피렌체식 스테이크🥩 + 파스타🍝 피렌체 현지 찐맛집 TOP3를 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhw8vwksjd39zgyqdfrty8g",
+      "videoId": "sHuBxUk2n9w",
+      "videoTitle": "베네치아 최고의 식당은 바로 이곳! 150만 원 상당의 고급 와인과 각종 이탈리아 요리 맛보고 왔습니다!!"
+    },
+    {
+      "spotId": "SS01kyhw8vwnx5fkv1vss110asfe",
+      "videoId": "UpknbGKq8MU",
+      "videoTitle": "최상급 재료의 음식만 파는 로마 최고의 식당!!🥂 관찰레가 들어간 로마식 까르보나라와 최고 등급 와인리스트를 보유한 로마 찐 맛집 전격 공개!"
+    },
+    {
+      "spotId": "SS01kyhw8vx9y1znnz6fcyadycwf",
+      "videoId": "8JN9YyIA-7U",
+      "videoTitle": "(EN) 늘 오고 싶게 만드는 가족 식당 | Dal Pescatore"
+    },
+    {
+      "spotId": "SS01kyhw8vxc6t8e70w73yd39dcc",
+      "videoId": "IpzLwlrTIFo",
+      "videoTitle": "돈까스의 원조, 밀라노 송아지 튀김 요리?🍗 100년 넘은 밀라노 전통 레스토랑을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhw8vxjttwf9q7yqjehqn9k",
+      "videoId": "IpzLwlrTIFo",
+      "videoTitle": "돈까스의 원조, 밀라노 송아지 튀김 요리?🍗 100년 넘은 밀라노 전통 레스토랑을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhw8vxm8gmvq5zq4s2qkhwy",
+      "videoId": "MFt1YAsgGrA",
+      "videoTitle": "미슐랭 2스타 이탈리아 인생 레스토랑! 농어 구이, 훈제 방어, 이탈리아식 파스타까지..풀 코스 전격 공개합니다"
+    },
+    {
+      "spotId": "SS01kyhw8vxpy36b7wrwxtqj14p3",
+      "videoId": "diHZr8fyZbU",
+      "videoTitle": "최근 이탈리아에서 가장 핫한 미슐랭 레스토랑? 어디서도 본 적 없는 퀄리티, 월드베스트 레스토랑으로 떠오르는 곳을 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhw8vxst016y76xp4bfv7d2",
+      "videoId": "DxB6A5ur9MA",
+      "videoTitle": "이탈리아 미슐랭 레스토랑에서 찾은 세계 최고의 와인?🍷 역대급 와인 리스트만 모아놓은 포지타노 레스토랑에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhw8vxvbq5314zd4myn984p",
+      "videoId": "xMDBOQrtwlw",
+      "videoTitle": "피렌체 2kg 스테이크 접수하고 왔습니다🥩(feat. 내장버거) | Paoli 1827, Da Nerbone, Caffè Gilli"
+    },
+    {
+      "spotId": "SS01kyhw8vxx8xvp1paaknh0cc5n",
+      "videoId": "xMDBOQrtwlw",
+      "videoTitle": "피렌체 2kg 스테이크 접수하고 왔습니다🥩(feat. 내장버거) | Paoli 1827, Da Nerbone, Caffè Gilli"
+    },
+    {
+      "spotId": "SS01kyhw8vy0ehep5n6s21ce30t1",
+      "videoId": "xMDBOQrtwlw",
+      "videoTitle": "피렌체 2kg 스테이크 접수하고 왔습니다🥩(feat. 내장버거) | Paoli 1827, Da Nerbone, Caffè Gilli"
+    },
+    {
+      "spotId": "SS01kyhw8vy2dkwxe7akw7wjjfx2",
+      "videoId": "YvDTCJhYEJE",
+      "videoTitle": "🐟10여 가지 해산물 전채와 날마다 바뀌는 해산물 파스타🍝 베네치아 최고의 가성비 식당에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhw8vy9hebzxn9g9jsqm2zt",
+      "videoId": "LaBQYfe7YqU",
+      "videoTitle": "많은 분들을 놀라게 한 수백억짜리 와인 셀러, 다시 찾고 실망한 이유ㅣ에노테카 핀키오리 [EN]"
+    },
+    {
+      "spotId": "SS01kyhw8vycrjdy7n6gcppthe7v",
+      "videoId": "T73wxsGB4wk",
+      "videoTitle": "[EN] 비밀이야 먹뱉 논란? 구글 평점 믿고 간 레스토랑 제대로 당했네요.. | 이탈리아 출장 EP.1 | San Silvestro | Corte Sconta"
+    },
+    {
+      "spotId": "SS01kyhw8vyfbhrfagy1q4s9wwpq",
+      "videoId": "T73wxsGB4wk",
+      "videoTitle": "[EN] 비밀이야 먹뱉 논란? 구글 평점 믿고 간 레스토랑 제대로 당했네요.. | 이탈리아 출장 EP.1 | San Silvestro | Corte Sconta"
+    },
+    {
+      "spotId": "SS01kyhw8vyjthyxmv2kpdh0879e",
+      "videoId": "sHZMGPDK_ok",
+      "videoTitle": "(EN) 사실 체육관 아니고, \"미쉐린 1스타 레스토랑\" | Il Convivio Troiani"
+    },
+    {
+      "spotId": "SS01kyhw8vymw3y5vz4swxrm2ztp",
+      "videoId": "p25xWRnIkdg",
+      "videoTitle": "전 세계에서 꼭 가봐야 할 이탈리아 여행지 1등! 한국인 취향까지 저격해버린 각종 해산물 요리 먹고 왔습니다"
+    },
+    {
+      "spotId": "SS01kyhw8vypjt4pgk0hvnwhaz2c",
+      "videoId": "afDn5kAWKzs",
+      "videoTitle": "[비밀이야 in 이탈리아] 밀라노 근교 다비토리오(da VittorioOㅣ미쉐린 3스타ㅣ이탈리아 최애 레스토랑ㅣ4년 만에 방문ㅣ역시는 역시!!ㅣ4시간 넘게 식사ㅣ식사 중 졸음ㅋㅣ"
+    },
+    {
+      "spotId": "SS01kyhw8vyq086pr38yr1fm5xyy",
+      "videoId": "BJjP1QVI0-M",
+      "videoTitle": "이탈리아 1등 레스토랑은 이곳입니다 | 달 페스카토레"
+    },
+    {
+      "spotId": "SS01kyhw8vyshdmctsx2yybnjq00",
+      "videoId": "Yhk7fn2AsJs",
+      "videoTitle": "로마, 피렌체, 밀라노 등 이탈리아의 숨겨진 미슐랭 맛집 싹 다 모았습니다!👨‍🍳 진짜 비밀이야.. (f. 프롤로그)"
+    },
+    {
+      "spotId": "SS01kyhw8vytv0nwy90ydp8mp0q4",
+      "videoId": "Yhk7fn2AsJs",
+      "videoTitle": "로마, 피렌체, 밀라노 등 이탈리아의 숨겨진 미슐랭 맛집 싹 다 모았습니다!👨‍🍳 진짜 비밀이야.. (f. 프롤로그)"
+    },
+    {
+      "spotId": "SS01kyhw8vyvdhe0d20r7nep42dq",
+      "videoId": "Yhk7fn2AsJs",
+      "videoTitle": "로마, 피렌체, 밀라노 등 이탈리아의 숨겨진 미슐랭 맛집 싹 다 모았습니다!👨‍🍳 진짜 비밀이야.. (f. 프롤로그)"
+    },
+    {
+      "spotId": "SS01kyhw8vywmxwc36tgzjy0b02q",
+      "videoId": "Yhk7fn2AsJs",
+      "videoTitle": "로마, 피렌체, 밀라노 등 이탈리아의 숨겨진 미슐랭 맛집 싹 다 모았습니다!👨‍🍳 진짜 비밀이야.. (f. 프롤로그)"
+    },
+    {
+      "spotId": "SS01kyhw8vyxcwb3sg523vrhq9cz",
+      "videoId": "Yhk7fn2AsJs",
+      "videoTitle": "로마, 피렌체, 밀라노 등 이탈리아의 숨겨진 미슐랭 맛집 싹 다 모았습니다!👨‍🍳 진짜 비밀이야.. (f. 프롤로그)"
+    },
+    {
+      "spotId": "SS01kyhw8vyzm460z1h7pn1ydt66",
+      "videoId": "6ISyBIQpcwY",
+      "videoTitle": "단돈 5만원짜리 프리미엄 트러플 요리가 있다? 피렌체 가시면 꼭 들려야할 곳ㅣOsteria Tre Panche"
+    },
+    {
+      "spotId": "SS01kyhw8vz16a331qg6mss1gtgx",
+      "videoId": "vfLu7DiGD4Y",
+      "videoTitle": "같은 년도 끼리 와인 맛은 똑같을까? 빈티지 와인에 대한 이야기 오늘 다 풀어봅니다 ㅣ로칸다 델 필로네"
+    },
+    {
+      "spotId": "SS01kyhw8vz3917krabbz168c01c",
+      "videoId": "Jnj43_lge20",
+      "videoTitle": "세상에서 제일 비싼 새우!🦐현지인 맛집에는 이유가 있구나 | Terrazza Calabritto, Luini, 밀라노 쇼핑"
+    },
+    {
+      "spotId": "SS01kyhw8vz5m0s42bptwdrj8sys",
+      "videoId": "Jnj43_lge20",
+      "videoTitle": "세상에서 제일 비싼 새우!🦐현지인 맛집에는 이유가 있구나 | Terrazza Calabritto, Luini, 밀라노 쇼핑"
+    },
+    {
+      "spotId": "SS01kyhw8vz7btaghew26gn7qv2e",
+      "videoId": "KnlYjxsqbZY",
+      "videoTitle": "이탈리아 미쉐린 별을 휩쓸고 있는 셰프, 그 이름을 건 식당 (feat. 미소년 서버👨🏻‍🍳)ㅣ엔리코 바르톨리니"
+    },
+    {
+      "spotId": "SS01kyhw8vz9y5ek366sdxb5thk5",
+      "videoId": "8swEJ-ZATnI",
+      "videoTitle": "100점 받은 와인과 먹는 역대급 파스타🍷매년 오는 이곳! | 트러플 축제, La Piola"
+    },
+    {
+      "spotId": "SS01kyhw8vzd06ev4dkfmbzd2tt5",
+      "videoId": "8jjUWH07IK4",
+      "videoTitle": "풍미부터 다른 이탈리아 정통 피자의 맛은?🍕 나폴리 부럽지않은 역대급 피자와 최고의 절경 포지타노에서 즐기는 조식까지 제대로 즐겨봤습니다!"
+    },
+    {
+      "spotId": "SS01kyhw8w0bkhtyz2c6ehx3sn9h",
+      "videoId": "8jjUWH07IK4",
+      "videoTitle": "풍미부터 다른 이탈리아 정통 피자의 맛은?🍕 나폴리 부럽지않은 역대급 피자와 최고의 절경 포지타노에서 즐기는 조식까지 제대로 즐겨봤습니다!"
+    },
+    {
+      "spotId": "SS01kyhw8w0dkt23ptd29689v5zr",
+      "videoId": "p1sG5mTi1wA",
+      "videoTitle": "(EN) 이곳의 타야린은 반드시! 맛보셔야 합니다 | La Piola"
+    },
+    {
+      "spotId": "SS01kyhw8w0f8akdajerqw5wmqz7",
+      "videoId": "5f5Vaky8DfY",
+      "videoTitle": "이탈리아에서 삼쏘에 80만 원 쓰고 왔습니다🐷🍺 (feat.흑백요리사) | 피렌체 한라산, 젤라또, 더몰 맛집"
+    },
+    {
+      "spotId": "SS01kyhw8w0h5dyzg587jvsqz4h1",
+      "videoId": "5f5Vaky8DfY",
+      "videoTitle": "이탈리아에서 삼쏘에 80만 원 쓰고 왔습니다🐷🍺 (feat.흑백요리사) | 피렌체 한라산, 젤라또, 더몰 맛집"
+    },
+    {
+      "spotId": "SS01kyhw8w0ng2h9dwxgp72zje14",
+      "videoId": "5f5Vaky8DfY",
+      "videoTitle": "이탈리아에서 삼쏘에 80만 원 쓰고 왔습니다🐷🍺 (feat.흑백요리사) | 피렌체 한라산, 젤라또, 더몰 맛집"
+    },
+    {
+      "spotId": "SS01kyhw8w0qhepkm9pv9pn2x4eb",
+      "videoId": "ZfAAbWNHZsg",
+      "videoTitle": "(EN) 합스부르크 가문에서 오픈한 레스토랑👑"
+    },
+    {
+      "spotId": "SS01kyhw8w0svp595sk1hhnnavzf",
+      "videoId": "U9OKVyamP7I",
+      "videoTitle": "내 맘대로 짜는 피렌체 1티어 해산물 코스🦐 | Fuor D'Acqua"
+    },
+    {
+      "spotId": "SS01kyhw8w0v5zv05dq6sxx3xdj1",
+      "videoId": "DlqcHq9pqts",
+      "videoTitle": "밀라노 대표 넘버원? 비싼 가격에 믿기지 않는 서비스 [EN]ㅣ랑고스테리아"
+    },
+    {
+      "spotId": "SS01kyhw8w0xnm87wevv69vxqzdj",
+      "videoId": "DlqcHq9pqts",
+      "videoTitle": "밀라노 대표 넘버원? 비싼 가격에 믿기지 않는 서비스 [EN]ㅣ랑고스테리아"
+    },
+    {
+      "spotId": "SS01kyhw8w0zje0xbmcttwvz3sdx",
+      "videoId": "bmRVDNxgVBs",
+      "videoTitle": "[비밀이야 in 이탈리아] 소렌토 토레 델 사라치노(Torre del Saracino)ㅣ미쉐린 2스타ㅣ바다 뷰ㅣ정말 애정하는 이탈리아 레스토랑ㅣ고기 못 먹어서 살짝 아쉬움"
+    },
+    {
+      "spotId": "SS01kyhw8w1197dt0rdxcmx3g7w4",
+      "videoId": "265ydJ9Otjc",
+      "videoTitle": "화이트 트러플 대축제 🎄다가오는 연말🎄 진하게 생각나는 이탈리아 레스토랑[EN]ㅣVilla Crespi"
+    },
+    {
+      "spotId": "SS01kyhw8w13q5kr8amm3y6js7x9",
+      "videoId": "xcoyMO3tQxg",
+      "videoTitle": "6년 만에 또간집, 미쉐린 3스타 | Uliassi"
+    },
+    {
+      "spotId": "SS01kyhw8w16ppcd13wk6xc72yqt",
+      "videoId": "KKp9RTuA3t4",
+      "videoTitle": "궁전에서 마시는 이탈리아 최고의 화이트 와인 | Atto di Vito Mollica"
+    },
+    {
+      "spotId": "SS01kyhw8w18yw438e8bw86fck6e",
+      "videoId": "xkHWTOcsJkQ",
+      "videoTitle": "이게 바로 화이트 트러플입니다🤍 (feat. 가성비 미친 와인샵, 트러플 짜파게티) | Il Centro"
+    },
+    {
+      "spotId": "SS01kyhw8w1bwjr6cdqym82e2hks",
+      "videoId": "TRhoUQoHJU0",
+      "videoTitle": "[비밀이야 in 이탈리아] 로마 아로마(Aroma)ㅣ미쉐린 1스타ㅣ콜로세움 뷰(feat.시위)ㅣ꼭 연인과 가세요!ㅣ뷰가 다했다"
+    },
+    {
+      "spotId": "SS01kyhw8w1dp6vv80pkz41pm8j7",
+      "videoId": "0MyfFFFfdOc",
+      "videoTitle": "[EN] 비밀이야가 말아주는 베네치아 꿀팁 총정리🍯| 이탈리아 출장 EP.2 | Trattoria Da Romano"
+    },
+    {
+      "spotId": "SS01kyhw8w1gb4sghgeprgfqkhmd",
+      "videoId": "zesn608_xzo",
+      "videoTitle": "혹평했던 레스토랑인데...직원들이 알아보네요 | Piazza Duomo"
+    },
+    {
+      "spotId": "SS01kyhw8w1h9wb2v427829272vr",
+      "videoId": "y8TnmVbNtgY",
+      "videoTitle": "밀라노의 힙한 성수 브레라!ㅣ와인잔은 넓은게 좋을까? 좁은게 좋을까? [EN]ㅣSette Cucina Urbana"
+    },
+    {
+      "spotId": "SS01kyhw8w1ke05vvmxfbk1r7qmx",
+      "videoId": "6b7x8AysySw",
+      "videoTitle": "(EN) 전 세계 최연소 미쉐린 3스타 셰프! 하지만 파스타는... | Ristorante Quadri"
+    },
+    {
+      "spotId": "SS01kyhw8w1n7pk75ja56xfsrxzh",
+      "videoId": "QBYqR8HoRAU",
+      "videoTitle": "제철 음식 챙겨 먹는데 이제 그게 화이트 트러플임🤍 | Il Luogo di Aimo e Nadia"
+    },
+    {
+      "spotId": "SS01kyhw8w1q3hmfafnepqrhgyan",
+      "videoId": "kj4mA9dxX2s",
+      "videoTitle": "광기 어린 셰프님과 그 아들 (feat. 진짜 이탈리아 가정식)ㅣ홀인원, 푸드라이터 [EN]"
+    },
+    {
+      "spotId": "SS01kyhw8w1t0vm8n298q6pa3gs1",
+      "videoId": "kj4mA9dxX2s",
+      "videoTitle": "광기 어린 셰프님과 그 아들 (feat. 진짜 이탈리아 가정식)ㅣ홀인원, 푸드라이터 [EN]"
+    },
+    {
+      "spotId": "SS01kyhw8w1w2kqdk0nymh6fh8cn",
+      "videoId": "GK7tzoJsVPY",
+      "videoTitle": "[EN] 그런데 미쉐린 음식에서 이물질이..? 이에 대한 생각 | 이탈리아 출장 EP.3 | Casa Perbellini"
+    },
+    {
+      "spotId": "SS01kyhw8w1yn1ws0bj32gc56pqh",
+      "videoId": "XrVKKGDTjyg",
+      "videoTitle": "이거 꿈인가요? 인생 숙소와 저녁식사 | Forestis Dolomites"
+    },
+    {
+      "spotId": "SS01kyhw8w1zecwr729sxrqj5k7r",
+      "videoId": "qrXzkgYQpSQ",
+      "videoTitle": "이탈리아의 '돼지 오줌보 스팀 파스타'를 먹어보다 | Lido84"
+    },
+    {
+      "spotId": "SS01kyhw8w2117jxy1rzpsdw24jd",
+      "videoId": "451vnX351yc",
+      "videoTitle": "[비밀이야 in 이탈리아] 피렌체 구찌 오스테리아(Gucci Osteria)ㅣ미쉐린 1스타ㅣ마시모 보투라 셰프ㅣ구찌와 마시모 보투라를 빼면 과연.."
+    },
+    {
+      "spotId": "SS01kyhw8w239ez185pefhx98twb",
+      "videoId": "CaHQnH6qK7Y",
+      "videoTitle": "[비밀이야 in 이탈리아] 나폴리 지노 소르빌로(Gino Sorbillo)ㅣ나폴리 4대 피자(내 맘대로ㅋ)ㅣ퀄리티에 비해 매우 저렴한 가격!ㅣ줄 서기 싫으면 말고 분점으로~"
+    },
+    {
+      "spotId": "SS01kyhw8w253se73d9xajgztm19",
+      "videoId": "nsTJJQaUTBo",
+      "videoTitle": "하루 단 20팀? 콜로세움뷰 럭셔리 호텔 후기⭐ | Palazzo Manfredi"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdH0bvPK3Fn4pY7jrcWKIX5J/locations.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdH0bvPK3Fn4pY7jrcWKIX5J/locations.json
@@ -3,1168 +3,852 @@
     {
       "videoId": "55L8utAPik8",
       "title": "(EN) ※역대급 주의※ 이탈리아 NO.1 와인 셀러",
-      "concept": "피렌체 미슐랭 3스타 와인 셀러 레스토랑",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Enoteca Pinchiorri",
-          "displayName": "Enoteca Pinchiorri",
+          "name": "Via Ghibellina, 87",
           "address": "Via Ghibellina, 87, 50122 Firenze FI, 이탈리아",
-          "latitude": 43.769999999999996,
-          "longitude": 11.2622222,
-          "googleMapsId": "ChIJJ9GCOAZUKhMRhWUgMfpfvX4",
-          "googleMapsUri": "https://maps.google.com/?cid=9132561147547903365&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=55L8utAPik8",
-          "description": "이탈리아 NO.1 와인 셀러로 화제가 된 레스토랑을 소개하는 영상에서 방문한 피렌체 미슐랭 3스타 레스토랑. 역대급 규모의 와인 셀러가 특징으로, 방대한 빈티지 컬렉션과 함께 코스를 즐길 수 있는 곳으로 극찬받았다."
+          "latitude": 43.7700104,
+          "longitude": 11.2621656,
+          "googleMapsId": "ChIJZ_CTRwZUKhMRM0qOJMO27lA",
+          "googleMapsUri": "https://maps.google.com/?cid=5831799516739553843&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "XiRHPQVB8dg",
       "title": "꼭꼭 숨겨둔 소믈리에 창고로 들어갔더니..🍾 주문하는 대로 나오는 미지의 공간 [EN]ㅣ Golden View Firenze",
-      "concept": "피렌체 폰테베키오 뷰 와인 레스토랑",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Golden View Firenze",
-          "displayName": "Golden View Firenze",
-          "address": "Via de' Bardi, 58/r, 50125 Firenze FI, 이탈리아",
-          "latitude": 43.7672859,
-          "longitude": 11.253231500000002,
-          "googleMapsId": "ChIJZaiZ_P9TKhMR7lLPKgvCIjE",
-          "googleMapsUri": "https://maps.google.com/?cid=3540605610285290222&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "Via de' Bardi, 58 R",
+          "address": "Via de' Bardi, 58 R, 50125 Firenze FI, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XiRHPQVB8dg",
-          "description": "피렌체 맛집을 소개하는 영상에서 방문한 폰테 베키오 뷰 레스토랑. 주문하는 대로 와인이 나오는 꼭꼭 숨겨둔 소믈리에 창고가 인상적인 공간으로 소개되었다."
+          "latitude": 43.767302699999995,
+          "longitude": 11.253342799999999,
+          "googleMapsId": "ChIJM33A8f9TKhMRdFU_hNxrrBo",
+          "googleMapsUri": "https://maps.google.com/?cid=1922029735836079476&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "F_dIt526c6M",
       "title": "지역 전통 와인을 곁들인 피렌체식 스테이크🥩 + 파스타🍝 피렌체 현지 찐맛집 TOP3를 소개합니다!",
-      "concept": "피렌체 현지 찐맛집 TOP3 (스테이크·파스타)",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Osteria Vini e Vecchi Sapori",
-          "displayName": "Vini e Vecchi Sapori",
-          "address": "Via dei Magazzini, 3/r, 50122 Firenze FI, 이탈리아",
-          "latitude": 43.7700901,
-          "longitude": 11.256815699999999,
-          "googleMapsId": "ChIJAfLFIwFUKhMRmv-jS9sjRb8",
-          "googleMapsUri": "https://maps.google.com/?cid=13782461659411120026&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "Via dei Magazzini, 3r",
+          "address": "Via dei Magazzini, 3r, 50122 Firenze FI, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=F_dIt526c6M",
-          "description": "피렌체 현지 찐맛집 TOP3를 소개하는 영상에서 방문한 전통 오스테리아. 지역 전통 와인을 곁들인 피렌체식 스테이크와 파스타가 일품인 곳으로 추천되었다."
+          "latitude": 43.7700252,
+          "longitude": 11.256751500000002,
+          "googleMapsId": "ChIJu_ewIQFUKhMRbVapcHmT2L8",
+          "googleMapsUri": "https://maps.google.com/?cid=13823961206004209261&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Trattoria L'oriuolo",
-          "displayName": "Trattoria L'Oriuolo",
+          "name": "Via dell' Oriuolo, 58r",
           "address": "Via dell' Oriuolo, 58r, 50122 Firenze FI, 이탈리아",
-          "latitude": 43.772140799999995,
-          "longitude": 11.2604252,
-          "googleMapsId": "ChIJSz1K-ANUKhMR5RcLI4IYm7c",
-          "googleMapsUri": "https://maps.google.com/?cid=13230195277543708645&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=F_dIt526c6M",
-          "description": "피렌체 현지 찐맛집 TOP3를 소개하는 영상에서 방문한 전통 토스카나 요리 전문 트라토리아. 지역 전통 와인과 함께 즐기는 피렌체 가정식이 매력으로 소개되었다."
+          "latitude": 43.7721544,
+          "longitude": 11.2604436,
+          "googleMapsId": "ChIJv-m1LgRUKhMRYJQRxLB8wv4",
+          "googleMapsUri": "https://maps.google.com/?cid=18357372129761137760&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Trattoria Sostanza",
-          "displayName": "트라토리아 소스탄자",
+          "name": "Via del Porcellana, 25/R",
           "address": "Via del Porcellana, 25/R, 50123 Firenze FI, 이탈리아",
-          "latitude": 43.7726719,
-          "longitude": 11.2470175,
-          "googleMapsId": "ChIJN60f96tWKhMRiZNBRkS36BM",
-          "googleMapsUri": "https://maps.google.com/?cid=1434597985181864841&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=F_dIt526c6M",
-          "description": "피렌체 현지 찐맛집 TOP3를 소개하는 영상에서 방문한 전통 트라토리아. 버터 치킨과 피렌체식 스테이크로 유명한 노포로 추천되었다."
+          "latitude": 43.7726705,
+          "longitude": 11.2470134,
+          "googleMapsId": "ChIJs4lM-qtWKhMR0djiGUoO14w",
+          "googleMapsUri": "https://maps.google.com/?cid=10148595996727367889&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "sHuBxUk2n9w",
       "title": "베네치아 최고의 식당은 바로 이곳! 150만 원 상당의 고급 와인과 각종 이탈리아 요리 맛보고 왔습니다!!",
-      "concept": "베네치아 고급 와인 레스토랑",
+      "concept": "Calle",
       "locations": [
         {
           "name": "Ristorante Glam",
-          "displayName": "Ristorante Glam",
           "address": "Calle Tron, 1961, 30135 Venezia VE, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Calle 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sHuBxUk2n9w",
           "latitude": 45.441379,
           "longitude": 12.329912,
           "googleMapsId": "ChIJcypW7sOxfkcRz-086hZfk34",
-          "googleMapsUri": "https://maps.google.com/?cid=9120738222379167183&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sHuBxUk2n9w",
-          "description": "베네치아 최고의 식당을 소개하는 영상에서 방문한 고급 레스토랑. 150만 원 상당의 고급 와인과 각종 이탈리아 요리를 즐길 수 있는 곳으로 극찬받았다."
+          "googleMapsUri": "https://maps.google.com/?cid=9120738222379167183&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "UpknbGKq8MU",
       "title": "최상급 재료의 음식만 파는 로마 최고의 식당!!🥂 관찰레가 들어간 로마식 까르보나라와 최고 등급 와인리스트를 보유한 로마 찐 맛집 전격 공개!",
-      "concept": "로마 최고급 까르보나라 레스토랑",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Roscioli",
-          "displayName": "Roscioli Salumeria con Cucina",
+          "name": "Roscioli (로마)",
           "address": "Via dei Giubbonari, 21, 00186 Roma RM, 이탈리아",
+          "description": "Roscioli (로마) — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=UpknbGKq8MU",
           "latitude": 41.894256,
           "longitude": 12.4742417,
           "googleMapsId": "ChIJ4T6-zEhgLxMRSa1VL3N0DyY",
           "googleMapsUri": "https://maps.google.com/?cid=2742538736156126537&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=UpknbGKq8MU",
-          "description": "로마 최고의 식당을 소개하는 영상에서 방문한 살루메리아 겸 레스토랑. 관찰레가 들어간 정통 로마식 까르보나라와 최고 등급 와인이 인기 메뉴로 소개되었다."
+          "geocodeWarning": "displayName 'Roscioli Salumeria con Cucina' != 'Roscioli (로마)'; verify"
         }
       ]
     },
     {
       "videoId": "8JN9YyIA-7U",
       "title": "(EN) 늘 오고 싶게 만드는 가족 식당 | Dal Pescatore",
-      "concept": "이탈리아 미슐랭 3스타 가족 레스토랑",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Dal Pescatore",
-          "displayName": "Ristorante Dal Pescatore Santini",
+          "name": "Via Runate, 15",
           "address": "Via Runate, 15, 46013 Canneto sull'Oglio MN, 이탈리아",
-          "latitude": 45.171066599999996,
-          "longitude": 10.3574144,
-          "googleMapsId": "ChIJEbzybxqzgUcRn1pQZjdmsH0",
-          "googleMapsUri": "https://maps.google.com/?cid=9056851238767843999&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=8JN9YyIA-7U",
-          "description": "늘 다시 오고 싶게 만드는 가족 식당을 소개하는 영상에서 방문한 미슐랭 3스타 레스토랑. 가족이 대를 이어 운영하는 따뜻한 분위기와 정통 이탈리아 요리로 극찬받았다."
+          "latitude": 45.171062299999996,
+          "longitude": 10.357653599999999,
+          "googleMapsId": "ChIJCd7GE6mzgUcRzHgthsEkamU",
+          "googleMapsUri": "https://maps.google.com/?cid=7307693758960466124&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "IpzLwlrTIFo",
       "title": "돈까스의 원조, 밀라노 송아지 튀김 요리?🍗 100년 넘은 밀라노 전통 레스토랑을 소개합니다!",
-      "concept": "밀라노 100년 전통 레스토랑 (밀라노식 송아지 커틀릿)",
+      "concept": "Largo",
       "locations": [
         {
-          "name": "Giacomo Arengario",
-          "displayName": "Giacomo Arengario",
-          "address": "Via Guglielmo Marconi, 1, 20123 Milano MI, 이탈리아",
-          "latitude": 45.463601999999995,
-          "longitude": 9.190309,
-          "googleMapsId": "ChIJwZnUpK7GhkcRoya_ZbIQ_nQ",
-          "googleMapsUri": "https://maps.google.com/?cid=8430193910881396387&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "사크로 쿠오레 가톨릭 대학교",
+          "address": "Largo Fra Agostino Gemelli, 1, 20123 Milano MI, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=IpzLwlrTIFo",
-          "description": "밀라노 전통 레스토랑을 소개하는 영상에서 방문한 두오모 뷰 레스토랑. 돈까스의 원조 격인 밀라노 송아지 튀김 요리(코톨레타)를 두오모를 바라보며 즐길 수 있는 곳으로 소개되었다."
+          "latitude": 45.4626029,
+          "longitude": 9.1767641,
+          "googleMapsId": "ChIJLdWinVbBhkcR18d96lFE08Y",
+          "googleMapsUri": "https://maps.google.com/?cid=14326869958212831191&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Solferino",
-          "displayName": "Solferino",
+          "name": "Via Castelfidardo, 2",
           "address": "Via Castelfidardo, 2, 20121 Milano MI, 이탈리아",
-          "latitude": 45.478087699999996,
-          "longitude": 9.1883237,
-          "googleMapsId": "ChIJV4j8tcrGhkcRQx-KpTMSvfM",
-          "googleMapsUri": "https://maps.google.com/?cid=17563214134844727107&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=IpzLwlrTIFo",
-          "description": "밀라노 전통 레스토랑을 소개하는 영상에서 방문한 100년 넘은 역사의 레스토랑. 밀라노 송아지 튀김 요리를 비롯한 클래식 밀라노 요리를 맛볼 수 있는 노포로 추천되었다."
+          "latitude": 45.4781723,
+          "longitude": 9.1885289,
+          "googleMapsId": "ChIJpefbtcrGhkcRBWIl963kCIk",
+          "googleMapsUri": "https://maps.google.com/?cid=9874393618836709893&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "MFt1YAsgGrA",
       "title": "미슐랭 2스타 이탈리아 인생 레스토랑! 농어 구이, 훈제 방어, 이탈리아식 파스타까지..풀 코스 전격 공개합니다",
-      "concept": "피렌체 미슐랭 2스타 레스토랑",
+      "concept": "Piazza",
       "locations": [
         {
-          "name": "Santa Elisabetta",
-          "displayName": "Ristorante Santa Elisabetta",
+          "name": "Piazza Sant'Elisabetta, 3",
           "address": "Piazza Sant'Elisabetta, 3, 50122 Firenze FI, 이탈리아",
-          "latitude": 43.7718205,
-          "longitude": 11.255752399999999,
-          "googleMapsId": "ChIJ4ZdxZQFUKhMRWpRqKWv90zI",
-          "googleMapsUri": "https://maps.google.com/?cid=3662549558680523866&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Piazza 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=MFt1YAsgGrA",
-          "description": "인생 레스토랑을 소개하는 영상에서 방문한 피렌체 미슐랭 2스타 레스토랑. 농어 구이, 훈제 방어, 이탈리아식 파스타까지 이어지는 풀 코스가 극찬받았다."
+          "latitude": 43.7717119,
+          "longitude": 11.255755899999999,
+          "googleMapsId": "ChIJ4z5_cAFUKhMRlCfoup35syU",
+          "googleMapsUri": "https://maps.google.com/?cid=2716789456075499412&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "diHZr8fyZbU",
       "title": "최근 이탈리아에서 가장 핫한 미슐랭 레스토랑? 어디서도 본 적 없는 퀄리티, 월드베스트 레스토랑으로 떠오르는 곳을 소개합니다!",
-      "concept": "가르다 호수변 월드베스트 미슐랭 레스토랑",
+      "concept": "Corso",
       "locations": [
         {
-          "name": "Lido 84",
-          "displayName": "Lido 84",
-          "address": "Corso Giuseppe Zanardelli, 196, 25083 Gardone Riviera BS, 이탈리아",
-          "latitude": 45.6251592,
-          "longitude": 10.5755666,
-          "googleMapsId": "ChIJx7BJHCKMgUcRA7aurgztHrQ",
-          "googleMapsUri": "https://maps.google.com/?cid=12979071814854424067&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "Grand Hotel Fasano",
+          "address": "Corso Giuseppe Zanardelli, 190, 25083 Gardone Riviera BS, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Corso 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=diHZr8fyZbU",
-          "description": "최근 이탈리아에서 가장 핫한 미슐랭 레스토랑을 소개하는 영상에서 방문한 가르다 호수변 레스토랑. 월드베스트 레스토랑에 오른 곳으로, 어디서도 본 적 없는 퀄리티의 요리로 화제가 되었다."
+          "latitude": 45.6241907,
+          "longitude": 10.573642399999999,
+          "googleMapsId": "ChIJ_f4KN3GMgUcRAtvz9zOC_eU",
+          "googleMapsUri": "https://maps.google.com/?cid=16572545363508189954&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "DxB6A5ur9MA",
       "title": "이탈리아 미슐랭 레스토랑에서 찾은 세계 최고의 와인?🍷 역대급 와인 리스트만 모아놓은 포지타노 레스토랑에 다녀왔습니다!",
-      "concept": "포지타노 미슐랭 와인 레스토랑",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Zass",
-          "displayName": "Zass",
+          "name": "Zass (포지타노)",
           "address": "Via Laurito, 2, 84017 Positano SA, 이탈리아",
+          "description": "Zass (포지타노) — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DxB6A5ur9MA",
           "latitude": 40.6231077,
           "longitude": 14.503753799999998,
           "googleMapsId": "ChIJTTegVVqXOxMRX4nA4MSAv-I",
-          "googleMapsUri": "https://maps.google.com/?cid=16338919556196108639&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DxB6A5ur9MA",
-          "description": "세계 최고의 와인을 찾아 떠난 영상에서 방문한 포지타노 미슐랭 레스토랑. 역대급 와인 리스트만 모아놓은 것이 특징으로, 절경과 함께 즐기는 파인다이닝으로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=16338919556196108639&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "xMDBOQrtwlw",
       "title": "피렌체 2kg 스테이크 접수하고 왔습니다🥩(feat. 내장버거) | Paoli 1827, Da Nerbone, Caffè Gilli",
-      "concept": "피렌체 스테이크·내장버거 맛집 투어",
+      "concept": "Via",
       "locations": [
         {
           "name": "Caffè Gilli",
-          "displayName": "Caffè Gilli",
           "address": "Via Roma, 1r, 50123 Firenze FI, 이탈리아",
+          "description": "Caffè Gilli — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xMDBOQrtwlw",
           "latitude": 43.771974799999995,
           "longitude": 11.2541636,
           "googleMapsId": "ChIJFbiwjwFUKhMRPJ-oDzQyiBU",
-          "googleMapsUri": "https://maps.google.com/?cid=1551545270811533116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xMDBOQrtwlw",
-          "description": "피렌체 스테이크와 내장버거를 소개하는 영상에서 방문한 역사적인 카페. 피렌체를 대표하는 클래식 카페로, 오랜 전통의 디저트와 커피로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=1551545270811533116&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
           "name": "Da Nerbone",
-          "displayName": "Da Nerbone",
           "address": "Piazza del Mercato Centrale, 50123 Firenze FI, 이탈리아",
+          "description": "Caffè Gilli — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xMDBOQrtwlw",
           "latitude": 43.7762847,
           "longitude": 11.2532869,
           "googleMapsId": "ChIJdXbJxwJUKhMRT0v1L3foRdQ",
-          "googleMapsUri": "https://maps.google.com/?cid=15295887308037114703&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xMDBOQrtwlw",
-          "description": "피렌체 스테이크와 내장버거를 소개하는 영상에서 방문한 중앙시장(메르카토 첸트랄레) 내 맛집. 피렌체 명물 내장버거(람프레도토)로 유명한 곳으로 추천되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=15295887308037114703&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
           "name": "Antico Ristorante Paoli 1827",
-          "displayName": "Antico Ristorante Paoli 1827",
           "address": "Via dei Tavolini, 12/R, 50122 Firenze FI, 이탈리아",
+          "description": "Caffè Gilli — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xMDBOQrtwlw",
           "latitude": 43.7708915,
           "longitude": 11.2557616,
           "googleMapsId": "ChIJfYUTEgFUKhMRTkbwYcXHR_M",
-          "googleMapsUri": "https://maps.google.com/?cid=17530199725128566350&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xMDBOQrtwlw",
-          "description": "피렌체 스테이크와 내장버거를 소개하는 영상에서 방문한 1827년 창업의 역사적 레스토랑. 2kg 스테이크에 도전한 곳으로, 고풍스러운 분위기 속 피렌체 정통 요리를 선보인다."
+          "googleMapsUri": "https://maps.google.com/?cid=17530199725128566350&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "YvDTCJhYEJE",
       "title": "🐟10여 가지 해산물 전채와 날마다 바뀌는 해산물 파스타🍝 베네치아 최고의 가성비 식당에 다녀왔습니다!",
-      "concept": "베네치아 가성비 해산물 식당",
+      "concept": "Calle",
       "locations": [
         {
           "name": "Corte Sconta",
-          "displayName": "Corte Sconta",
           "address": "Calle del Pestrin, 3886, 30122 Venezia VE, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Calle 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YvDTCJhYEJE",
           "latitude": 45.4347585,
           "longitude": 12.3479577,
           "googleMapsId": "ChIJb3wPKtmxfkcRkgz0O_Owlv0",
-          "googleMapsUri": "https://maps.google.com/?cid=18272987096831757458&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YvDTCJhYEJE",
-          "description": "베네치아 최고의 가성비 식당을 소개하는 영상에서 방문한 해산물 전문점. 10여 가지 해산물 전채와 날마다 바뀌는 해산물 파스타가 대표 메뉴로 극찬받았다."
+          "googleMapsUri": "https://maps.google.com/?cid=18272987096831757458&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "LaBQYfe7YqU",
       "title": "많은 분들을 놀라게 한 수백억짜리 와인 셀러, 다시 찾고 실망한 이유ㅣ에노테카 핀키오리 [EN]",
-      "concept": "피렌체 미슐랭 3스타 와인 셀러 재방문기",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Enoteca Pinchiorri",
-          "displayName": "Enoteca Pinchiorri",
+          "name": "에노테카 핀키오리",
           "address": "Via Ghibellina, 87, 50122 Firenze FI, 이탈리아",
+          "description": "에노테카 핀키오리 — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=LaBQYfe7YqU",
           "latitude": 43.769999999999996,
           "longitude": 11.2622222,
           "googleMapsId": "ChIJJ9GCOAZUKhMRhWUgMfpfvX4",
           "googleMapsUri": "https://maps.google.com/?cid=9132561147547903365&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=LaBQYfe7YqU",
-          "description": "수백억짜리 와인 셀러로 화제가 된 레스토랑을 재방문하는 영상에서 다시 찾은 피렌체 미슐랭 3스타 레스토랑. 다시 찾아 실망한 이유를 솔직하게 다루며 와인 셀러와 코스를 재평가했다."
+          "geocodeWarning": "displayName 'Enoteca Pinchiorri' != '에노테카 핀키오리'; verify"
         }
       ]
     },
     {
       "videoId": "T73wxsGB4wk",
       "title": "[EN] 비밀이야 먹뱉 논란? 구글 평점 믿고 간 레스토랑 제대로 당했네요.. | 이탈리아 출장 EP.1 | San Silvestro | Corte Sconta",
-      "concept": "베네치아 구글 평점 레스토랑 검증기",
+      "concept": "Rio",
       "locations": [
         {
           "name": "Ristorante San Silvestro",
-          "displayName": "Ristorante San Silvestro",
           "address": "Rio Terà S. Silvestro, 1022B, 30125 Venezia VE, 이탈리아",
+          "description": "안녕하세요, 비밀이야 입니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=T73wxsGB4wk",
           "latitude": 45.4377657,
           "longitude": 12.3332093,
           "googleMapsId": "ChIJa6Ogq2OxfkcRGd6I5V4T_Go",
-          "googleMapsUri": "https://maps.google.com/?cid=7709057960450252313&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=T73wxsGB4wk",
-          "description": "구글 평점을 믿고 방문한 베네치아 레스토랑 투어 영상에서 소개된 식당. 높은 구글 평점에 비해 기대에 미치지 못했다는 솔직한 평가가 담겼다."
+          "googleMapsUri": "https://maps.google.com/?cid=7709057960450252313&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Corte Sconta",
-          "displayName": "Corte Sconta",
+          "name": "두 번째 식당 [ Corte Sconta ]",
           "address": "Calle del Pestrin, 3886, 30122 Venezia VE, 이탈리아",
+          "description": "안녕하세요, 비밀이야 입니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=T73wxsGB4wk",
           "latitude": 45.4347585,
           "longitude": 12.3479577,
           "googleMapsId": "ChIJb3wPKtmxfkcRkgz0O_Owlv0",
-          "googleMapsUri": "https://maps.google.com/?cid=18272987096831757458&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=T73wxsGB4wk",
-          "description": "구글 평점을 믿고 방문한 베네치아 레스토랑 투어 영상에서 다시 찾은 해산물 맛집. 이전 방문에 이어 재방문하며 베네치아 해산물 요리를 비교했다."
+          "googleMapsUri": "https://maps.google.com/?cid=18272987096831757458&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "sHZMGPDK_ok",
       "title": "(EN) 사실 체육관 아니고, \"미쉐린 1스타 레스토랑\" | Il Convivio Troiani",
-      "concept": "로마 미쉐린 1스타 레스토랑",
+      "concept": "Vicolo",
       "locations": [
         {
-          "name": "Il Convivio Troiani",
-          "displayName": "Il Convivio Troiani",
+          "name": "Vicolo dei Soldati, 31",
           "address": "Vicolo dei Soldati, 31, 00186 Roma RM, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Vicolo 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sHZMGPDK_ok",
           "latitude": 41.901561,
           "longitude": 12.472707,
-          "googleMapsId": "ChIJ-aRG9FBgLxMRslFkAD02DNo",
-          "googleMapsUri": "https://maps.google.com/?cid=15711992835616297394&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sHZMGPDK_ok",
-          "description": "이탈리아 맛집을 소개하는 영상에서 방문한 로마 미쉐린 1스타 레스토랑. 체육관처럼 생긴 외관과 달리 고급스러운 요리를 선보이는 반전 매력의 파인다이닝으로 소개되었다."
+          "googleMapsId": "ChIJqb7rflBgLxMRzeH0P04wxuk",
+          "googleMapsUri": "https://maps.google.com/?cid=16845204568864514509&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "p25xWRnIkdg",
       "title": "전 세계에서 꼭 가봐야 할 이탈리아 여행지 1등! 한국인 취향까지 저격해버린 각종 해산물 요리 먹고 왔습니다",
-      "concept": "포지타노 해산물 레스토랑",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Chez Black",
-          "displayName": "Chez Black",
-          "address": "Via del Brigantino, 19, 84017 Positano SA, 이탈리아",
+          "name": "Via del Brigantino, 19",
+          "address": "Via del Brigantino, 19, 84017 Montepertuso SA, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=p25xWRnIkdg",
           "latitude": 40.6280498,
           "longitude": 14.4869969,
-          "googleMapsId": "ChIJTVr63miXOxMRKMOIeBJLsIQ",
-          "googleMapsUri": "https://maps.google.com/?cid=9561224551611286312&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=p25xWRnIkdg",
-          "description": "전 세계에서 꼭 가봐야 할 이탈리아 여행지 1등으로 소개된 포지타노에서 방문한 해산물 레스토랑. 한국인 취향까지 저격한 각종 해산물 요리로 추천되었다."
-        }
-      ]
-    },
-    {
-      "videoId": "afDn5kAWKzs",
-      "title": "[비밀이야 in 이탈리아] 밀라노 근교 다비토리오(da VittorioOㅣ미쉐린 3스타ㅣ이탈리아 최애 레스토랑ㅣ4년 만에 방문ㅣ역시는 역시!!ㅣ4시간 넘게 식사ㅣ식사 중 졸음ㅋㅣ",
-      "concept": "밀라노 근교 미쉐린 3스타 레스토랑",
-      "locations": [
-        {
-          "name": "da Vittorio",
-          "displayName": "Da Vittorio",
-          "address": "Via Cantalupa, 17, 24060 Brusaporto BG, 이탈리아",
-          "latitude": 45.676035999999996,
-          "longitude": 9.7695512,
-          "googleMapsId": "ChIJ4Sv3o_9agUcROCSRC0X4C90",
-          "googleMapsUri": "https://maps.google.com/?cid=15928097482556384312&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=afDn5kAWKzs",
-          "description": "밀라노 근교 미쉐린 3스타 레스토랑을 소개하는 영상에서 방문한 진행자의 이탈리아 최애 레스토랑. 4년 만에 재방문했을 때도 음식부터 와인까지 흠잡을 데 없이 만족스러웠다고 극찬했다."
+          "googleMapsId": "ChIJs1oP4GiXOxMRLBAneHY1t_g",
+          "googleMapsUri": "https://maps.google.com/?cid=17921852025082417196&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "BJjP1QVI0-M",
       "title": "이탈리아 1등 레스토랑은 이곳입니다 | 달 페스카토레",
-      "concept": "이탈리아 1등 미슐랭 3스타 레스토랑",
+      "concept": "Via",
       "locations": [
         {
           "name": "Ristorante Dal Pescatore Santini",
-          "displayName": "Ristorante Dal Pescatore Santini",
           "address": "Via Runate, 15, 46013 Canneto sull'Oglio MN, 이탈리아",
+          "description": "Ristorante Dal Pescatore Santini — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BJjP1QVI0-M",
           "latitude": 45.171066599999996,
           "longitude": 10.3574144,
           "googleMapsId": "ChIJEbzybxqzgUcRn1pQZjdmsH0",
-          "googleMapsUri": "https://maps.google.com/?cid=9056851238767843999&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BJjP1QVI0-M",
-          "description": "이탈리아 1등 레스토랑을 직접 소개하는 영상에서 방문한 미슐랭 3스타 레스토랑. 가족이 경영하는 따뜻한 분위기와 정통 이탈리아 요리로 이탈리아 최고로 꼽혔다."
+          "googleMapsUri": "https://maps.google.com/?cid=9056851238767843999&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "Yhk7fn2AsJs",
       "title": "로마, 피렌체, 밀라노 등 이탈리아의 숨겨진 미슐랭 맛집 싹 다 모았습니다!👨‍🍳 진짜 비밀이야.. (f. 프롤로그)",
-      "concept": "이탈리아 숨은 미슐랭 맛집 총정리 (편집본)",
+      "concept": "Largo",
       "locations": [
         {
-          "name": "Giacomo Arengario",
-          "displayName": "Giacomo Arengario",
-          "address": "Via Guglielmo Marconi, 1, 20123 Milano MI, 이탈리아",
-          "latitude": 45.463601999999995,
-          "longitude": 9.190309,
-          "googleMapsId": "ChIJwZnUpK7GhkcRoya_ZbIQ_nQ",
-          "googleMapsUri": "https://maps.google.com/?cid=8430193910881396387&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "사크로 쿠오레 가톨릭 대학교",
+          "address": "Largo Fra Agostino Gemelli, 1, 20123 Milano MI, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Yhk7fn2AsJs",
-          "description": "로마·피렌체·밀라노 등 이탈리아 숨은 미슐랭 맛집을 총정리하는 영상에 등장한 밀라노 두오모 뷰 레스토랑. 밀라노 송아지 튀김 요리를 즐길 수 있는 곳으로 소개되었다."
+          "latitude": 45.4626029,
+          "longitude": 9.1767641,
+          "googleMapsId": "ChIJLdWinVbBhkcR18d96lFE08Y",
+          "googleMapsUri": "https://maps.google.com/?cid=14326869958212831191&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Lido 84",
-          "displayName": "Lido 84",
-          "address": "Corso Giuseppe Zanardelli, 196, 25083 Gardone Riviera BS, 이탈리아",
-          "latitude": 45.6251592,
-          "longitude": 10.5755666,
-          "googleMapsId": "ChIJx7BJHCKMgUcRA7aurgztHrQ",
-          "googleMapsUri": "https://maps.google.com/?cid=12979071814854424067&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "Grand Hotel Fasano",
+          "address": "Corso Giuseppe Zanardelli, 190, 25083 Gardone Riviera BS, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Yhk7fn2AsJs",
-          "description": "이탈리아 숨은 미슐랭 맛집을 총정리하는 영상에 등장한 가르다 호수변 레스토랑. 월드베스트 레스토랑에 오른 화제의 미슐랭 레스토랑으로 소개되었다."
+          "latitude": 45.6241907,
+          "longitude": 10.573642399999999,
+          "googleMapsId": "ChIJ_f4KN3GMgUcRAtvz9zOC_eU",
+          "googleMapsUri": "https://maps.google.com/?cid=16572545363508189954&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
           "name": "Ristorante Glam",
-          "displayName": "Ristorante Glam",
           "address": "Calle Tron, 1961, 30135 Venezia VE, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Yhk7fn2AsJs",
           "latitude": 45.441379,
           "longitude": 12.329912,
           "googleMapsId": "ChIJcypW7sOxfkcRz-086hZfk34",
-          "googleMapsUri": "https://maps.google.com/?cid=9120738222379167183&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Yhk7fn2AsJs",
-          "description": "이탈리아 숨은 미슐랭 맛집을 총정리하는 영상에 등장한 베네치아 고급 레스토랑. 고급 와인과 함께 즐기는 이탈리아 요리로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=9120738222379167183&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Osteria Vini e Vecchi Sapori",
-          "displayName": "Vini e Vecchi Sapori",
-          "address": "Via dei Magazzini, 3/r, 50122 Firenze FI, 이탈리아",
-          "latitude": 43.7700901,
-          "longitude": 11.256815699999999,
-          "googleMapsId": "ChIJAfLFIwFUKhMRmv-jS9sjRb8",
-          "googleMapsUri": "https://maps.google.com/?cid=13782461659411120026&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "사크로 쿠오레 가톨릭 대학교",
+          "address": "Largo Fra Agostino Gemelli, 1, 20123 Milano MI, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Yhk7fn2AsJs",
-          "description": "이탈리아 숨은 미슐랭 맛집을 총정리하는 영상에 등장한 피렌체 전통 오스테리아. 피렌체식 스테이크와 파스타가 일품인 현지 맛집으로 소개되었다."
+          "latitude": 45.4626029,
+          "longitude": 9.1767641,
+          "googleMapsId": "ChIJLdWinVbBhkcR18d96lFE08Y",
+          "googleMapsUri": "https://maps.google.com/?cid=14326869958212831191&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Zass",
-          "displayName": "Zass",
+          "name": "Via dei Magazzini, 3r",
+          "address": "Via dei Magazzini, 3r, 50122 Firenze FI, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Yhk7fn2AsJs",
+          "latitude": 43.7700252,
+          "longitude": 11.256751500000002,
+          "googleMapsId": "ChIJu_ewIQFUKhMRbVapcHmT2L8",
+          "googleMapsUri": "https://maps.google.com/?cid=13823961206004209261&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "Via Laurito, 2",
           "address": "Via Laurito, 2, 84017 Positano SA, 이탈리아",
-          "latitude": 40.6231077,
-          "longitude": 14.503753799999998,
-          "googleMapsId": "ChIJTTegVVqXOxMRX4nA4MSAv-I",
-          "googleMapsUri": "https://maps.google.com/?cid=16338919556196108639&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Yhk7fn2AsJs",
-          "description": "이탈리아 숨은 미슐랭 맛집을 총정리하는 영상에 등장한 포지타노 미슐랭 레스토랑. 역대급 와인 리스트와 절경으로 소개되었다."
+          "latitude": 40.623308099999996,
+          "longitude": 14.5041174,
+          "googleMapsId": "ChIJ08yONRaXOxMRBqjBQpiyZiY",
+          "googleMapsUri": "https://maps.google.com/?cid=2767095388090509318&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "6ISyBIQpcwY",
       "title": "단돈 5만원짜리 프리미엄 트러플 요리가 있다? 피렌체 가시면 꼭 들려야할 곳ㅣOsteria Tre Panche",
-      "concept": "피렌체 가성비 트러플 요리 오스테리아",
+      "concept": "Vicolo",
       "locations": [
         {
-          "name": "Osteria Tre Panche",
-          "displayName": "Osteria delle Tre Panche - Centro Storico",
+          "name": "Vicolo Marzio, 1",
           "address": "Vicolo Marzio, 1, 50122 Firenze FI, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Vicolo 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6ISyBIQpcwY",
           "latitude": 43.7685232,
           "longitude": 11.253906899999999,
-          "googleMapsId": "ChIJkSF6cBVUKhMRhWz9opGQgZg",
-          "googleMapsUri": "https://maps.google.com/?cid=10989223520939895941&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6ISyBIQpcwY",
-          "description": "피렌체 가성비 트러플 요리를 소개하는 영상에서 방문한 오스테리아. 단돈 5만 원에 프리미엄 트러플 요리를 맛볼 수 있어 피렌체에서 꼭 들러야 할 곳으로 추천되었다."
+          "googleMapsId": "ChIJbQnlbABUKhMRMv5TjfuO99c",
+          "googleMapsUri": "https://maps.google.com/?cid=15562064248461065778&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "vfLu7DiGD4Y",
       "title": "같은 년도 끼리 와인 맛은 똑같을까? 빈티지 와인에 대한 이야기 오늘 다 풀어봅니다 ㅣ로칸다 델 필로네",
-      "concept": "알바 빈티지 와인 레스토랑",
+      "concept": "Strada",
       "locations": [
         {
-          "name": "Locanda del Pilone",
-          "displayName": "Locanda del Pilone",
+          "name": "로칸다 델 필로네",
           "address": "Strada Della Cicchetta, Località Madonna di Como, 34, 12051 Alba CN, 이탈리아",
+          "description": "로칸다 델 필로네 — 비밀이야 in 한국 영상에서 소개한 Strada 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vfLu7DiGD4Y",
           "latitude": 44.6675632,
           "longitude": 8.0646374,
           "googleMapsId": "ChIJvd0i1mW00hIRbiJA_zy0Vwk",
           "googleMapsUri": "https://maps.google.com/?cid=673204843388609134&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vfLu7DiGD4Y",
-          "description": "빈티지 와인에 대한 이야기를 풀어낸 영상에서 방문한 알바 지역의 레스토랑. 같은 년도 와인의 맛 차이를 비교하며 피에몬테 요리와 함께 즐겼다."
+          "geocodeWarning": "displayName 'Locanda del Pilone' != '로칸다 델 필로네'; verify"
         }
       ]
     },
     {
       "videoId": "Jnj43_lge20",
       "title": "세상에서 제일 비싼 새우!🦐현지인 맛집에는 이유가 있구나 | Terrazza Calabritto, Luini, 밀라노 쇼핑",
-      "concept": "밀라노 현지인 맛집 (판제로티·새우 요리)",
+      "concept": "Via",
       "locations": [
         {
           "name": "Panzerotti Luini",
-          "displayName": "Panzerotti Luini",
           "address": "Via Santa Radegonda, 16, 20121 Milano MI, 이탈리아",
+          "description": "Panzerotti Luini — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Jnj43_lge20",
           "latitude": 45.465828599999995,
           "longitude": 9.1915578,
           "googleMapsId": "ChIJoUEJQq7GhkcRI153LB6-eXY",
-          "googleMapsUri": "https://maps.google.com/?cid=8537063605461802531&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Jnj43_lge20",
-          "description": "밀라노 현지인 맛집을 소개하는 영상에서 방문한 명물 판제로티 가게. 두오모 근처에서 줄 서서 먹는 밀라노 길거리 명물로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=8537063605461802531&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
           "name": "Terrazza Calabritto Milano",
-          "displayName": "Terrazza Calabritto Milano",
           "address": "Viale Monte Grappa, 7, 20124 Milano MI, 이탈리아",
+          "description": "Panzerotti Luini — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Jnj43_lge20",
           "latitude": 45.4806819,
           "longitude": 9.1888239,
           "googleMapsId": "ChIJl7OytjTBhkcRjnbwMclcNfY",
-          "googleMapsUri": "https://maps.google.com/?cid=17741188326291961486&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Jnj43_lge20",
-          "description": "밀라노 현지인 맛집을 소개하는 영상에서 방문한 해산물 레스토랑. 세상에서 제일 비싼 새우 요리로 화제가 된 곳으로, 현지인 맛집의 이유를 보여준다."
+          "googleMapsUri": "https://maps.google.com/?cid=17741188326291961486&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "KnlYjxsqbZY",
       "title": "이탈리아 미쉐린 별을 휩쓸고 있는 셰프, 그 이름을 건 식당 (feat. 미소년 서버👨🏻‍🍳)ㅣ엔리코 바르톨리니",
-      "concept": "밀라노 미쉐린 셰프 레스토랑 (Enrico Bartolini)",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Enrico Bartolini MUDEC",
-          "displayName": "Enrico Bartolini",
+          "name": "Mudec",
           "address": "Via Tortona, 56, 20144 Milano MI, 이탈리아",
-          "latitude": 45.4515503,
-          "longitude": 9.1616272,
-          "googleMapsId": "ChIJr54jbebDhkcRlR68yNtO368",
-          "googleMapsUri": "https://maps.google.com/?cid=12672934582316441237&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KnlYjxsqbZY",
-          "description": "이탈리아 미쉐린 별을 휩쓸고 있는 셰프를 소개하는 영상에서 방문한 밀라노 무덱(MUDEC) 내 레스토랑. 셰프 엔리코 바르톨리니의 이름을 건 식당답게 정교한 코스 요리를 선보인다."
+          "latitude": 45.4515435,
+          "longitude": 9.1615384,
+          "googleMapsId": "ChIJwcLyGObDhkcRd4Ay1dlKE3I",
+          "googleMapsUri": "https://maps.google.com/?cid=8219996044326502519&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "8swEJ-ZATnI",
       "title": "100점 받은 와인과 먹는 역대급 파스타🍷매년 오는 이곳! | 트러플 축제, La Piola",
-      "concept": "알바 트러플 축제 파스타 레스토랑",
+      "concept": "Piazza",
       "locations": [
         {
           "name": "La Piola",
-          "displayName": "La Piola",
           "address": "Piazza Risorgimento, 4, 12051 Alba CN, 이탈리아",
+          "description": "La Piola — 비밀이야 in 한국 영상에서 소개한 Piazza 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=8swEJ-ZATnI",
           "latitude": 44.7006186,
           "longitude": 8.0358792,
           "googleMapsId": "ChIJSw-GLl2z0hIRo_VcAuRgpZQ",
-          "googleMapsUri": "https://maps.google.com/?cid=10711073821179049379&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=8swEJ-ZATnI",
-          "description": "알바 트러플 축제에 맞춰 매년 찾는다는 영상에서 방문한 레스토랑. 100점 받은 와인과 함께 즐기는 역대급 파스타로 극찬받았다."
+          "googleMapsUri": "https://maps.google.com/?cid=10711073821179049379&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "8jjUWH07IK4",
       "title": "풍미부터 다른 이탈리아 정통 피자의 맛은?🍕 나폴리 부럽지않은 역대급 피자와 최고의 절경 포지타노에서 즐기는 조식까지 제대로 즐겨봤습니다!",
-      "concept": "포지타노·아말피 정통 이탈리아 피자",
+      "concept": "Viale",
       "locations": [
         {
-          "name": "Gabrisa",
-          "displayName": "Da Gabrisa Restaurant",
-          "address": "Viale Pasitea, 221, 84017 Positano SA, 이탈리아",
-          "latitude": 40.628475,
-          "longitude": 14.482769000000001,
-          "googleMapsId": "ChIJ205yPmaXOxMRlcyATSvOS8I",
-          "googleMapsUri": "https://maps.google.com/?cid=14000510551990520981&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "포지타노 아트 호텔 파시티아",
+          "address": "Viale Pasitea, 207, 84017 Positano SA, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Viale 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=8jjUWH07IK4",
-          "description": "이탈리아 정통 피자를 소개하는 영상에서 방문한 포지타노의 숙소 겸 레스토랑. 나폴리 부럽지 않은 역대급 피자와 최고의 절경으로 소개되었다."
+          "latitude": 40.628691800000006,
+          "longitude": 14.48236,
+          "googleMapsId": "ChIJYZl9aGaXOxMRD3UV9K2KlHM",
+          "googleMapsUri": "https://maps.google.com/?cid=8328434090643911951&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Donna Stella",
-          "displayName": "Pizzeria Donna Stella",
-          "address": "Salita d'Ancora, 4, 84011 Amalfi SA, 이탈리아",
-          "latitude": 40.636452399999996,
-          "longitude": 14.6022571,
-          "googleMapsId": "ChIJQZxV162VOxMRGW5ZKZ9MKz8",
-          "googleMapsUri": "https://maps.google.com/?cid=4551816094865255961&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "L’Ancora di Amalfi",
+          "address": "Salita Rascica, 1, 84011 Amalfi SA, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Viale 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=8jjUWH07IK4",
-          "description": "이탈리아 정통 피자를 소개하는 영상에서 방문한 아말피의 피자집. 풍미부터 다른 정통 이탈리아 피자를 맛볼 수 있는 곳으로 추천되었다."
+          "latitude": 40.6363735,
+          "longitude": 14.602283199999997,
+          "googleMapsId": "ChIJLYCYclGVOxMR7xWUoJWYy0w",
+          "googleMapsUri": "https://maps.google.com/?cid=5533684335566394863&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "p1sG5mTi1wA",
       "title": "(EN) 이곳의 타야린은 반드시! 맛보셔야 합니다 | La Piola",
-      "concept": "알바 타야린 전문 레스토랑",
+      "concept": "Piazza",
       "locations": [
         {
-          "name": "La Piola",
-          "displayName": "La Piola",
+          "name": "Piazza Risorgimento, 4",
           "address": "Piazza Risorgimento, 4, 12051 Alba CN, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Piazza 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=p1sG5mTi1wA",
           "latitude": 44.7006186,
           "longitude": 8.0358792,
-          "googleMapsId": "ChIJSw-GLl2z0hIRo_VcAuRgpZQ",
-          "googleMapsUri": "https://maps.google.com/?cid=10711073821179049379&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=p1sG5mTi1wA",
-          "description": "이탈리아 맛집을 소개하는 영상에서 방문한 알바 지역의 레스토랑. 이곳의 타야린(타야린 파스타)은 반드시 맛봐야 한다고 강력 추천되었다."
+          "googleMapsId": "ChIJu14-LF2z0hIRsU_pMWMZiwI",
+          "googleMapsUri": "https://maps.google.com/?cid=183268123668467633&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "5f5Vaky8DfY",
       "title": "이탈리아에서 삼쏘에 80만 원 쓰고 왔습니다🐷🍺 (feat.흑백요리사) | 피렌체 한라산, 젤라또, 더몰 맛집",
-      "concept": "피렌체 삼겹살·젤라또 (흑백요리사 feat.)",
+      "concept": "SR69,",
       "locations": [
         {
           "name": "da MASSIMO MORDI e FUGGI",
-          "displayName": "Da Massimo Mordi e Fuggi",
           "address": "SR69, Località Ruota al Mandò, 86, 50066 Loc, FI, 이탈리아",
+          "description": "da MASSIMO MORDI e FUGGI — 비밀이야 in 한국 영상에서 소개한 SR69, 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5f5Vaky8DfY",
           "latitude": 43.6846846,
           "longitude": 11.463971899999999,
           "googleMapsId": "ChIJLXes3TuuKxMRUAk9ztI58F8",
-          "googleMapsUri": "https://maps.google.com/?cid=6913089005579733328&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5f5Vaky8DfY",
-          "description": "이탈리아에서 삼쏘(삼겹살+소주)에 돈을 쓴 영상에서 방문한 더 몰(The Mall) 근처 맛집. 흑백요리사 출연자와 함께한 식사로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=6913089005579733328&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Hallasan 한라산",
-          "displayName": "한라산 - Hallasan",
+          "name": "한라산 - Hallasan",
           "address": "Via Guelfa, 98 R, 50129 Firenze FI, 이탈리아",
+          "description": "da MASSIMO MORDI e FUGGI — 비밀이야 in 한국 영상에서 소개한 SR69, 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5f5Vaky8DfY",
           "latitude": 43.778006399999995,
           "longitude": 11.253952799999999,
           "googleMapsId": "ChIJeVxalJFVKhMRrGBLNk-PtTU",
-          "googleMapsUri": "https://maps.google.com/?cid=3870157025170907308&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5f5Vaky8DfY",
-          "description": "이탈리아에서 삼겹살을 찾아 떠난 영상에서 방문한 피렌체 한식당 한라산. 이탈리아에서 즐기는 한국식 삼겹살로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=3870157025170907308&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
           "name": "Perché no!...",
-          "displayName": "Perché no!...",
           "address": "Via dei Tavolini, 19r, 50122 Firenze FI, 이탈리아",
+          "description": "da MASSIMO MORDI e FUGGI — 비밀이야 in 한국 영상에서 소개한 SR69, 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5f5Vaky8DfY",
           "latitude": 43.7708328,
           "longitude": 11.2554362,
           "googleMapsId": "ChIJTZ5cCQFUKhMR_OZ-LDIQ_1c",
-          "googleMapsUri": "https://maps.google.com/?cid=6340804608041871100&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5f5Vaky8DfY",
-          "description": "이탈리아 미식 여행 영상에서 방문한 피렌체의 유명 젤라또 가게. 피렌체를 대표하는 젤라또 명소로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=6340804608041871100&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "ZfAAbWNHZsg",
       "title": "(EN) 합스부르크 가문에서 오픈한 레스토랑👑",
-      "concept": "피렌체 합스부르크 가문 레스토랑",
+      "concept": "Borgo",
       "locations": [
         {
-          "name": "La Giostra",
-          "displayName": "La Giostra",
-          "address": "Borgo Pinti, 16 R, 50121 Firenze FI, 이탈리아",
-          "latitude": 43.7720862,
-          "longitude": 11.2621153,
-          "googleMapsId": "ChIJt9Hy2AVUKhMRfaoxnj4MUDA",
-          "googleMapsUri": "https://maps.google.com/?cid=3481295975038954109&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "name": "Borgo Pinti, 10/18R",
+          "address": "Borgo Pinti, 10/18R, 50121 Firenze FI, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Borgo 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ZfAAbWNHZsg",
-          "description": "이탈리아 맛집을 소개하는 영상에서 방문한 피렌체의 독특한 레스토랑. 합스부르크 가문에서 오픈한 곳으로, 왕실 분위기와 함께 토스카나 요리를 즐길 수 있다."
+          "latitude": 43.772102,
+          "longitude": 11.26222,
+          "googleMapsId": "ChIJiauf3QVUKhMRvZCqS08RX-4",
+          "googleMapsUri": "https://maps.google.com/?cid=17176466536083919037&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "U9OKVyamP7I",
       "title": "내 맘대로 짜는 피렌체 1티어 해산물 코스🦐 | Fuor D'Acqua",
-      "concept": "피렌체 1티어 해산물 코스 레스토랑",
+      "concept": "Via",
       "locations": [
         {
           "name": "Fuor D'Acqua",
-          "displayName": "Fuor D'Acqua",
           "address": "Via Pisana, 37r, 50143 Firenze FI, 이탈리아",
+          "description": "Fuor D'Acqua — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=U9OKVyamP7I",
           "latitude": 43.7707191,
           "longitude": 11.2388351,
           "googleMapsId": "ChIJm55m6rJWKhMRiWyJSF0XuDY",
-          "googleMapsUri": "https://maps.google.com/?cid=3942927163179232393&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=U9OKVyamP7I",
-          "description": "피렌체 1티어 해산물 코스를 소개하는 영상에서 방문한 해산물 전문 레스토랑. 내 맘대로 짜는 신선한 해산물 코스로 추천되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=3942927163179232393&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "DlqcHq9pqts",
       "title": "밀라노 대표 넘버원? 비싼 가격에 믿기지 않는 서비스 [EN]ㅣ랑고스테리아",
-      "concept": "밀라노 대표 해산물 레스토랑 (Langosteria)",
+      "concept": "Strada",
       "locations": [
         {
-          "name": "Langosteria",
-          "displayName": "Langosteria",
-          "address": "Via Savona, 10, 20144 Milano MI, 이탈리아",
-          "latitude": 45.4556091,
-          "longitude": 9.1684202,
-          "googleMapsId": "ChIJJ-xSRePDhkcRDJRTjmN-7_o",
-          "googleMapsUri": "https://maps.google.com/?cid=18081809994970534924&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DlqcHq9pqts",
-          "description": "밀라노 대표 넘버원 해산물 레스토랑을 소개하는 영상에서 방문한 곳. 비싼 가격에 비해 서비스가 기대에 못 미쳤다는 솔직한 후기가 담겼다."
-        },
-        {
-          "name": "Locanda del Pilone",
-          "displayName": "Locanda del Pilone",
+          "name": "로칸다 델 필로네",
           "address": "Strada Della Cicchetta, Località Madonna di Como, 34, 12051 Alba CN, 이탈리아",
+          "description": "로칸다 델 필로네 — 비밀이야 in 한국 영상에서 소개한 Strada 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DlqcHq9pqts",
           "latitude": 44.6675632,
           "longitude": 8.0646374,
           "googleMapsId": "ChIJvd0i1mW00hIRbiJA_zy0Vwk",
           "googleMapsUri": "https://maps.google.com/?cid=673204843388609134&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DlqcHq9pqts",
-          "description": "밀라노 대표 레스토랑을 소개하는 영상에서 함께 다룬 알바 지역의 레스토랑. 빈티지 와인과 함께 피에몬테 요리를 즐긴 곳으로 소개되었다."
-        }
-      ]
-    },
-    {
-      "videoId": "bmRVDNxgVBs",
-      "title": "[비밀이야 in 이탈리아] 소렌토 토레 델 사라치노(Torre del Saracino)ㅣ미쉐린 2스타ㅣ바다 뷰ㅣ정말 애정하는 이탈리아 레스토랑ㅣ고기 못 먹어서 살짝 아쉬움",
-      "concept": "소렌토 근교 미쉐린 2스타 바다뷰 레스토랑",
-      "locations": [
-        {
-          "name": "Torre del Saracino",
-          "displayName": "Torre del Saracino",
-          "address": "Via Torretta, 9, 80069 Vico Equense NA, 이탈리아",
-          "latitude": 40.6605999,
-          "longitude": 14.419622100000002,
-          "googleMapsId": "ChIJEyOciPmYOxMRGiimZJL8YNg",
-          "googleMapsUri": "https://maps.google.com/?cid=15591739615640692762&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=bmRVDNxgVBs",
-          "description": "이탈리아 맛집을 소개하는 영상에서 방문한 소렌토 근교 미쉐린 2스타 레스토랑. 시원한 바다 뷰가 인상적이며, 4년 만에 다시 찾은 손꼽히는 곳으로 극찬받았다."
+          "geocodeWarning": "displayName 'Locanda del Pilone' != '로칸다 델 필로네'; verify"
         }
       ]
     },
     {
       "videoId": "265ydJ9Otjc",
       "title": "화이트 트러플 대축제 🎄다가오는 연말🎄 진하게 생각나는 이탈리아 레스토랑[EN]ㅣVilla Crespi",
-      "concept": "오르타 산 줄리오 미슐랭 2스타 (화이트 트러플)",
+      "concept": "Via",
       "locations": [
         {
-          "name": "Villa Crespi",
-          "displayName": "Villa Crespi",
+          "name": "Via Giuseppe Fava, 18",
           "address": "Via Giuseppe Fava, 18, 28016 Orta San Giulio NO, 이탈리아",
-          "latitude": 45.7964103,
-          "longitude": 8.416053699999999,
-          "googleMapsId": "ChIJCbA4Ku4MhkcRDYaPQYuwaCI",
-          "googleMapsUri": "https://maps.google.com/?cid=2479425707014325773&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=265ydJ9Otjc",
-          "description": "연말에 진하게 생각나는 이탈리아 레스토랑을 소개하는 영상에서 방문한 오르타 산 줄리오의 미슐랭 2스타. 화이트 트러플 대축제와 함께 즐기는 코스로 소개되었다."
+          "latitude": 45.796468700000005,
+          "longitude": 8.4162437,
+          "googleMapsId": "ChIJ69UgLe4MhkcRxQm5b_Fg8do",
+          "googleMapsUri": "https://maps.google.com/?cid=15776497559733340613&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "xcoyMO3tQxg",
       "title": "6년 만에 또간집, 미쉐린 3스타 | Uliassi",
-      "concept": "세니갈리아 미쉐린 3스타 (Uliassi)",
+      "concept": "Banchina",
       "locations": [
         {
           "name": "Uliassi",
-          "displayName": "Uliassi",
           "address": "Banchina di Levante, 6, 60019 Senigallia AN, 이탈리아",
+          "description": "Uliassi — 비밀이야 in 한국 영상에서 소개한 Banchina 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xcoyMO3tQxg",
           "latitude": 43.719463100000006,
           "longitude": 13.2208132,
           "googleMapsId": "ChIJcR28_J1zLRMRk_P3vABNEog",
-          "googleMapsUri": "https://maps.google.com/?cid=9804984004304696211&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xcoyMO3tQxg",
-          "description": "6년 만에 또 찾은 이탈리아 맛집을 소개하는 영상에서 방문한 세니갈리아의 미쉐린 3스타 레스토랑. '또간집'이라 부를 만큼 만족스러운 해산물 중심 코스로 극찬받았다."
+          "googleMapsUri": "https://maps.google.com/?cid=9804984004304696211&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "KKp9RTuA3t4",
       "title": "궁전에서 마시는 이탈리아 최고의 화이트 와인 | Atto di Vito Mollica",
-      "concept": "피렌체 궁전 내 화이트 와인 레스토랑",
+      "concept": "Via",
       "locations": [
         {
           "name": "Atto di Vito Mollica",
-          "displayName": "Atto di Vito Mollica",
-          "address": "Salotto Portinari Bistrot di Vito Mollica, Via del Corso, 6, 50122 Firenze FI, 이탈리아",
+          "address": "Via del Corso, 6, 50122 Firenze FI, 이탈리아",
+          "description": "Atto di Vito Mollica — 비밀이야 in 한국 영상에서 소개한 Salotto 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KKp9RTuA3t4",
           "latitude": 43.7715125,
           "longitude": 11.257390400000002,
-          "googleMapsId": "ChIJBZGWxU1VKhMRDdBZosnDJ9E",
-          "googleMapsUri": "https://maps.google.com/?cid=15071229948798291981&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KKp9RTuA3t4",
-          "description": "이탈리아 최고의 화이트 와인을 즐긴 영상에서 방문한 피렌체 궁전 내 레스토랑. 셰프 비토 몰리카의 요리와 함께 궁전에서 마시는 화이트 와인으로 소개되었다."
+          "googleMapsId": "ChIJcdGCTY1VKhMRZMpo-EoJYeE",
+          "googleMapsUri": "https://maps.google.com/?cid=16240271948874566244&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "displayName 'Salotto Portinari Bistrot di Vito Mollica' != 'Atto di Vito Mollica'; verify"
         }
       ]
     },
     {
       "videoId": "xkHWTOcsJkQ",
       "title": "이게 바로 화이트 트러플입니다🤍 (feat. 가성비 미친 와인샵, 트러플 짜파게티) | Il Centro",
-      "concept": "알바 근교 화이트 트러플 레스토랑",
+      "concept": "Via",
       "locations": [
         {
           "name": "Ristorante Il Centro",
-          "displayName": "Ristorante Il Centro",
           "address": "Via Umberto I°, 5, 12040 Priocca CN, 이탈리아",
+          "description": "Ristorante Il Centro — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xkHWTOcsJkQ",
           "latitude": 44.7905172,
           "longitude": 8.0624853,
           "googleMapsId": "ChIJY8SHv6v2h0cR6lvRbmrgGAc",
-          "googleMapsUri": "https://maps.google.com/?cid=511405305436920810&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xkHWTOcsJkQ",
-          "description": "화이트 트러플을 소개하는 영상에서 방문한 알바 근교 프리오카의 레스토랑. 가성비 미친 와인샵과 트러플 요리로 소개되었다."
-        }
-      ]
-    },
-    {
-      "videoId": "TRhoUQoHJU0",
-      "title": "[비밀이야 in 이탈리아] 로마 아로마(Aroma)ㅣ미쉐린 1스타ㅣ콜로세움 뷰(feat.시위)ㅣ꼭 연인과 가세요!ㅣ뷰가 다했다",
-      "concept": "로마 콜로세움 뷰 미쉐린 1스타",
-      "locations": [
-        {
-          "name": "Aroma",
-          "displayName": "Aroma",
-          "address": "Via Labicana, 125, 00184 Roma RM, 이탈리아",
-          "latitude": 41.8901781,
-          "longitude": 12.4955196,
-          "googleMapsId": "ChIJ_RzlBblhLxMR11BvqYi8aoQ",
-          "googleMapsUri": "https://maps.google.com/?cid=9541646055682035927&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=TRhoUQoHJU0",
-          "description": "로마 미쉐린 1스타 레스토랑을 소개하는 영상에서 방문한 콜로세움 뷰 레스토랑. 음식과 가격은 1스타이지만 뷰만큼은 3스타라는 평으로, 연인과 함께 갈 곳으로 추천되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=511405305436920810&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "0MyfFFFfdOc",
       "title": "[EN] 비밀이야가 말아주는 베네치아 꿀팁 총정리🍯| 이탈리아 출장 EP.2 | Trattoria Da Romano",
-      "concept": "베네치아 부라노 섬 트라토리아",
+      "concept": "Via",
       "locations": [
         {
           "name": "Trattoria Da Romano",
-          "displayName": "Trattoria da Romano",
           "address": "Via San Martino destro, 221, 30142 Venezia VE, 이탈리아",
+          "description": "Trattoria Da Romano — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0MyfFFFfdOc",
           "latitude": 45.4851027,
           "longitude": 12.418166000000001,
           "googleMapsId": "ChIJa5wpQlKsfkcRM0QAOw_Caqg",
-          "googleMapsUri": "https://maps.google.com/?cid=12135725516573393971&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0MyfFFFfdOc",
-          "description": "베네치아 여행 꿀팁을 총정리하는 영상에서 방문한 부라노 섬의 트라토리아. 베네치아 여행 시 꼭 들러야 할 맛집으로 추천되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=12135725516573393971&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "zesn608_xzo",
       "title": "혹평했던 레스토랑인데...직원들이 알아보네요 | Piazza Duomo",
-      "concept": "알바 미슐랭 3스타 레스토랑 재방문",
+      "concept": "Vicolo",
       "locations": [
         {
           "name": "Piazza Duomo",
-          "displayName": "Piazza Duomo",
           "address": "Vicolo dell' Arco, 12, 12051 Alba CN, 이탈리아",
+          "description": "Piazza Duomo — 비밀이야 in 한국 영상에서 소개한 Piazza 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zesn608_xzo",
           "latitude": 44.700570299999995,
           "longitude": 8.0358077,
           "googleMapsId": "ChIJSw-GLl2z0hIRX8zyKXltoq8",
-          "googleMapsUri": "https://maps.google.com/?cid=12655798270026763359&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zesn608_xzo",
-          "description": "이전에 혹평했던 레스토랑을 재방문하는 영상에서 소개된 알바의 미슐랭 3스타 레스토랑. 직원들이 알아볼 정도로 화제가 된 곳으로, 재평가를 시도했다."
-        }
-      ]
-    },
-    {
-      "videoId": "y8TnmVbNtgY",
-      "title": "밀라노의 힙한 성수 브레라!ㅣ와인잔은 넓은게 좋을까? 좁은게 좋을까? [EN]ㅣSette Cucina Urbana",
-      "concept": "밀라노 브레라 트렌디 레스토랑",
-      "locations": [
-        {
-          "name": "Sette Cucina Urbana",
-          "displayName": "Bauscia",
-          "address": "Via dell'Orso, 2, 20121 Milano MI, 이탈리아",
-          "latitude": 45.4692242,
-          "longitude": 9.1877512,
-          "googleMapsId": "ChIJ86o_8bLGhkcR4zCyqJjuoBU",
-          "googleMapsUri": "https://maps.google.com/?cid=1558507810502881507&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=y8TnmVbNtgY",
-          "description": "밀라노의 힙한 브레라 지구를 소개하는 영상에서 방문한 트렌디 레스토랑. 와인잔의 넓고 좁음에 따른 맛 차이를 이야기하며 즐긴 곳으로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=12655798270026763359&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "6b7x8AysySw",
       "title": "(EN) 전 세계 최연소 미쉐린 3스타 셰프! 하지만 파스타는... | Ristorante Quadri",
-      "concept": "베네치아 산마르코 미쉐린 레스토랑 (Quadri)",
+      "concept": "P.za",
       "locations": [
         {
           "name": "Ristorante Quadri",
-          "displayName": "Ristorante Quadri",
           "address": "P.za San Marco, 123, 30124 Venezia VE, 이탈리아",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 [P.za](http://p.za/) 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6b7x8AysySw",
           "latitude": 45.4343356,
           "longitude": 12.3381504,
           "googleMapsId": "ChIJFaSvYdexfkcRumqldW76xcE",
-          "googleMapsUri": "https://maps.google.com/?cid=13962841572059212474&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6b7x8AysySw",
-          "description": "전 세계 최연소 미쉐린 3스타 셰프를 소개하는 영상에서 방문한 베네치아 산마르코 광장의 레스토랑. 화려한 위치와 달리 파스타는 아쉬웠다는 솔직한 후기가 담겼다."
+          "googleMapsUri": "https://maps.google.com/?cid=13962841572059212474&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "QBYqR8HoRAU",
       "title": "제철 음식 챙겨 먹는데 이제 그게 화이트 트러플임🤍 | Il Luogo di Aimo e Nadia",
-      "concept": "밀라노 미슐랭 레스토랑 (화이트 트러플)",
+      "concept": "Via",
       "locations": [
         {
           "name": "Il Luogo di Aimo e Nadia",
-          "displayName": "Il Luogo di Aimo e Nadia",
           "address": "Via Privata Raimondo Montecuccoli, 6, 20147 Milano MI, 이탈리아",
+          "description": "Il Luogo di Aimo e Nadia — 비밀이야 in 한국 영상에서 소개한 Via 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=QBYqR8HoRAU",
           "latitude": 45.4584762,
           "longitude": 9.131244400000002,
           "googleMapsId": "ChIJ9aorjSvChkcRD0Zd5dxZ2s4",
-          "googleMapsUri": "https://maps.google.com/?cid=14905324722011850255&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=QBYqR8HoRAU",
-          "description": "제철 음식과 화이트 트러플을 소개하는 영상에서 방문한 밀라노 미슐랭 레스토랑. 제철 재료인 화이트 트러플을 듬뿍 활용한 코스로 소개되었다."
-        }
-      ]
-    },
-    {
-      "videoId": "kj4mA9dxX2s",
-      "title": "광기 어린 셰프님과 그 아들 (feat. 진짜 이탈리아 가정식)ㅣ홀인원, 푸드라이터 [EN]",
-      "concept": "밀라노 이탈리아 가정식 레스토랑",
-      "locations": [
-        {
-          "name": "Hole in One",
-          "displayName": "Hole In One Drink & Golf (open bar dall’una alle due)",
-          "address": "Via Michelangelo Buonarroti, 19, 20149 Milano MI, 이탈리아",
-          "latitude": 45.4693353,
-          "longitude": 9.1550768,
-          "googleMapsId": "ChIJUfHo62XBhkcRWp3UlYQOlEQ",
-          "googleMapsUri": "https://maps.google.com/?cid=4941590653744487770&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kj4mA9dxX2s",
-          "description": "광기 어린 셰프와 이탈리아 가정식을 소개하는 영상에서 방문한 밀라노 캐주얼 레스토랑. 독특한 분위기 속 진짜 이탈리아 가정식을 선보인다."
-        },
-        {
-          "name": "Food Writers",
-          "displayName": "Food Writers",
-          "address": "Via Domenico Millelire, 14, 20147 Milano MI, 이탈리아",
-          "latitude": 45.466687,
-          "longitude": 9.1288214,
-          "googleMapsId": "ChIJZckOtYPBhkcRv1N-SmskCig",
-          "googleMapsUri": "https://maps.google.com/?cid=2885158554514117567&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kj4mA9dxX2s",
-          "description": "광기 어린 셰프와 이탈리아 가정식을 소개하는 영상에서 방문한 밀라노 레스토랑. 개성 넘치는 셰프와 그 아들이 함께 선보이는 가정식으로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=14905324722011850255&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "GK7tzoJsVPY",
       "title": "[EN] 그런데 미쉐린 음식에서 이물질이..? 이에 대한 생각 | 이탈리아 출장 EP.3 | Casa Perbellini",
-      "concept": "베로나 미쉐린 레스토랑 검증기",
+      "concept": "Vicolo",
       "locations": [
         {
           "name": "Casa Perbellini 12 Apostoli",
-          "displayName": "Casa Perbellini 12 Apostoli",
           "address": "Vicolo Corticella S. Marco, 3, 37121 Verona VR, 이탈리아",
+          "description": "Casa Perbellini 12 Apostoli — 비밀이야 in 한국 영상에서 소개한 Vicolo 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GK7tzoJsVPY",
           "latitude": 45.4426738,
           "longitude": 10.9961133,
           "googleMapsId": "ChIJu8s0-1dff0cR-BmaS83pW3U",
-          "googleMapsUri": "https://maps.google.com/?cid=8456609793264196088&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GK7tzoJsVPY",
-          "description": "이탈리아 출장 중 방문한 베로나의 미쉐린 레스토랑을 소개하는 영상. 미쉐린 음식에서 이물질이 나온 에피소드와 그에 대한 생각을 솔직하게 다뤘다."
+          "googleMapsUri": "https://maps.google.com/?cid=8456609793264196088&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "XrVKKGDTjyg",
       "title": "이거 꿈인가요? 인생 숙소와 저녁식사 | Forestis Dolomites",
-      "concept": "돌로미테 인생 숙소 레스토랑",
+      "concept": "Palmschoß",
       "locations": [
         {
           "name": "Forestis Dolomites",
-          "displayName": "Forestis Dolomites",
           "address": "Palmschoß 22, 39042 Bressanone BZ, 이탈리아",
+          "description": "Forestis Dolomites — 비밀이야 in 한국 영상에서 소개한 Palmschoß 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XrVKKGDTjyg",
           "latitude": 46.675755699999996,
           "longitude": 11.7100308,
           "googleMapsId": "ChIJUzkj65AQeEcRKXSK0ZN3uS8",
-          "googleMapsUri": "https://maps.google.com/?cid=3438911267233494057&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XrVKKGDTjyg",
-          "description": "인생 숙소와 저녁식사를 소개하는 영상에서 방문한 돌로미테의 호텔 레스토랑. 꿈같은 숙소와 함께 즐기는 저녁식사로 극찬받았다."
+          "googleMapsUri": "https://maps.google.com/?cid=3438911267233494057&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "qrXzkgYQpSQ",
       "title": "이탈리아의 '돼지 오줌보 스팀 파스타'를 먹어보다 | Lido84",
-      "concept": "가르다 호수변 미슐랭 레스토랑 (독특한 요리)",
+      "concept": "Corso",
       "locations": [
         {
-          "name": "Lido 84",
-          "displayName": "Lido 84",
+          "name": "Lido84",
           "address": "Corso Giuseppe Zanardelli, 196, 25083 Gardone Riviera BS, 이탈리아",
+          "description": "Lido84 — 비밀이야 in 한국 영상에서 소개한 Corso 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=qrXzkgYQpSQ",
           "latitude": 45.6251592,
           "longitude": 10.5755666,
           "googleMapsId": "ChIJx7BJHCKMgUcRA7aurgztHrQ",
-          "googleMapsUri": "https://maps.google.com/?cid=12979071814854424067&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=qrXzkgYQpSQ",
-          "description": "이탈리아 독특한 요리를 소개하는 영상에서 방문한 가르다 호수변 미슐랭 레스토랑. '돼지 오줌보 스팀 파스타'라는 독특한 시그니처 요리로 화제가 되었다."
-        }
-      ]
-    },
-    {
-      "videoId": "451vnX351yc",
-      "title": "[비밀이야 in 이탈리아] 피렌체 구찌 오스테리아(Gucci Osteria)ㅣ미쉐린 1스타ㅣ마시모 보투라 셰프ㅣ구찌와 마시모 보투라를 빼면 과연..",
-      "concept": "피렌체 구찌 오스테리아 미쉐린 1스타",
-      "locations": [
-        {
-          "name": "Gucci Osteria",
-          "displayName": "Gucci Osteria da Massimo Bottura",
-          "address": "P.za della Signoria, 10, 50122 Firenze FI, 이탈리아",
-          "latitude": 43.769737,
-          "longitude": 11.2568188,
-          "googleMapsId": "ChIJXWil3wBUKhMRCNkg3KPI-FY",
-          "googleMapsUri": "https://maps.google.com/?cid=6266979487584409864&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=451vnX351yc",
-          "description": "피렌체 미쉐린 1스타 레스토랑을 소개하는 영상에서 방문한 구찌와 셰프 마시모 보투라의 협업 레스토랑. 식사와 함께 구찌 박물관도 볼 수 있는 독특한 공간으로 소개되었다."
-        }
-      ]
-    },
-    {
-      "videoId": "CaHQnH6qK7Y",
-      "title": "[비밀이야 in 이탈리아] 나폴리 지노 소르빌로(Gino Sorbillo)ㅣ나폴리 4대 피자(내 맘대로ㅋ)ㅣ퀄리티에 비해 매우 저렴한 가격!ㅣ줄 서기 싫으면 말고 분점으로~",
-      "concept": "나폴리 4대 피자 (Gino Sorbillo)",
-      "locations": [
-        {
-          "name": "Gino Sorbillo",
-          "displayName": "Gino e Toto Sorbillo",
-          "address": "Via dei Tribunali, 32, 80138 Napoli NA, 이탈리아",
-          "latitude": 40.850425,
-          "longitude": 14.255358099999999,
-          "googleMapsId": "ChIJuyXzSEIIOxMR5KQy1mftAr0",
-          "googleMapsUri": "https://maps.google.com/?cid=13619709253352858852&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=CaHQnH6qK7Y",
-          "description": "나폴리 4대 피자(내 맘대로) 중 하나를 소개하는 영상에서 방문한 전설적인 피자집 지노 소르빌로. 퀄리티에 비해 매우 저렴한 가격이 특징이며, 나폴리에 가면 꼭 들러야 할 곳으로 추천되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=12979071814854424067&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "nsTJJQaUTBo",
       "title": "하루 단 20팀? 콜로세움뷰 럭셔리 호텔 후기⭐ | Palazzo Manfredi",
-      "concept": "로마 콜로세움 뷰 럭셔리 호텔",
+      "concept": "Via",
       "locations": [
         {
           "name": "Palazzo Manfredi",
-          "displayName": "Palazzo Manfredi",
           "address": "Via Labicana, 125, 00184 Roma RM, 이탈리아",
+          "description": "👍중간에 나온 로마 아로마(Aroma) 보러가기🏃",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=nsTJJQaUTBo",
           "latitude": 41.8901976,
           "longitude": 12.495603899999999,
           "googleMapsId": "ChIJTVNJb7dhLxMRdE-kPPU1f_o",
-          "googleMapsUri": "https://maps.google.com/?cid=18050205158924898164&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": 0,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=nsTJJQaUTBo",
-          "description": "로마의 럭셔리 호텔을 소개하는 영상에서 방문한 콜로세움 뷰 호텔. 하루 단 20팀만 받으며 콜로세움을 바로 앞에서 조망할 수 있는 곳으로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=18050205158924898164&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     }

--- a/.claude/workspace/youtube/PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi/_create_manifest.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi/_create_manifest.json
@@ -1,0 +1,196 @@
+{
+  "sunreiId": "SR01kyj0fmjw206ew2t5j9rz7yaj",
+  "sourceId": "SRC01kyhw8vq7ze5mry327y36vrwd",
+  "spots": [
+    {
+      "spotId": "SS01kyj0fmkh49z9prdz39ybe92g",
+      "videoId": "aDcCeWReTG0",
+      "videoTitle": "프렌치 셰프도 감탄한 삿포로 3스타 재패니즈 프렌치🍽️북해도 식재료 끝판왕 | 몰리에르 モリエール"
+    },
+    {
+      "spotId": "SS01kyj0fmknn28q273210safqw1",
+      "videoId": "90FahyHS8dA",
+      "videoTitle": "1박에 500만 원짜리 료칸 밥은 뭐가 나올까? | 소네카"
+    },
+    {
+      "spotId": "SS01kyj0fmkqwzwq8j9kbapq6pwh",
+      "videoId": "p582RAgWsHs",
+      "videoTitle": "설경 뻥뷰의 미쉐린 료칸☃️...아라마사를 이 가격에? | Niseko Zaborin"
+    },
+    {
+      "spotId": "SS01kyj0fmkrgphsd57404h886t8",
+      "videoId": "0VWZ5bhb7Bk",
+      "videoTitle": "삿포로 소바집에서 취했습니다. | 미슐랭 1스타_테우치소바 코하시 | (+비추천 이자카야)"
+    },
+    {
+      "spotId": "SS01kyj0fmkt5yrrvkmaq31e43bd",
+      "videoId": "TIlMgP127dc",
+      "videoTitle": "[EN] 한국에선 불법! '야생요리 전문식당' | 일본 야나기야 | Cuisine Yanagiya"
+    },
+    {
+      "spotId": "SS01kyj0fmkved0bazgsj4n6jtd7",
+      "videoId": "5JIZFg4dXfo",
+      "videoTitle": "뭐 하나 빠짐없이 좋았던 홋카이도 프리미엄 료칸 (feat. 훌륭한 퀄리티의 해산물)[EN]ㅣ모쿠노쇼"
+    },
+    {
+      "spotId": "SS01kyj0fmkx9pdfyneg8eceqaxg",
+      "videoId": "ls0stez98hg",
+      "videoTitle": "이 시골 료칸이 홋카이도 유일의 미쉐린 1스타를 받은 곳이라고?[EN]ㅣ비쿠니 칸코 하우스"
+    },
+    {
+      "spotId": "SS01kyj0fmkzcepfajc62qyezv1f",
+      "videoId": "ylfG2fvn3K4",
+      "videoTitle": "🍷다시는 못 볼 줄 알았던 와인과의 운명적인 만남[EN]ㅣ코트도르"
+    },
+    {
+      "spotId": "SS01kyj0fmm0frd7ftd1035tbe98",
+      "videoId": "zFKDef6mDHY",
+      "videoTitle": "인당 45만원, 와인만 250만원 나온 후덜덜한 일본 타베로그 TOP10 맛집! 과연 그 맛은? (feat. 깻잎에 싸주는 말고기🐎)[EN]ㅣACA"
+    },
+    {
+      "spotId": "SS01kyj0fmm1g9ve28hzedn1gdhk",
+      "videoId": "pn6xLx1HwJE",
+      "videoTitle": "이름 내건 식당은 일단 맛 보장이 국룰🏅미쉐린 2스타를 이끌던 류지로 셰프가 차린 도쿄 고급 스시의 한끝차이ㅣ류지로"
+    },
+    {
+      "spotId": "SS01kyj0fmm2wv758vaxv6mw937b",
+      "videoId": "aZbrrnUTjSU",
+      "videoTitle": "간판없는 식당? 입소문으로만 찾아가야 하는 꼼꼼 숨겨진 일본 소고기 오마카세[EN]ㅣ미가키쇼 나가야마"
+    },
+    {
+      "spotId": "SS01kyj0fmm3vdztc7sph8nyrc63",
+      "videoId": "1XZofgYeyUw",
+      "videoTitle": "동에 번쩍 서에 번쩍하는 비밀이야가 호텔 고르는 꿀팁🌟[EN]ㅣ만다린 오리엔탈 도쿄"
+    },
+    {
+      "spotId": "SS01kyj0fmm4jg66ngx972ev3k1d",
+      "videoId": "eodAIw3o50E",
+      "videoTitle": "❄️영하 9도 삿포로에서 프라이빗하게 즐기는 료칸과 최고급 가이세키 식사ㅣ스이잔테이 클럽 [EN]"
+    },
+    {
+      "spotId": "SS01kyj0fmm57za0rf05m52bc5hr",
+      "videoId": "JO9Cqs4Cf-o",
+      "videoTitle": "새우탕 찐하게 우려낸 국물 라멘 🦐 이거지...삿포로가면 꼭 들려야 할 두 곳ㅣ수프카레 사무라이&에비소바 이치겐 [EN]"
+    },
+    {
+      "spotId": "SS01kyj0fmm6gt3fk2660ac9nkg7",
+      "videoId": "JO9Cqs4Cf-o",
+      "videoTitle": "새우탕 찐하게 우려낸 국물 라멘 🦐 이거지...삿포로가면 꼭 들려야 할 두 곳ㅣ수프카레 사무라이&에비소바 이치겐 [EN]"
+    },
+    {
+      "spotId": "SS01kyj0fmm7z4za3hvtgb6fah3m",
+      "videoId": "ZyY6Hl555Ws",
+      "videoTitle": "이 영상을 보시면 단번에 이해하실 수 있습니다ㅣ짧고 굵은 가심비 1등 스시집 소개🍣ㅣ스시미야카와 [EN]"
+    },
+    {
+      "spotId": "SS01kyj0fmm8pp5ej8a27bdzv1js",
+      "videoId": "BGmaULQnWR0",
+      "videoTitle": "맛&가성비 둘 다 잡은 카이센동 맛집 두 곳 추천!ㅣ우니 무라카미&사카나야노 다이도코로 [EN]"
+    },
+    {
+      "spotId": "SS01kyj0fmm9fmmrtpy5nve31ksg",
+      "videoId": "BGmaULQnWR0",
+      "videoTitle": "맛&가성비 둘 다 잡은 카이센동 맛집 두 곳 추천!ㅣ우니 무라카미&사카나야노 다이도코로 [EN]"
+    },
+    {
+      "spotId": "SS01kyj0fmmaqzqm0yz7bg4dwthn",
+      "videoId": "ILFK8cODr4U",
+      "videoTitle": "징기스칸 양고기 타파할 최고 맛집 대공개🍖🪇ㅣ이타다끼마쓰&호르몬풍토 [EN]"
+    },
+    {
+      "spotId": "SS01kyj0fmmbmgzgna8fw82n20eg",
+      "videoId": "ILFK8cODr4U",
+      "videoTitle": "징기스칸 양고기 타파할 최고 맛집 대공개🍖🪇ㅣ이타다끼마쓰&호르몬풍토 [EN]"
+    },
+    {
+      "spotId": "SS01kyj0fmmcya9pcds7ah5zv6z3",
+      "videoId": "YYhUDMpqnOY",
+      "videoTitle": "겉바속촉 덴뿌라 진짜 잘하는 집은 따로 있다?! 🦐 미슐랭 투스타 단골집 [EN]ㅣ덴푸라아라키"
+    },
+    {
+      "spotId": "SS01kyj0fmmdyr8j0anwgctgg7ck",
+      "videoId": "kwNgGM31Wn4",
+      "videoTitle": "비밀이야가 오픈런하는 장어맛집?🏃🏻‍♂️사르르 녹는 장어와 맥주 한잔..🍺 [EN]ㅣ우나메이"
+    },
+    {
+      "spotId": "SS01kyj0fmmeg5bgnwbyfpt3hknw",
+      "videoId": "LVbINarIdNA",
+      "videoTitle": "삿포로의 함박 눈꽃 게살🌨️🦀있잖아요..저 너무 들떴어요 [EN] ㅣ카츠카니노 하나사키"
+    },
+    {
+      "spotId": "SS01kyj0fmmfxdj6zjm8kccx1ead",
+      "videoId": "tbosSzVJGqw",
+      "videoTitle": "역대급 야끼니꾸 맛집🔥안심에 버금가는 와규 부위는 어디일까? 애기보, 대창, 양깃머리까지 맛있는 집 [EN]ㅣ도쿄 킨류잔"
+    },
+    {
+      "spotId": "SS01kyj0fmmgny6cns3221c9w6hz",
+      "videoId": "qGhQRyw6IRE",
+      "videoTitle": "(EN) 이런 초대형 아스파라거스 요리 본 적 있어요? 프랑스 본점에서 건물, 인테리어, 음식, 와인리스트까지 그대로 들여온 이곳 ㅣ L’Auberge de L’ill"
+    },
+    {
+      "spotId": "SS01kyj0fmmhhk6khkkp815rvkp2",
+      "videoId": "pmOL-N9ZgYQ",
+      "videoTitle": "(EN) 일본에서 가장 먼저 찾게 되는 삿포로 미슐랭 투스타 술집🐟🍶 비밀이야가 이토록 사랑하는 이유는? l 슈보신센"
+    },
+    {
+      "spotId": "SS01kyj0fmmje6c711sze21hxzdy",
+      "videoId": "vSNU8_Aft-M",
+      "videoTitle": "홋카이도를 대표하는 고급 생선 홍살치🐟"
+    },
+    {
+      "spotId": "SS01kyj0fmmkc7tvm9kpz1cwmsxq",
+      "videoId": "vSNU8_Aft-M",
+      "videoTitle": "홋카이도를 대표하는 고급 생선 홍살치🐟"
+    },
+    {
+      "spotId": "SS01kyj0fmmmw7zndecjzzr9acn7",
+      "videoId": "m5uPotCxv2Y",
+      "videoTitle": "삿포로에서 2차 가기 좋은 곳 대방출✌"
+    },
+    {
+      "spotId": "SS01kyj0fmmp85g1c44xmfx9w1sc",
+      "videoId": "m5uPotCxv2Y",
+      "videoTitle": "삿포로에서 2차 가기 좋은 곳 대방출✌"
+    },
+    {
+      "spotId": "SS01kyj0fmmqcv6cep6ksq0w665n",
+      "videoId": "m5uPotCxv2Y",
+      "videoTitle": "삿포로에서 2차 가기 좋은 곳 대방출✌"
+    },
+    {
+      "spotId": "SS01kyj0fmmrphkj26wgr9jq2s53",
+      "videoId": "BnpEQIAGbUM",
+      "videoTitle": "여기는 재료 퀄리티로 승부 보는 식당입니다🍣"
+    },
+    {
+      "spotId": "SS01kyj0fmmsynfw1tr04hpccg10",
+      "videoId": "_1-2klFGMw8",
+      "videoTitle": "클래식한 음식으로 35년 동안 자리를 지킬 수 있었던 이유🤫"
+    },
+    {
+      "spotId": "SS01kyj0fmmtmx4jrafbm81vpjj0",
+      "videoId": "Bm0e98UsIYA",
+      "videoTitle": "맛있는 거 다음 맛있는 거 🍣"
+    },
+    {
+      "spotId": "SS01kyj0fmmv29t7pyvh1fd6dmn2",
+      "videoId": "rMu6RFdC038",
+      "videoTitle": "삿포로의 투스타 튀김 오마카세"
+    },
+    {
+      "spotId": "SS01kyj0fmmwyns0wj7r23h0sxk8",
+      "videoId": "fdZlJ49JBig",
+      "videoTitle": "여기 예약하기가 진짜 어렵습니다"
+    },
+    {
+      "spotId": "SS01kyj0fmmx2x88772sq7b8jajk",
+      "videoId": "GgUXN4BiXck",
+      "videoTitle": "일본인 셰프에게 취향저격 당했습니다"
+    },
+    {
+      "spotId": "SS01kyj0fmmy55566h8b6tpgk6vs",
+      "videoId": "AtrrQe6srv8",
+      "videoTitle": "아니 셰프님! 그분을 모르시다니...😮"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi/locations.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi/locations.json
@@ -1,759 +1,614 @@
 {
   "videos": [
     {
+      "videoId": "aDcCeWReTG0",
+      "title": "프렌치 셰프도 감탄한 삿포로 3스타 재패니즈 프렌치🍽️북해도 식재료 끝판왕 | 몰리에르 モリエール",
+      "concept": "일본",
+      "locations": [
+        {
+          "name": "몰리에르 Moliere モリエール",
+          "address": "일본 〒064-0959 Hokkaido, Sapporo, Chuo Ward, Miyagaoka, 2-chōme−1−１ ラファイエット宮ケ丘 1F",
+          "description": "삿포로 미야가오카 공원 앞에 자리한 재패니즈 프렌치 레스토랑으로, 2017년 미쉐린 가이드 홋카이도 특별판에서 쓰리스타를 받은 곳이다. 클래식 프렌치가 아니라 모던한 '재패니즈 프렌치'를 표방하며 홋카이도 해산물과 농작물 재료를 적극적으로 활용하고, 서양식 스톡 대신 다시(출시) 느낌으로 국물을 잡하는 등 일본만의 스타일을 더해 동행한 프렌치 셰프도 인정했다. 점심 코스로 방문했으며 은행 튀김 같은 이색적인 애프타티저부터 쌀가루를 입혀 바삭함을 살린 생선 뮈니에르(레몬 버터 케이퍼 소스), 압도적인 크기로 등장하는 홋카이도 대표 고급 조개 호키가이(북방조개), 니세코에서 길러 낸 감자로 만든 도피누아(그라탕)까지 이어진다. 크리에이터는 '버터도 잘 쓰고 과하지 않아 밸런스가 완벽하다'며 '고기보다 감자가 더 맛있다'고 극찬했고, 밤 대신 일본 토착 밤(백화)으로 만든 몽블랑과 갈레트 데 루아 아몬드 파이로 디저트를 마무리했다. 와인은 좋아하는 버건디 화이트 뿔리니 몽라셰 2019와 보르도 생테스테프 샤토 몽로주 1998를 페어링해 완벽한 밸런스를 강조했다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=aDcCeWReTG0",
+          "latitude": 43.057375,
+          "longitude": 141.3115977,
+          "googleMapsId": "ChIJ14UhkcMpC18RYEwgnUQ8T10",
+          "googleMapsUri": "https://maps.google.com/?cid=6723659034079022176&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
       "videoId": "90FahyHS8dA",
       "title": "1박에 500만 원짜리 료칸 밥은 뭐가 나올까? | 소네카",
-      "concept": "일본 료칸 방문기",
+      "concept": "307-1",
       "locations": [
         {
           "name": "SONEKA",
-          "displayName": "SONEKA",
           "address": "307-1 Ōmagari, Kitahiroshima, Hokkaido 061-1270 일본",
+          "description": "삿포로에서 차로 약 40분 거리의 기타히로시마에 자리한 독채형 프리미엄 료칸으로, 크리에이터가 '홋카이도 끝판왕, 전 일본을 통틀어도 이보다 좋은 곳이 많지 않다'고 평가한 곳이다. 서로 다른 컨셉의 독채 객실 4채만 운영하며 객실마다 실내탕과 노천탕, 식기세척기·오븐·에스프레소 머신을 완비한 주방을 갖췄고, 식사를 포함하지 않고 취사도 가능한 유연한 구조다. 온천은 식물성 온천수에 찬물이 섞여 수영장처럼 미지근하게 유지되는 게 특징이고 일부 객실은 노천탕 대신 사우나를 갖췄다. 저녁 식사는 일식과 양식이 섞인 퓨전 코스로 한국인 손님에겐 한글 메뉴를 따로 준비해 주며, 홋카이도에서 가장 비싼 생선으로 꼬는 긴키(김기) 구이, 진짜 시샤모, 송이버섯 파스타, 홋카이도 소고기 등이 나온다. 식사 후에는 객실 앞에서 모닥불을 피워주고 마시멜로와 불꽃놀이 세트까지 챙겨주는 섬세한 환대가 인상적이며, 인당 가격이 아닌 객실 기준 요금이라 여럿이 묵을수록 가성비가 좋아 '또 오고 싶다'는 반응을 남겼다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=90FahyHS8dA",
           "latitude": 42.9529822,
           "longitude": 141.479408,
           "googleMapsId": "ChIJkw1nKADVdF8R-aM98eQnyIQ",
-          "googleMapsUri": "https://maps.google.com/?cid=9567941272601994233&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=90FahyHS8dA",
-          "description": "일본 프리미엄 료칸을 소개하는 영상에서 방문한 홋카이도 키타히로시마의 고급 료칸. 1박에 500만 원이라는 파격적인 가격에 걸맞은 최상급 식사와 서비스가 인상적이다."
+          "googleMapsUri": "https://maps.google.com/?cid=9567941272601994233&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "p582RAgWsHs",
       "title": "설경 뻥뷰의 미쉐린 료칸☃️...아라마사를 이 가격에? | Niseko Zaborin",
-      "concept": "일본 료칸 방문기",
+      "concept": "76-4",
       "locations": [
         {
-          "name": "Zaborin",
-          "displayName": "Zaborin Ryokan",
+          "name": "Zaborin Ryokan 坐忘林",
           "address": "76-4 Hanazono, Kutchan, Abuta District, Hokkaido 044-0084 일본",
+          "description": "니세코 한조노에 자리한 프리미엄 료칸으로 눈 덮인 설경을 객실에서 감상할 수 있고 크리에이터가 오랜 로망으로 삼아온 곳이다. 크리에이터는 '지금까지 본 료칸 중 와인 리스트가 가장 좋다'고 평가했고, 구하기 힘든 모던 사케 아라마사(핑크 유니콘, 농민예술개론 등 실험적인 이름을 단 사케)를 합리적인 가격에 즐길 수 있다는 점을 특히 강조했다. 식사는 전형적인 가이세키에서 한 발 나아가 코스 수가 더 많고 변형이 가미된 구성으로, 오징어 스프링롤과 오징어 간 흑마늘 소스, 달달한 일본 당근에 와규 플레이크와 비트 퓨레를 얹은 야채 요리, 해초를 입힌 굴 튀김과 락시위드 다시, 가리비 관자와 밤 같은 백합뿌리 완자, 산 와사비를 곁들인 볼락·문어·참치·성게 모둠 사시미 등이 차례로 나온다. 평소 당근을 안 먹는 크리에이터가 당근 요리를 비워가며 극찬했고, 동행 일행도 '지금까지 묵은 료칸 중 음식이 제일 좋다'고 평가했다. 1박은 아까우니 2박 이상 머물러 여유를 즐기기를 권하며, 체크아웃 길에는 니세코 스키장 인근 상점에서 우유·치즈로 만든 아이스크림과 케이크를 들를 수 있다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=p582RAgWsHs",
           "latitude": 42.9046156,
           "longitude": 140.6773586,
           "googleMapsId": "ChIJAeZ_igC7Cl8Rt7UeTpnAhUU",
-          "googleMapsUri": "https://maps.google.com/?cid=5009621925192709559&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=p582RAgWsHs",
-          "description": "일본 미쉐린 료칸을 소개하는 영상에서 방문한 니세코의 료칸. 설경 뻥뷰와 함께 아라마사 사케를 합리적인 가격에 즐길 수 있으며, 미쉐린 인정을 받은 곳이다."
+          "googleMapsUri": "https://maps.google.com/?cid=5009621925192709559&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "0VWZ5bhb7Bk",
       "title": "삿포로 소바집에서 취했습니다. | 미슐랭 1스타_테우치소바 코하시 | (+비추천 이자카야)",
-      "concept": "일본 미슐랭 맛집",
+      "concept": "21-chōme-1-2",
       "locations": [
         {
-          "name": "테우치소바 코하시",
-          "displayName": "테우치소바 코하시",
+          "name": "테우치소바 코하시 手打ち蕎麦 こはし",
           "address": "21-chōme-1-2 Kita 10 Jōnishi, Chuo Ward, Sapporo, Hokkaido 060-0010 일본",
+          "description": "삿포로 중앙도매시장 장외시장 인근에 자리한 수타 소바 전문점으로, 2017년 미쉐린 가이드 홋카이도 특별판에서 1스타를 받은 크리에이터의 또간집이다. 시내에 있으면서도 눈이 보이는 고즈넉한 분위기로 '시내인데 시외 느낌'이라는 묘사를 받았다. 메밀을 직접 방앗간에서 제분해 100% 메밀로 반죽한 면이 특징으로, 기본 소바(950엔)부터 따뜻한 나메코 소바(1,200엔), 차가운 소바를 뜨거운 오리 육수에 찍어 먹는 카모세이로(1,800엔)까지 다양하다. 이곳은 '소바집이 사실은 술집'이라는 모토답게 일본어 메뉴판에만 안주가 추가로 있어 생유바 사시미(750엔, 부라타치즈 같은 식감), 우엉 튀김(650엔), 오리 구이(1,700엔), 단새우 튀김(800엔) 등을 곁들여 낮술을 즐기기 좋다. 소바로 만든 술 소바쇼츄 소바유와리와 마지막에 소바 유를 쯔유에 섞어 먹는 방식, 날달걀을 추가해 찍어 먹는 색다른 경험이 겹쳐 '뻔한 삿포로 음식이 먹기 싫을 때 방문하면 좋다'는 총평을 남겼다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0VWZ5bhb7Bk",
           "latitude": 43.06912,
           "longitude": 141.3212051,
           "googleMapsId": "ChIJEbDvNwApC18RGJVv5fGeXGU",
-          "googleMapsUri": "https://maps.google.com/?cid=7303887457461703960&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0VWZ5bhb7Bk",
-          "description": "삿포로 미슐랭 1스타 소바집을 소개하는 영상에서 방문한 곳. 소바와 함께 사케를 즐기다 취할 정도로 매력적인 곳이며, 비추천 이자카야 정보도 함께 다루었다."
+          "googleMapsUri": "https://maps.google.com/?cid=7303887457461703960&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "TIlMgP127dc",
       "title": "[EN] 한국에선 불법! '야생요리 전문식당' | 일본 야나기야 | Cuisine Yanagiya",
-      "concept": "기후현 야생요리 전문식당",
+      "concept": "Mashizume-573-27",
       "locations": [
         {
-          "name": "야나기야 Cuisine Yanagiya",
-          "displayName": "Yanagiya",
+          "name": "야나기야",
           "address": "Mashizume-573-27 陶町猿爪 Mizunami, Gifu 509-6361 일본",
+          "description": "기후현 미즈나미에 있는 사냥·채집한 야생 재료로 요리를 만드는 야생요리 전문점으로 미쉐린 2스타를 받은 곳이다. 나고야에서 기차로 한 시간 거리이며 4명 이상만 예약을 받고(6명이면 한 방에서 딱 좋다), 역에서 미리 연락하면 픽업도 나온다. 5년 전 가을에 다녀와 잊지 못해 다시 찾았다는 크리에이터는 계절마다 메뉴가 바뀌는 점을 강조하며 특히 가을 방문을 추천했다. 피를 즉시 빼내 특유의 향을 없앤 사슴 심장 사시미를 비롯해 멧돼지 파꼬치(네기마), 멧돼지 목등심·등심, 사슴 로스, 쇠오리 구이 등을 비장탄과 일반 숯 두 종류로 숯불 구워 내고, 마지막에는 멧돼지 된장국과 마를 얹은 밥으로 마무리한다. '한국에서는 규제 때문에 이런 야생요리 식당이 법적으로 불가능하다'는 점도 특별함으로 꼽았으며, 크리에이터 총평은 '가을 시즌에 한 번 더 방문할 것', 인당 약 2만 엔 수준의 가격대였다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=TIlMgP127dc",
           "latitude": 35.3180079,
           "longitude": 137.3345021,
           "googleMapsId": "ChIJq6pWUtJRA2ARtKygfg8ao4A",
           "googleMapsUri": "https://maps.google.com/?cid=9269281111909903540&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=TIlMgP127dc",
-          "description": "한국에서는 불법인 야생요리 전문식당을 소개하는 영상에서 방문한 기후현 미즈나미의 레스토랑. 독특한 야생 식재료를 활용한 요리가 특징이며, 일본만의 식문화를 체험할 수 있다."
+          "geocodeWarning": "displayName 'Yanagiya' != '야나기야'; verify"
         }
       ]
     },
     {
       "videoId": "5JIZFg4dXfo",
       "title": "뭐 하나 빠짐없이 좋았던 홋카이도 프리미엄 료칸 (feat. 훌륭한 퀄리티의 해산물)[EN]ㅣ모쿠노쇼",
-      "concept": "일본 료칸 방문기",
+      "concept": "393393",
       "locations": [
         {
-          "name": "모쿠노쇼",
-          "displayName": "Niseko Konbu Onsen Tsuruga Besso Moku no Sho",
+          "name": "모쿠노쇼 (Mokunoshou)",
           "address": "393 Niseko, Abuta District, Hokkaido 048-1511 일본",
+          "description": "니세코 곤후 온천에 자리한 츠루가 그룹의 프리미엄 료칸 '모쿠노쇼'로, 삿포로에서 약 1시간 30분 거리의 계곡물이 흐르는 한적한 숲 속에 있다. 객실 수가 적어 프라이빗한 분위기이며 2020년에 문을 열었으나 기존 건물을 개조한 듯한 느낌이고, 노천 온천이 딸린 스위트룸과 바 앞 족욕 공간, 새벽에도 이용 가능한 대욕장을 갖췄다. 저녁은 가이세키로 호박 두부, 산초잎을 얹은 관자 수프, 광어·참치·도화새우·북방조개·성게 모둠 사시미, 러시아산 킹크랩 다리 찜, 가을 일식에서 빠질 수 없는 꽁치와 고급 심해어 메누키 찜, 큼직한 전복과 버섯찜, 홋카이도 와규, 연어 솥밥이 차례로 나온다. 크리에이터는 '전반적으로 재료가 굉장히 좋다'고 반복해 강조했고, 꽁치는 비늘이 깨끗해 낚시로 잡은 것이라고 추정할 정도로 퀄리티가 높았다. 인당 약 50만 원대의 가격대이지만 캠프파이어에서 마시멜로를 구워주는 츠루가 특유의 환대가 더해져 '겨울이 아니어도 충분히 만족스러운 하루'라는 총평을 남겼다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5JIZFg4dXfo",
           "latitude": 42.8394239,
           "longitude": 140.6223305,
           "googleMapsId": "ChIJS-oU_YClCl8RiXnw9Fjhe-U",
-          "googleMapsUri": "https://maps.google.com/?cid=16536058229003680137&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=5JIZFg4dXfo",
-          "description": "홋카이도 프리미엄 료칸을 소개하는 영상에서 방문한 니세코의 료칸. 뭐 하나 빠짐없이 좋았다는 평가를 받았으며, 특히 훌륭한 퀄리티의 해산물 요리가 인상적이다."
+          "googleMapsUri": "https://maps.google.com/?cid=16536058229003680137&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "ls0stez98hg",
       "title": "이 시골 료칸이 홋카이도 유일의 미쉐린 1스타를 받은 곳이라고?[EN]ㅣ비쿠니 칸코 하우스",
-      "concept": "일본 료칸 방문기",
+      "concept": "일본",
       "locations": [
         {
-          "name": "비쿠니 칸코 하우스",
-          "displayName": "Bikuni Kanko House",
-          "address": "일본 〒046-0201 北海道積丹郡積丹町美国町船澗４９",
-          "latitude": 43.2990852,
-          "longitude": 140.5994288,
-          "googleMapsId": "ChIJlU4uFwT3Cl8RKGo6vRZq3AU",
-          "googleMapsUri": "https://maps.google.com/?cid=422329110962530856&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "name": "후나마",
+          "address": "일본 〒046-0201 홋카이도 Shakotan District, 샤코탄조 비쿠니초 후나마",
+          "description": "홋카이도 샤코탄 반도 비쿠니항에 자리한 소박한 시골 료칸으로, 삿포로에서 약 2시간·오타루에서 약 1시간 거리에 있다. 크리에이터는 이곳을 '비쿠니 칸코 하우스'라 부르며, 온천이 있는 것도 아니고 객실에 화장실·욕실조차 없는 단출한 시설이지만 2017년 미쉐린 가이드 북해도 특별판에서 북해도 숙소 중 유일하게 '음식'으로 1스타를 받은 곳이라고 소개한다. 저녁은 정통 가이세키가 아닌 투박하면서도 직관적인 해산물 코스로, 전복·문어·북방조개·새우튀김으로 시작해 부드럽고 기름기가 쫙 퍼지는 송어, 알이 가득 찬 갯가재, 한국에서는 어획이 불법인 대게 암컷의 알과 살, 도화새우·전복 튀김이 차례로 나오고, 우럭으로 끓인 된장 나베는 '국물이 예술로 우러났다'는 평가를 받는다. 다음 날 아침에는 임연수 된장구이와 함께 밥 위에 생 성게·생 전복을 통째로 올린 덮밥이 나오며, 근처 요이치의 100% 생사과 주스가 곁들여진다. 술은 같은 요이치 지역 닛카 위스키의 다케츠루·싱글몰트 요이치 하이볼이 잘 어울리고, 숙박·식사 포함 인당 약 25~26만 원 수준이다. 시설은 열악하지만 해산물 요리의 완성도가 뛰어나 '지금까지 먹어 본 북해도 료칸 중 음식이 제일 괜찮았다'며 샤코탄 반도 일정이라면 들러볼 만한 곳으로 추천한다.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ls0stez98hg",
-          "description": "홋카이도 유일의 미쉐린 1스타 료칸을 소개하는 영상에서 방문한 샤코탄의 시골 료칸. 시골 위치에도 불구하고 미쉐린 1스타를 받은 실력파 료칸으로, 소박하지만 깊은 맛이 특징이다."
+          "latitude": 43.2975159,
+          "longitude": 140.5870735,
+          "googleMapsId": "ChIJ114uFwT3Cl8RevK_3TsnOOU",
+          "googleMapsUri": "https://maps.google.com/?cid=16516994771458191994&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "ylfG2fvn3K4",
       "title": "🍷다시는 못 볼 줄 알았던 와인과의 운명적인 만남[EN]ㅣ코트도르",
-      "concept": "일본의 프렌치 레스토랑",
+      "concept": "일본",
       "locations": [
         {
-          "name": "Restaurant Cote d'Or",
-          "displayName": "코트도르(Côte d'Or)",
-          "address": "1-chōme-2-38 Miyagaoka, Chuo Ward, Sapporo, Hokkaido 064-0959 일본",
-          "latitude": 43.0580144,
-          "longitude": 141.3121224,
-          "googleMapsId": "ChIJr-5x8cMpC18RE14Vils4K9c",
-          "googleMapsUri": "https://maps.google.com/?cid=15504548107962899987&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "name": "レストランコートドール",
+          "address": "일본 〒064-0959 Hokkaido, Sapporo, Chuo Ward, Miyagaoka, 1-chōme−2−３８ レストランコートドール",
+          "description": "삿포로 마루야마 공원 인근, 이른바 삿포로의 청담동이라 불리는 거리에 자리한 클래식 프렌치 레스토랑으로, 이름인 코트도르(Côte d'Or)는 부르고뉴 레드 와인의 핵심 지역인 '황금의 언덕'을 뜻한다. 2017년 미쉐린 가이드 북해도 특별판에서 1스타를 받았으며, 바게트와 버터가 완벽하고 푸아그라 꽁피에 무화과 잼·브리오슈를 곁들이는 등 전형적이면서 정교한 프렌치 코스를 내놓는다. 홋카이도산 와규 안심에 프랑스산 포르치니와 꽁떼 치즈 라비올리를 얹은 메인(약 16,000엔)은 한 접시에 담긴 구성이 인상적이고, 셰리 비네거 소스를 곁들인 긴포튀김, 홍합·오이 소스의 플랑 등 북해도 산지를 적극 활용한 요리가 이어진다. 디저트는 계절 수플레와 코코넛 블랑망제 등 네 종에서 고를 수 있으며, 수플레는 갓 구워 부풀린 뒤 가운데 아이스크림을 넣어 먹는 올타임 페이보릿으로 꼽힌다. 가장 큰 매력은 와인 리스트로, 국제 소매가 대비 눈에 띄게 저렴한 명품 와인들이 남아 있어 더 이상 구할 수 없는 Domaine Leflaive Batard Montrachet 1999(화이트)와 Prieure Roch Clos de Beze 1996(레드, 플래그십) 같은 희귀 빈티지를 만날 수 있다. 기대를 저버리지 않는 음식에 환상적인 와인이 어우러진, 오래 기억에 남을 삿포로의 저녁이라는 평가다.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ylfG2fvn3K4",
-          "description": "일본 프렌치 레스토랑에서의 와인 경험을 소개하는 영상에서 방문한 삿포로의 레스토랑. 다시는 못 볼 줄 알았던 와인과의 운명적인 만남이 펼쳐진 곳으로, 와인 리스트가 훌륭하다."
+          "latitude": 43.058048799999995,
+          "longitude": 141.3121601,
+          "googleMapsId": "ChIJH5908cMpC18RSNyatFBNVz4",
+          "googleMapsUri": "https://maps.google.com/?cid=4492144162348129352&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "zFKDef6mDHY",
       "title": "인당 45만원, 와인만 250만원 나온 후덜덜한 일본 타베로그 TOP10 맛집! 과연 그 맛은? (feat. 깻잎에 싸주는 말고기🐎)[EN]ㅣACA",
-      "concept": "일본 와인 레스토랑",
+      "concept": "일본",
       "locations": [
         {
-          "name": "ACA",
-          "displayName": "la cocina de acá 1°",
+          "name": "Aca (아카)",
           "address": "일본 〒103-0002 Tokyo, Chuo City, Nihonbashimuromachi, 2-chōme−1−１ 三井二号館 1F",
+          "description": "도쿄 니혼바시무로마치 미츠이 2호관에 자리한 스페인 레스토랑 '아카(Aca)'로, 크리에이터가 '일본에서 최고로 핫한 스페인 레스토랑'이라 부르는 곳이다. 오픈 주방이라 셰프가 요리하는 과정을 실시간으로 볼 수 있으며, 숯불 직화를 기본으로 일본 와규와 해산물을 스페인 테크닉으로 풀어내는 스타일이다. 코스는 북방조개 직화 구이, 쉐리 와인 비네거로 산미를 잡은 킨메다이, 양젖으로 만든 만체고 치즈를 곁들인 은어(아유), 깻잎(시소) 향을 입힌 말고기 타르타르(함박 모양으로 굽고 계란 노른자를 올림), 하얀 돼지 하몽으로 우려낸 국물 등 독특한 구성으로 이어진다. 가고시마규 등심·안심은 겉 기름을 떼지 않고 통째로 숯향 가득 구워내고, 전복 내장(게우) 향이 폭발하는 전복죽, 비트 아이스크림과 페루 카카오 초콜릿·커피까지 디저트까지 갖춘 끝장코스다. 와인 리스트는 충격적일 정도로 비싸 Egly Ouriet 그랑크루 샴페인은 엄두도 내지 못했지만, 해외 시세의 2배 미만인 Domaine Ponsot Clos de La Roche 2015를 만날 수 있었다. 인당 약 5만 엔, 와인 2병에 약 250만 원이 나가는 만큼 특별한 날에 어울리는 파인다이닝이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zFKDef6mDHY",
           "latitude": 35.686865,
           "longitude": 139.7723438,
           "googleMapsId": "ChIJfy-g6MuLGGAR0jcF50OsA3A",
-          "googleMapsUri": "https://maps.google.com/?cid=8071484364816725970&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zFKDef6mDHY",
-          "description": "일본 타베로그 TOP10 맛집을 소개하는 영상에서 방문한 도쿄 니혼바시의 와인 레스토랑. 인당 45만원에 와인만 250만원이 나올 정도로 와인에 진심인 곳이며, 깻잎에 싸주는 말고기 요리가 유명하다."
+          "googleMapsUri": "https://maps.google.com/?cid=8071484364816725970&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "pn6xLx1HwJE",
       "title": "이름 내건 식당은 일단 맛 보장이 국룰🏅미쉐린 2스타를 이끌던 류지로 셰프가 차린 도쿄 고급 스시의 한끝차이ㅣ류지로",
-      "concept": "일본 스시/오마카세",
+      "concept": "일본",
       "locations": [
         {
-          "name": "류지로",
-          "displayName": "스시 류지로",
+          "name": "스시 류지로",
           "address": "일본 〒107-0062 Tokyo, Minato City, Minamiaoyama, 2-chōme−11−１１ ARISTO南青山 １階",
+          "description": "도쿄 미나미아오야마에 자리한 미쉐린 1스타 스시집으로, 류지로 상이 직접 미소를 띄우며 간결하게 스시를 쥐고 마무리에 향을 뿌려주는 퍼포먼스까지 겸하는 카운터와 세컨 셰프가 맡는 카운터 두 곳으로 운영된다. 외국인 예약이 비교적 수월해 한국인 방문 후기가 꽤 많은 편이며, 코로나 이후 오랜만에 찾은 도쿄 고급 스시의 밤을 다룬 영상이다. 츠마미는 야마가타 산 재료를 쓴 상큼한 사시미 모듬, 자연산 전복(밤·고구마 향), 빨판을 따로 내주는 문어 튀김으로 시작해 시마네현 민물장어(겉을 바삭하게 구움), 하모가 들어간 투명하고 탄력 있는 소면, 도톰하고 풍미 깊은 무늬오징어가 이어진다. 니기리에서는 산미가 좋아 '이날 가장 기억에 남는 한 점'이 된 가쓰오, 고급 스시집에서는 잘 나오지 않는 기름진 연어, 참치의 감·주도로·도로 등 새 살을 연달아 내 일본 현지의 참치 수준을 체감하게 한다. 성게의 퀄리티가 압도적이고, 아나고를 오이와 함께 김에 싸주는 스타일, 갓 구워 뜨겁게 내는 계란, 스시에서 드물게 쓰는 넙치 관자(추가 주문할 정도로 맛있었다)까지 구성이 세심하다. 전반적으로 재료가 압도적으로 좋아 맛있게 먹으면서도 한국 스시의 수준이 크게 올라왔음을 다시금 느끼게 하는 한 끼다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=pn6xLx1HwJE",
           "latitude": 35.6713126,
           "longitude": 139.7210433,
           "googleMapsId": "ChIJwaYqX1CNGGARY7CAGDEQOIE",
-          "googleMapsUri": "https://maps.google.com/?cid=9311210032639029347&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=pn6xLx1HwJE",
-          "description": "도쿄 고급 스시를 소개하는 영상에서 방문한 미나미아오야마의 스시집. 미쉐린 2스타를 이끌던 류지로 셰프가 자신의 이름을 걸고 차린 곳으로, 고급 스시의 한끝차이를 느낄 수 있다."
+          "googleMapsUri": "https://maps.google.com/?cid=9311210032639029347&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "aZbrrnUTjSU",
       "title": "간판없는 식당? 입소문으로만 찾아가야 하는 꼼꼼 숨겨진 일본 소고기 오마카세[EN]ㅣ미가키쇼 나가야마",
-      "concept": "일본 스시/오마카세",
+      "concept": "3-chōme-14-2",
       "locations": [
         {
-          "name": "미가키쇼 나가야마",
-          "displayName": "磨匠ながやま",
-          "address": "일본 〒107-0052 Tokyo, Minato City, Akasaka, 3-chōme−14−２ ドルミ赤坂 2階",
+          "name": "미가키쇼 나가야마 (牧之士長山)",
+          "address": "4-chōme-11-24 Akasaka, Minato City, Tokyo 107-0052 일본",
+          "description": "도쿄 아카사카 건물 2층에 자리한 '미가키쇼 나가야마'는 예약 손님만 받는 니쿠 갓포(소고기 오마카세) 전문점으로, 한때 화제를 모았던 '와규 마피아' 출신이 독립해 운영하는 히스토리를 가진 곳이다. 단순히 고기를 구워주는 야키니쿠가 아니라 일본 와규를 다양한 요리로 풀어내는 콘셉트로, 육사시미(양깃머리·심장·살치살을 날로), 안심 카츠산도, 염도 2.8%의 저염 캐비아를 올린 와규 타르타르, 수비드 안심추리에 소 기름과 우유로 만든 매쉬 포테이토와 호주산 윈터 트러플을 곁들이는 등 아이디어가 돋보인다. 이어 북해도산 우니를 듬뿍 올린 '성게 폭탄' 소바, 안심 샤토브리앙 튀김과 비와호 은어 튀김, 생후추를 더한 우설 구이('가장 맛이 다르다'며 만족), 에다마메 소스의 소고기 경단, 알등심까지 고기 부위별 매력을 촘촘히 보여준다. 마지막엔 계란 노른자를 얹은 간장 소고기 덮밥(살짝 안 비벼 먹는 게 낫다는 아쉬움)과 소 기름을 넣어 직접 만든 와라비 모찌 아이스크림으로 마무리하며, 젓가락을 닦는 티슈와 함께 젓가락을 선물로 챙겨주는 디테일도 인상적이다. 와인 리스트도 괜찮아 루이 로드레 크리스탈이 3만 엔대, 2010년 샤또네프 뒤 파프를 곁들일 수 있고, 인당 약 25만 원·와인 1병 약 30만 원 선이다. 같은 건물 앞에는 1624년부터 이어진 주류 전문점 '아카사카 요모'가 있어 식사 후 한 잔하기 좋다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=aZbrrnUTjSU",
           "latitude": 35.673862899999996,
           "longitude": 139.73738079999998,
-          "googleMapsId": "ChIJ7Zm7SwWLGGARUzBYPUz7JSs",
-          "googleMapsUri": "https://maps.google.com/?cid=3109167422634471507&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=aZbrrnUTjSU",
-          "description": "숨겨진 소고기 오마카세를 소개하는 영상에서 방문한 도쿄 아카사카의 레스토랑. 간판 없이 입소문으로만 찾아가야 하는 곳으로, 꼼꼼하게 숨겨진 와규 오마카세가 인상적이다."
+          "googleMapsId": "ChIJ_bCImn-MGGARzmY45JJFJEo",
+          "googleMapsUri": "https://maps.google.com/?cid=5342471555164694222&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
+          "geocodeWarning": "간판 없는 입소문 식당 - Places 미등록, 주소 기준 좌표"
         }
       ]
     },
     {
       "videoId": "1XZofgYeyUw",
       "title": "동에 번쩍 서에 번쩍하는 비밀이야가 호텔 고르는 꿀팁🌟[EN]ㅣ만다린 오리엔탈 도쿄",
-      "concept": "도쿄 럭셔리 호텔",
+      "concept": "2-chōme-1-1",
       "locations": [
         {
-          "name": "만다린 오리엔탈 도쿄",
-          "displayName": "만다린 오리엔탈 도쿄",
+          "name": "만다린 오리엔탈 도쿄 (Mandarin Oriental Tokyo)",
           "address": "2-chōme-1-1 Nihonbashimuromachi, Chuo City, Tokyo 103-8328 일본",
+          "description": "도쿄 니혼바시, 도쿄역에서 도보 거리에 자리한 만다린 오리엔탈 도쿄는 38층 로비를 품은 고층 럭셔리 호텔로, 맑은 날엔 객실에서 후지산이 보이고 도쿄 시내와 야경을 한눈에 내려다볼 수 있는 전망이 가장 큰 자랑이다. 넓은 욕실과 풍성한 어메니티, 웰컴 샴페인·과일·초콜릿·기프트, 편안한 침대와 스피커까지 세심한 디테일이 돋보이며, 지하 통로로 미츠코시 백화점 니혼바시 본점과 바로 이어지고 다카시마야·도쿄역도 가까워 쇼핑과 이동이 편리하다. 특히 음식에 진심인 호텔로 크고 작은 레스토랑이 무려 10개나 들어 있고, 삿포로 미야카와가 운영하는 '스시신'을 비롯해 스시·일식·이탈리안·프렌치·피자 바·스페인 타파스 바까지 갖추고 있다. 조식은 뷔페에 계란·프렌치토스트·와플·라멘 등 메인을 주문하는 방식이며, 생선과 치킨 육수를 섞은 시오라멘이 꽤 괜찮은 퀄리티로 나온다. 유명한 애프터눈 티는 2시간 제한으로 무한 리필 음료와 함께 브레게 콜라보 케이스 스탠드에 가리미+캐비아, 스모크샐몬+아스파라거스 샌드위치, 로스트비프, 스페인풍 오믈렛+판체타 트러플 소스, 사요리(학꽁치) 요리, 레몬 무스, 피스타치오·체리, 슈크림까지 정교하게 차려 나오며 한국인 직원이 한국어로 설명까지 해준다. 디럭스룸 1박 약 150만 원, 애프터눈 티 인당 약 1만 엔 수준으로, 좋은 호텔에서의 경험 자체가 여행의 일부가 되는 숙소라는 평가다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1XZofgYeyUw",
           "latitude": 35.6870475,
           "longitude": 139.7730634,
           "googleMapsId": "ChIJ281VfFWJGGARYaR_hmZuo0I",
-          "googleMapsUri": "https://maps.google.com/?cid=4801803014329312353&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=1XZofgYeyUw",
-          "description": "호텔 고르는 꿀팁을 소개하는 영상에서 방문한 도쿄 니혼바시의 럭셔리 호텔. 동에 번쩍 서에 번쩍하는 여행자를 위한 호텔 선택 기준이 영상에서 공유되었다."
-        }
-      ]
-    },
-    {
-      "videoId": "zuf53B4FMgI",
-      "title": "원두면 몰라도 우유를 골라 마시는 카페가 있다? 홋카이도 필수 카페 4곳 [EN]",
-      "concept": "홋카이도 카페 투어",
-      "locations": [
-        {
-          "name": "미야코시야 커피",
-          "displayName": "Miyakoshiya Coffee",
-          "address": "1, 28-chōme-1 Minami 2 Jōnishi, Chuo Ward, Sapporo, Hokkaido 060-0062 일본",
-          "latitude": 43.05410940000001,
-          "longitude": 141.315684,
-          "googleMapsId": "ChIJ3Uho0ukpC18R5WJsIlq_sx0",
-          "googleMapsUri": "https://maps.google.com/?cid=2140264641776607973&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zuf53B4FMgI",
-          "description": "홋카이도 필수 카페 4곳을 소개하는 영상에서 방문한 삿포로 마루야마의 클래식 커피 전문점. 원두보다 우유를 골라 마시는 독특한 컨셉의 카페 투어 중 하나로 소개되었다."
-        },
-        {
-          "name": "바리스타트 커피",
-          "displayName": "바리스타트 커피",
-          "address": "일본 〒060-0061 Hokkaido, Sapporo, Chuo Ward, Minami 1 Jōnishi, 4-chōme 第二ビル 1F 札幌市中央区南１条西４丁目８番地 NKC1-4",
-          "latitude": 43.0583246,
-          "longitude": 141.3513244,
-          "googleMapsId": "ChIJL6ONVJspC18Rl9-QN-T7Qh4",
-          "googleMapsUri": "https://maps.google.com/?cid=2180582127204097943&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zuf53B4FMgI",
-          "description": "홋카이도 필수 카페 4곳을 소개하는 영상에서 방문한 삿포로의 라떼 전문 카페. 우유를 골라 마실 수 있는 독특한 시스템이 특징이며, 홋카이도 우유의 다양한 맛을 즐길 수 있다."
-        },
-        {
-          "name": "산드리아",
-          "displayName": "산도리아",
-          "address": "9-chōme-758-14 Minami 8 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0808 일본",
-          "latitude": 43.049428299999995,
-          "longitude": 141.3457879,
-          "googleMapsId": "ChIJI2yh5YspC18RLAGjlDAyrXQ",
-          "googleMapsUri": "https://maps.google.com/?cid=8407431263604113708&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zuf53B4FMgI",
-          "description": "홋카이도 필수 카페 4곳을 소개하는 영상에서 방문한 삿포로의 24시간 샌드위치집. 가성비 좋은 샌드위치를 언제든 즐길 수 있으며, 카페 투어의 한 코스로 추천되었다."
-        },
-        {
-          "name": "카페 랑방",
-          "displayName": "카페 랑방",
-          "address": "5-chōme-20 Minami 3 Jōnishi, Chuo Ward, Sapporo, Hokkaido 060-0063 일본",
-          "latitude": 43.056446699999995,
-          "longitude": 141.3500799,
-          "googleMapsId": "ChIJEyIp4IQpC18RpKVcYyIzW8s",
-          "googleMapsUri": "https://maps.google.com/?cid=14653362035368961444&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=zuf53B4FMgI",
-          "description": "홋카이도 필수 카페 4곳을 소개하는 영상에서 방문한 삿포로 다누키코지 인근의 아침 카페. 아침 시간대에 방문하기 좋은 카페로, 홋카이도 카페 투어의 마무리로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=4801803014329312353&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "eodAIw3o50E",
       "title": "❄️영하 9도 삿포로에서 프라이빗하게 즐기는 료칸과 최고급 가이세키 식사ㅣ스이잔테이 클럽 [EN]",
-      "concept": "일본 료칸 방문기",
+      "concept": "2-chōme-2-10",
       "locations": [
         {
-          "name": "스이잔테이 클럽",
-          "displayName": "수이잔테이 클럽 조잔케이",
+          "name": "스이잔테이 클럽 조잔케이",
           "address": "2-chōme-2-10 Jōzankeionsennishi, Minami Ward, Sapporo, Hokkaido 061-2303 일본",
+          "description": "삿포로에서 차로 약 1시간 거리의 조잔케이 온천에 자리한 프라이빗 고급 료칸으로, 삿포로에서 가장 가까운 온천지라 접근성이 좋다. 전 세계에 두 곳뿐이라는 식물성 '모로 온천' 수질이 매끈하고 느낌이 좋아 목욕 자체가 즐겁고, 객실 수가 적어 한결 조용하다. 노천탕이 딸린 객실과 사우나·욕조를 갖춘 스위트룸 등 시설이 충실해 눈 내리는 겨울에는 노천탕에서 사케와 맥주를 칠링해 마시는 운치가 더해진다. 저녁 가이세키는 한식·양식·일식에 두루 정통한 셰프가 이끄는데, 안키모 자왕무시와 대구 이리 두부로 시작해 후구·새우·참치·북방조개 사시미에 성게와 털게, 전복 찜, 와규 안심 스테이크를 거쳐 밥과 디저트로 이어진다. 료칸치고는 사시미 양이 유난히 풍성하고, 고쿠류 준마이 다이긴죠 한 병이 약 5,000엔이라 사케 가격도 가성비가 좋다. 냉장고 음료와 바의 위스키 일부를 제외한 주류가 무료여서 늦은 밤 라운지에서 즐기기에도 좋다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=eodAIw3o50E",
           "latitude": 42.9718616,
           "longitude": 141.1658683,
           "googleMapsId": "ChIJd8VMBSfSCl8REvfyFPL_J6Y",
           "googleMapsUri": "https://maps.google.com/?cid=11972819549586388754&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=eodAIw3o50E",
-          "description": "삿포로 프라이빗 료칸을 소개하는 영상에서 방문한 조잔케이의 료칸. 영하 9도의 설경 속에서 프라이빗하게 최고급 가이세키 식사를 즐길 수 있는 곳이다."
+          "geocodeWarning": "displayName '수이잔테이 클럽 조잔케이' != '스이잔테이 클럽 조잔케이'; verify"
         }
       ]
     },
     {
       "videoId": "JO9Cqs4Cf-o",
       "title": "새우탕 찐하게 우려낸 국물 라멘 🦐 이거지...삿포로가면 꼭 들려야 할 두 곳ㅣ수프카레 사무라이&에비소바 이치겐 [EN]",
-      "concept": "삿포로 라멘/수프카레",
+      "concept": "일본",
       "locations": [
         {
           "name": "수프카레 사무라이",
-          "displayName": "로지우라 커리 사무라이 사쿠라점",
           "address": "일본 〒060-0063 Hokkaido, Sapporo, Chuo Ward, Minami 3 Jōnishi, 6-chōme−１−３ ティアラ36 2F",
+          "description": "스스키노 근처의 수프카레 전문점으로, 삿포로 여행 중 한 번은 꼭 들르게 되는 중독성 있는 맛을 선보인다. 야채·돼지고기·치킨 가라아게 등 들어가는 재료를 고르고, 국물 양과 맵기를 단계별로 선택하는 주문 방식이다. 매운맛 7~8단계쯤이면 신라면 한 끼 정도의 매쾌함이고, 온센 타마고를 터뜨려 밥을 말아 먹으면 추운 겨울 점심으로 제격이다. 매운맛이 캡사이신 계열이 아니라 커리 향신료의 스파이시라 얼큰하면서도 뒤끝이 개운하다. 비수기에는 줄 없이 들어가기도 해 숙소 가까이 있어 부담 없이 찾기 좋다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JO9Cqs4Cf-o",
           "latitude": 43.0557952,
           "longitude": 141.3498962,
           "googleMapsId": "ChIJDT3-FoUpC18RpIexpQUNUTg",
           "googleMapsUri": "https://maps.google.com/?cid=4058039057143400356&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JO9Cqs4Cf-o",
-          "description": "삿포로 라멘과 수프카레 맛집을 소개하는 영상에서 방문한 수프카레 전문점. 삿포로에 가면 꼭 들러야 할 곳 중 하나로 추천되었다."
+          "geocodeWarning": "displayName '로지우라 커리 사무라이 사쿠라점' != '수프카레 사무라이'; verify"
         },
         {
           "name": "에비소바 이치겐",
-          "displayName": "에비소바 이치겐",
           "address": "9-chōme-1024-10 Minami 7 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0807 일본",
+          "description": "신치토세 공항에도 입점해 관광객에게 익숙한 삿포로의 새우 라멘 명소로, 본점은 보통 30분~1시간 웨이팅이 있다. 국물은 새우 베이스의 '오리지날', 돼지뼈를 섞은 '모더레이트', 걸쭉하고 진한 '리치' 세 종류이고 양념은 미소·시오·쇼유 중에서 고른다. 새우를 튀겨 갈아 올려 '새우탕면 열두 배'라는 표현이 나올 정도로 임팩트가 강하고, 초행에는 진한 리치에 미소 조합을 추천한다. 얇은 면발에 양념이 잘 붙고, 교자를 곁들인 뒤 남은 국물에 밥을 말아 먹으면 마무리까지 든든하다. 웨이팅을 싫어하는 Creator도 삿포로에 오면 한 번씩 들를 만큼 본점만의 바이브와 맛이 확실하다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JO9Cqs4Cf-o",
           "latitude": 43.051269999999995,
           "longitude": 141.345472,
           "googleMapsId": "ChIJz4qGso4pC18R4wEprPFt2wE",
-          "googleMapsUri": "https://maps.google.com/?cid=133821498680476131&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JO9Cqs4Cf-o",
-          "description": "삿포로 라멘과 수프카레 맛집을 소개하는 영상에서 방문한 새우 라멘 전문점. 새우탕을 찐하게 우려낸 국물이 특징이며, 삿포로 방문 시 꼭 들러야 할 곳으로 추천되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=133821498680476131&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "ZyY6Hl555Ws",
       "title": "이 영상을 보시면 단번에 이해하실 수 있습니다ㅣ짧고 굵은 가심비 1등 스시집 소개🍣ㅣ스시미야카와 [EN]",
-      "concept": "일본 스시/오마카세",
+      "concept": "일본",
       "locations": [
         {
-          "name": "스시미야카와",
-          "displayName": "스시 미야카와",
+          "name": "스시 미야카와",
           "address": "일본 〒064-0824 Hokkaido, Sapporo, Chuo Ward, Kita 4 Jōnishi, 25-chōme−2−２ リヒトラーレ円山 1F",
+          "description": "삿포로의 미쉐린 3스타 스시집으로, 도쿄 3스타 '요시타케' 출신 셰프가 이끌어 정통 에도마에의 섬세함이 돋보인다. 새로 이전한 자리는 전보다 작고 아담하지만 코스의 완성도와 만족도는 오히려 단단해졌다. 백옥돈·어란·미나리 전채로 시작해 다금바리 샤브, 방어와 야마와사비, 와라야키 가쓰오, 에조 전복 내장 크림 소스를 거쳐 갑오징어·피조개 스시, 2주 숙성 삼치(이날의 베스트), 도요스 참치 뱃살, 고등어 봉초밥, 성게·김 스시, 장어까지 차례로 이어진다. 쥬욘다이와 아라마사 특별 버전 등 고급 사케를 코스 흐름에 맞춰 페어링할 수 있고, 예약만 된다면 무조건 한 번은 가볼 만큼 가성비도 갖췄다. 인당 약 25만 원, 주류는 인당 약 10만 원.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ZyY6Hl555Ws",
           "latitude": 43.0621249,
           "longitude": 141.3176119,
           "googleMapsId": "ChIJq6o2ZuopC18R-IYrrMOFUWI",
-          "googleMapsUri": "https://maps.google.com/?cid=7084590764284151544&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ZyY6Hl555Ws",
-          "description": "짧고 굵은 가심비 1등 스시집을 소개하는 영상에서 방문한 삿포로 마루야마의 스시집. 영상을 보면 단번에 이해할 수 있을 정도로 가심비가 뛰어난 곳이다."
+          "googleMapsUri": "https://maps.google.com/?cid=7084590764284151544&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "BGmaULQnWR0",
       "title": "맛&가성비 둘 다 잡은 카이센동 맛집 두 곳 추천!ㅣ우니 무라카미&사카나야노 다이도코로 [EN]",
-      "concept": "삿포로 카이센동",
+      "concept": "일본",
       "locations": [
         {
           "name": "우니 무라카미",
-          "displayName": "우니 무라카미",
           "address": "일본 〒060-0003 Hokkaido, Sapporo, Chuo Ward, Kita 3 Jōnishi, 4-chōme−1−１ 日本生命札幌ビル B1F",
+          "description": "성게로 유명한 하코다테 본점의 삿포로 분점으로, 삿포로역 인근 일본생명 빌딩 지하에 자리해 시장보다 깔끔한 분위기에서 카이센동을 즐길 수 있다. 삿포로 카이센동집 중 성게 퀄리티가 가장 좋은 곳으로 꼽히며, 카드 결제가 돼 현금 준비 부담이 없어 가족 단위 손님에도 편하다. 시그니처 우니동에는 성게 80g이 올라가고, 우니 이꾸라동·삼색동(우니·이꾸라·연어)·우니 그라탱까지 성게를 다양하게 즐길 수 있다. 여름철엔 성게 사이즈가 더 커지고, 니조시장 노점들과 달리 예쁘고 정갈하게 나와 사진을 찾는 손님이 많다. 다만 밥은 간을 하지 않은 맨밥이라 간장을 곁들여야 간이 맞는다. 인당 약 5만 원대.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BGmaULQnWR0",
           "latitude": 43.0648623,
           "longitude": 141.3499018,
           "googleMapsId": "ChIJ9a9vKJ4pC18RDdPwRNvPVPo",
-          "googleMapsUri": "https://maps.google.com/?cid=18038270948187099917&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BGmaULQnWR0",
-          "description": "맛과 가성비를 모두 잡은 카이센동 맛집을 소개하는 영상에서 방문한 삿포로의 우니 전문점. 성게를 전문으로 하며, 신선한 카이센동을 합리적인 가격에 즐길 수 있다."
+          "googleMapsUri": "https://maps.google.com/?cid=18038270948187099917&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
           "name": "사카나야노 다이도코로",
-          "displayName": "사카나야노 다이도코로 니조시장 본점",
           "address": "일본 〒060-0052 Hokkaido, Sapporo, Chuo Ward, Minami 2 Jōhigashi, 2-chōme−１０ 小西ビル １ 階",
+          "description": "니조시장 안에 자리한 카이센동 전문점으로, 시내에서 접근성이 좋아 관광객뿐 아니라 현지인도 자주 찾는다. 같은 체인이 중앙도매시장에도 있지만 이곳 니조시장점을 주로 찾으며, 현금만 받으니 미리 준비해야 한다. 시그니처는 성게와 연어알을 듬뿍 올린 우니 이꾸라동에 가리비 토핑을 얹은 조합이고, 통통하고 크리미한 생굴(개당 330엔)도 빼놓지 않는다. 식사 중 임연수 구이(홋케)를 한 마리 시키면 바삭한 껍질과 촉촉한 살이 남은 밥과 어울어져 든든한 한 끼가 된다. 시장 안이라 식사 전후로 건어물과 특산물 쇼핑까지 덤으로 즐길 수 있다. 인당 약 5만 원대.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BGmaULQnWR0",
           "latitude": 43.0587872,
           "longitude": 141.3588443,
           "googleMapsId": "ChIJ7wioW4IpC18RpY8ZVvVXm0o",
-          "googleMapsUri": "https://maps.google.com/?cid=5375987291419938725&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BGmaULQnWR0",
-          "description": "맛과 가성비를 모두 잡은 카이센동 맛집을 소개하는 영상에서 방문한 삿포로 니조시장의 카이센동 전문점. 시장 안에 위치해 신선한 해산물을 가성비 좋게 맛볼 수 있다."
+          "googleMapsUri": "https://maps.google.com/?cid=5375987291419938725&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "ILFK8cODr4U",
       "title": "징기스칸 양고기 타파할 최고 맛집 대공개🍖🪇ㅣ이타다끼마쓰&호르몬풍토 [EN]",
-      "concept": "삿포로 징기스칸(양고기)",
+      "concept": "5-chōme-1-6",
       "locations": [
         {
           "name": "이타다끼마쓰",
-          "displayName": "이타다키마스",
           "address": "5-chōme-1-6 Minami 5 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0805 일본",
+          "description": "스스키노에서 점심에 문을 여는 드문 징기스칸집으로, 북해도산 생 양고기를 부위별로 숙성해 구워 내는 것이 특징이다. 구글 평점은 가격이 비싸 다른 데보다 낮지만, 뉴질랜드산 냉동이 아닌 국산 생고기를 다양하게 맛볼 수 있어 양고기 애호가 사이에서 꼽히는 곳이다. 등심을 비롯해 허파(카파)·혓바닥·간·양깃머리 등 한정판 부위가 한글 메뉴판으로 주문할 수 있다. 고기를 구워 창난젓·깻잎·김치·감자와 곁들이고, 남은 밥에는 간장 소스를 찍어 양파·숙주와 함께 먹으면 좋다. 마지막에 양파를 넣고 끓인 양고기 수프가 소고기뭇국처럼 든든해 별미로 꼽힌다. 인당 약 7만 원.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ILFK8cODr4U",
           "latitude": 43.0539704,
           "longitude": 141.3519437,
           "googleMapsId": "ChIJkWU54IUpC18RILG14Mo_wmM",
           "googleMapsUri": "https://maps.google.com/?cid=7188378095822680352&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ILFK8cODr4U",
-          "description": "삿포로 징기스칸 양고기 맛집을 소개하는 영상에서 방문한 전문점. 징기스칸 양고기를 타파할 최고의 맛집으로 대공개되었으며, 양고기의 진수를 맛볼 수 있다."
+          "geocodeWarning": "displayName '이타다키마스' != '이타다끼마쓰'; verify"
         },
         {
           "name": "호르몬풍토",
-          "displayName": "화로구이 징기스칸 호르몬풍토 스스키노점",
           "address": "일본 〒064-0806 홋카이도 삿포로시 주오구 미나미 6 조니시 4 조메",
+          "description": "스스키노에서 밤늦게까지 문을 여는 현지인 밀착 고깃집으로, 징기스칸과 와규 야키니쿠, 호르몬을 한자리에서 모두 취급하는 독특한 구성이 강점이다. 영어·한글 메뉴판이 없어 현지 추천으로 찾는 곳이며, 의자 아래 옷 보관 공간이 있어 연기 냄새 걱정이 덜하다. 소고기 스지 오토시로 시작해 홍창·안창살·하라미·매콤한 양념 호르몬·진갈비살까지 고기 퀄리티가 먹을 만하고 가격도 합리적이다. 한국식 김치 세트와 육개장, 채수 간장 베이스의 냉면을 곁들이면 한국인 입맛에도 잘 맞는다. 해산물 위주 식사가 물릴 때 밤에 편하게 술 한 잔 더 하기 좋은 선택지다. 인당 약 4만 원.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ILFK8cODr4U",
           "latitude": 43.053794499999995,
           "longitude": 141.3535497,
           "googleMapsId": "ChIJR9aHw4UpC18Rwqk-Np2JogI",
-          "googleMapsUri": "https://maps.google.com/?cid=189865442615929282&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=ILFK8cODr4U",
-          "description": "삿포로 징기스칸과 호르몬을 소개하는 영상에서 방문한 스스키노의 화로구이 전문점. 징기스칸과 함께 호르몬(내장) 야키니쿠를 즐길 수 있는 곳이다."
+          "googleMapsUri": "https://maps.google.com/?cid=189865442615929282&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "YYhUDMpqnOY",
       "title": "겉바속촉 덴뿌라 진짜 잘하는 집은 따로 있다?! 🦐 미슐랭 투스타 단골집 [EN]ㅣ덴푸라아라키",
-      "concept": "일본 덴푸라",
+      "concept": "1-chōme-13-1",
       "locations": [
         {
-          "name": "덴푸라 아라키",
-          "displayName": "텐푸라 아라키",
+          "name": "덴푸라 아라키 (天ぷら あら木)",
           "address": "일본 〒064-0807 Hokkaido, Sapporo, Chuo Ward, Minami 7 Jōnishi, 4-chōme−１−２ 1F",
+          "description": "이 영상에서 다루는 곳은 미쉐린 2스타 덴푸라 아라키로, 삿포로 스스키노에 자리하며 북해도의 질 좋은 해산물과 채소로 최고 수준의 튀김 코스를 선보인다. 별 획득 전부터 단골이던 자리라 패기 넘치던 젊은 셰프가 어느덧 2스타의 아우라를 갖추었고, 홍콩 분점까지 낼 정도로 입지를 다졌다. 새우 머리 튀김, 레어와 미디움으로 나눠 내는 새우살, 무늬오징어, 어란·백합뿌리, 보리멸, 북방조개, 20분 튀긴 연근, 김 위의 성게, 삼치, 표고와 새우, 관자, 와사비 얹은 장어까지 재료마다 온도와 시간을 달리한다. 볶은 참기름을 곁들인 튀김옷에 스타치(영귤)·라임 소금을 찍고, 대합 국물과 해조류 국물로 입을 가신 뒤 텐차(튀김오차즈케)로 마무리한다. 1년에 고구마를 900kg 사 들여온다는 시그니처 고구마 튀김과 북해도 야마와사비의 향긋함이 코스를 빛낸다. 인당 약 21만 원, 주류는 약 7만 원. (참고: locations.json의 spot명은 인근 호텔명으로 잘못 추출된 것으로 보이며, 실제 영상 소재는 덴푸라 아라키 식당입니다.)",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YYhUDMpqnOY",
           "latitude": 43.0525053,
           "longitude": 141.3535794,
           "googleMapsId": "ChIJG79FOYYpC18ROd2h5DgUOG0",
-          "googleMapsUri": "https://maps.google.com/?cid=7870062583416479033&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=YYhUDMpqnOY",
-          "description": "삿포로 미슐랭 2스타 덴푸라를 소개하는 영상에서 방문한 전문점. 겉바속촉 덴뿌라를 진짜 잘하는 집으로, 영상 진행자의 단골집으로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=7870062583416479033&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "kwNgGM31Wn4",
       "title": "비밀이야가 오픈런하는 장어맛집?🏃🏻‍♂️사르르 녹는 장어와 맥주 한잔..🍺 [EN]ㅣ우나메이",
-      "concept": "삿포로 장어 맛집",
+      "concept": "27-chōme-3-3",
       "locations": [
         {
-          "name": "우나메이",
-          "displayName": "우나메이",
+          "name": "우나메이 (うなめい)",
           "address": "27-chōme-3-3 Kita 1 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0821 일본",
+          "description": "삿포로 마루야마 공원 인근에 자리한 장어 전문점 '우나메이'로, 비밀이야가 삿포로에 올 때마다 빠짐없이 들르는 가장 아끼는 식당 중 하나다. 11시 반 오픈과 동시에 자리가 차기 때문에 오픈런이 기본이고, 한번 들어오지 못하면 30~40분을 더 기다려야 하며 현금 결제만 가능하다. 맥주를 시키면 곁들여 나오는 장어뼈튀김, 오이와 장어를 초절임한 우자쿠, 한정판 장어 간 꼬치, 소금과 미림만으로 구운 시라야키, 청어알 와사비 무침, 채소 절임 오신코를 거쳐 마지막에 장어덮밥 '송'과 맑은 장어국이 이어진다. 도쿄·나고야식보다 양념이 약해 슴슴하면서도 깔끔한 것이 특징이며, 한국인이 좋아하는 바삭함보다는 찐 뒤 숯불 향으로 살짝 구운 일본 특유의 부드러운 식감을 즐길 수 있다. 산초를 솔솔 뿌려 먹으면 느끼함 없이 깔끔하게 장어 한 상을 마무리할 수 있어 부드러운 일본식 장어의 매력을 대표하는 곳이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kwNgGM31Wn4",
           "latitude": 43.0574494,
           "longitude": 141.31674669999998,
           "googleMapsId": "ChIJW3y2nsEpC18RjabZB_61zOo",
-          "googleMapsUri": "https://maps.google.com/?cid=16919098002782135949&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=kwNgGM31Wn4",
-          "description": "삿포로 장어 맛집을 소개하는 영상에서 방문한 마루야마의 장어 전문점. 영상 진행자가 오픈런할 정도로 좋아하는 곳이며, 사르르 녹는 장어와 맥주 조합이 인상적이다."
+          "googleMapsUri": "https://maps.google.com/?cid=16919098002782135949&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "LVbINarIdNA",
       "title": "삿포로의 함박 눈꽃 게살🌨️🦀있잖아요..저 너무 들떴어요 [EN] ㅣ카츠카니노 하나사키",
-      "concept": "삿포로 게요리",
+      "concept": "일본",
       "locations": [
         {
           "name": "카츠카니노 하나사키",
-          "displayName": "카츠카니노 하나사키",
-          "address": "일본 〒064-0805 Hokkaido, Sapporo, Chuo Ward, Minami 5 Jōnishi, 2-chōme−1−１ 美松村岡ビル 5Ｆ",
-          "latitude": 43.0543482,
-          "longitude": 141.3566687,
-          "googleMapsId": "ChIJc6VQuoYpC18RSdN7phs5lhc",
-          "googleMapsUri": "https://maps.google.com/?cid=1699608700298974025&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "address": "일본 〒064-0805 Hokkaido, Sapporo, Chuo Ward, Minami 5 Jōnishi, 2-chōme−１−１ 美松村岡ビル ５F",
+          "description": "스스키노 호스이역 인근에 위치한 2017년 미쉐린 북해도 특별판 원스타 게 요리 전문점으로, 킹크랩(하나사키 크랩)을 주력으로 하는 고급 관광 식당이다. 게 요릿집 중에서도 가장 비싼 축에 속하지만, 할아버지 셰프가 자리에서 킹크랩을 부위별로 직접 발라 사시미·구이·통구이 등 다채로운 조리법으로 선보인다. VIP 코스는 직화로 구운 250g짜리 대형 전복, 성게, 거대한 굴과 해삼 등의 전채에 이어 얼음물에 꽃처럼 핀 킹크랩 사시미, 익힘 정도를 달리한 다리살, 심장과 통킹크랩까지 이어지며, 마지막엔 리시리산 다시마 국물과 연어알(이꾸라) 밥, 레미 마르탱 XO를 뿌린 멜론 디저트로 마무리된다. 게를 직접 까먹는 수고 없이 먹기 좋게 발라주는 서비스가 인상적이며, 16분 삶기 등 디테일이 살아있는 인당 약 5만 엔짜리 킹크랩의 끝판왕 경험이다.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=LVbINarIdNA",
-          "description": "삿포로 게요리 맛집을 소개하는 영상에서 방문한 게살 전문점. 함박 눈꽃처럼 풍성한 게살 요리가 특징이며, 삿포로에서 꼭 맛봐야 할 게요리로 추천되었다."
+          "latitude": 43.0543444,
+          "longitude": 141.35666279999998,
+          "googleMapsId": "ChIJc6VQuoYpC18RSdN7phs5lhc",
+          "googleMapsUri": "https://maps.google.com/?cid=1699608700298974025&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "tbosSzVJGqw",
       "title": "역대급 야끼니꾸 맛집🔥안심에 버금가는 와규 부위는 어디일까? 애기보, 대창, 양깃머리까지 맛있는 집 [EN]ㅣ도쿄 킨류잔",
-      "concept": "일본 야끼니꾸",
+      "concept": "3-chōme-14-1",
       "locations": [
         {
           "name": "킨류잔",
-          "displayName": "Kinryūzan",
           "address": "3-chōme-14-1 Shirokane, Minato City, Tokyo 108-0072 일본",
+          "description": "도쿄 시로카네에 자리한 40년 이상 역사의 야키니쿠 명소로, 타베로그 야키니쿠 부문 최상위권(과거 1위, 현재 4위권)에 랭크된 사실상 예약 불가 식당이다. 단골 위주로만 운영되어 신규 예약은 받지 않고, 단골조차 다음 예약까지 6개월을 기다려야 할 정도로 인기가 높다. 같은 집안에서 운영하는 아카사카 '라이몬'은 예약 텀이 1년 6개월에 달할 만큼 일본 야키니쿠를 대표하는 가게로 꼽힌다. 전날 도축한 신선한 암소 와규를 주로 쓰며, 소금·후추만 양념한 우설을 레몬즙과 파랑에 싸 먹는 것을 시작으로, 법상 생식이 불가능해 살짝 익혀 내는 간, 샤토브리앙(안심 중앙부)·리브로스(등심)·신신(도가니살)·토시살·하라미로 구성된 와규 모듬, 코부쿠로·양깃머리·기름 제거 대창의 호르몬 세트가 이어진다. 특히 간의 맛에 크게 감탄했고, 와규 특유의 과한 느끼함 대신 향과 깊은 맛이 살아 있어 최고의 한우가 떠오를 만큼 인상적이었다. 소꼬리 뭇국과 김치가 곁들여지며 야마자키 12년 하이볼을 함께 즐기는 인당 약 15만 원 코스다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tbosSzVJGqw",
           "latitude": 35.645340999999995,
           "longitude": 139.72829099999998,
           "googleMapsId": "ChIJ_ePZ4AiLGGARHaUyRzvWWfk",
           "googleMapsUri": "https://maps.google.com/?cid=17967627738457220381&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tbosSzVJGqw",
-          "description": "역대급 야끼니꾸 맛집을 소개하는 영상에서 방문한 도쿄 시로카네의 전문점. 안심에 버금가는 와규 부위부터 애기보, 대창, 양깃머리까지 다양한 부위를 맛볼 수 있다."
-        }
-      ]
-    },
-    {
-      "videoId": "brRcKWhPkKw",
-      "title": "작은 마을 하나를 섭렵해 보았습니다 [마쓰야마 투어 2편][EN]ㅣ오마카세, 프렌치 레스토랑",
-      "concept": "마쓰야마 미식 투어",
-      "locations": [
-        {
-          "name": "키요미즈",
-          "displayName": "카이세키 해산물 일식 레스토랑 키요미즈 마쓰야마 에히메",
-          "address": "1-chōme-5-16 Nibanchō, Matsuyama, Ehime 790-0002 일본",
-          "latitude": 33.8394354,
-          "longitude": 132.77393279999998,
-          "googleMapsId": "ChIJn-shGe_lTzURq9zNCP-QjOE",
-          "googleMapsUri": "https://maps.google.com/?cid=16252524580312046763&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=brRcKWhPkKw",
-          "description": "마쓰야마 미식 투어 2편에서 방문한 오마카세 레스토랑. 작은 마을 하나를 섭렵하는 코스 중 하나로, 미쉐린 1스타 수준의 가이세키 요리가 인상적이다."
-        }
-      ]
-    },
-    {
-      "videoId": "SLEXVgPrklk",
-      "title": "물건 제대로 건졌다🐟 비주얼에 한번 맛에 두번 감탄하는 가성비 갑 오마카세 [EN]ㅣDogo Kaishu",
-      "concept": "일본 스시/오마카세",
-      "locations": [
-        {
-          "name": "도고 카이슈",
-          "displayName": "도고 카이슈",
-          "address": "15-15番27号 Dōgoyunomachi, Matsuyama, Ehime 790-0842 일본",
-          "latitude": 33.8519556,
-          "longitude": 132.78438269999998,
-          "googleMapsId": "ChIJg5YFy-7lTzURIgAtnzprbPU",
-          "googleMapsUri": "https://maps.google.com/?cid=17684627736299896866&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SLEXVgPrklk",
-          "description": "마쓰야마 도고 온천의 오마카세를 소개하는 영상에서 방문한 가성비 맛집. 비주얼에 한번 맛에 두번 감탄하는 가성비 갑 오마카세로, 물건을 제대로 건졌다는 극찬을 받았다."
-        }
-      ]
-    },
-    {
-      "videoId": "QRDDx31HolM",
-      "title": "미식 투어는 이렇게 하는 거에요🤫 17시간 강행군 [마쓰야마 투어 1편] [EN]ㅣ야키토리, 우동, 사케, 길거리먹방",
-      "concept": "마쓰야마 미식 투어",
-      "locations": [
-        {
-          "name": "토리이즈미",
-          "displayName": "Yakitoritoriizumi",
-          "address": "3-chōme-2-22 Nibanchō, Matsuyama, Ehime 790-0002 일본",
-          "latitude": 33.838903,
-          "longitude": 132.7694544,
-          "googleMapsId": "ChIJ35_DkO3lTzUREShn9thpEPQ",
-          "googleMapsUri": "https://maps.google.com/?cid=17586672925449594897&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=QRDDx31HolM",
-          "description": "마쓰야마 미식 투어 1편에서 방문한 야키토리 전문점. 17시간 강행군 미식 투어의 일부로, 야키토리와 사케, 우동 등 다양한 음식을 즐기는 코스에 포함되었다."
+          "geocodeWarning": "displayName 'Kinryūzan' != '킨류잔'; verify"
         }
       ]
     },
     {
       "videoId": "qGhQRyw6IRE",
       "title": "(EN) 이런 초대형 아스파라거스 요리 본 적 있어요? 프랑스 본점에서 건물, 인테리어, 음식, 와인리스트까지 그대로 들여온 이곳 ㅣ L’Auberge de L’ill",
-      "concept": "일본 와인 레스토랑",
+      "concept": "28-chōme-3-1",
       "locations": [
         {
-          "name": "L'Auberge de L'ill",
-          "displayName": "L'Auberge de L'ill Sapporo",
+          "name": "오베르주 드 릴 (L Auberge de L il)",
           "address": "28-chōme-3-1 Minami 1 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0801 일본",
+          "description": "마루야마 공원 앞에 자리한 미쉐린 원스타 프렌치 '오베르주 드 릴'로, 프랑스 알자스에서 1967년부터 50년 넘게 쓰리스타를 유지했던 전설의 레스토랑을 건물·인테리어·요리·와인 리스트까지 그대로 재현한 분점 격 식당이다. 코스는 아뮤즈(양파 포타주, 알자스식 타르트 플람베)로 시작해 아마에비와 블러드 오렌지·허브 캐비어 전채, 청어 소스를 곁들인 화이트 아스파라거스 파이, 워터크레송 벨루떼의 가리비, 봄 채소를 곁들인 삼치 팬프라이, 모렐 버섯과 뱅존 소스의 송아지 비리까지 이어지는 정통 클래식 프렌치 구성이다. 식자재는 북해도산 최상품을 적극 활용해 가리비와 화이트 아스파라거스의 퀄리티가 유독 돋보였고, 소스를 즉석에서 자글자글 끓여내는 기본기가 인상적이었다. 알자스 와인 리스트가 풍성해 몽라쉐 프르미에 크루 끌라바용 2019나 20년 숙성된 도멘 드 슈발리에 블랑 등 한국에서는 구하기 힘든 와인을 합리적인 가격에 마실 수 있어, 북해도 프렌치의 수준을 보여주는 최고의 선택이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=qGhQRyw6IRE",
           "latitude": 43.0548885,
           "longitude": 141.314502,
           "googleMapsId": "ChIJ3cVpe8IpC18R9_v6oY2YRh8",
-          "googleMapsUri": "https://maps.google.com/?cid=2253656397620902903&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=qGhQRyw6IRE",
-          "description": "일본 와인 레스토랑을 소개하는 영상에서 방문한 삿포로의 프렌치 레스토랑. 프랑스 본점에서 건물, 인테리어, 음식, 와인리스트까지 그대로 들여온 곳으로, 초대형 아스파라거스 요리가 인상적이다."
+          "googleMapsUri": "https://maps.google.com/?cid=2253656397620902903&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "pmOL-N9ZgYQ",
       "title": "(EN) 일본에서 가장 먼저 찾게 되는 삿포로 미슐랭 투스타 술집🐟🍶 비밀이야가 이토록 사랑하는 이유는? l 슈보신센",
-      "concept": "일본 미슐랭 맛집",
+      "concept": "3-chōme-6-22",
       "locations": [
         {
-          "name": "슈보신센",
-          "displayName": "슈보신센",
+          "name": "슈보신센 (酒房しんせん)",
           "address": "3-chōme-6-22 Minami 6 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0806 일본",
+          "description": "삿포로에 위치한 미쉐린 투스타 일본 요리 술집으로, 비밀이야가 홋카이도에서 가장 사랑하는 식당으로 꼽는 곳이다. 코로나 이후 첫 일본 여행에서 첫 식당으로 선택했을 만큼 애정이 깊고, 3년 만에 부모님을 모시고 다시 찾았는데도 노장 셰프가 손을 잡으며 따뜻하게 맞아주는 정이 넘치는 집이다. 고래 볼살(밍크고래), 김기 어묵 국물, 한치 회, 시샤모·명란·소라·밤콩·감자 같은 북해도 특산물 전채, 꽃새우·새치·가리비·돌돔 회, 좋은 버터를 얹은 그린 아스파라가스 조개 구이, 봄 털게와 와사비 잎, 굵은 죽순 오징어 등 그때그때 가장 좋은 재료만 골라 내준다. 정미도 18% 도수 15~16도의 한정판 사케와 나라산 하루식가라 사케 다이긴죠 등 취향 좋은 주류가 어우러져 와도 와도 새로운 메뉴가 나오며, 가격은 재료 시세에 따라 만 몇천 엔에서 2만 5천 엔까지 천차만별이라 셰프를 온전히 믿고 맡기면 된다. 따뜻한 옹로(녹차)와 딸기 디저트까지 마치면 맨정신으로 나오기 아쉬운, 노장의 손맛이 살아있는 곳이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=pmOL-N9ZgYQ",
           "latitude": 43.0534939,
           "longitude": 141.35475409999998,
           "googleMapsId": "ChIJyYryYYYpC18RMnPzPXVoq6Y",
-          "googleMapsUri": "https://maps.google.com/?cid=12009807684073386802&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=pmOL-N9ZgYQ",
-          "description": "삿포로 미슐랭 2스타 술집을 소개하는 영상에서 방문한 곳. 일본에서 가장 먼저 찾게 되는 삿포로 단골집으로, 영상 진행자가 이토록 사랑하는 이유가 상세히 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=12009807684073386802&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "vSNU8_Aft-M",
       "title": "홋카이도를 대표하는 고급 생선 홍살치🐟",
-      "concept": "삿포로 해산물 맛집",
+      "concept": "4-chōme-2-18",
       "locations": [
         {
-          "name": "슈안 고다이",
-          "displayName": "슈안 고다이",
+          "name": "酒庵 五醍 (슈안 고다이)",
           "address": "4-chōme-2-18 Minami 7 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0807 일본",
+          "description": "삿포로 스스키노 안쪽 골목(덴뿌라 아라키 인근)에 자리한 로바다야끼 집으로, 저녁 식사 후 해산물과 채소를 숯불에 구워 가볍게 술 한잔하기 좋은 분위기의 식당이다. 시그니처는 북해도를 대표하는 고급 생선 김기로, 말려 살짝 구워 내는데 한 마리에 5~8천 엔을 호가하지만 기름지면서도 촉촉하고 감칠맛이 폭발해 비싼 값을 금방 알게 된다. 손바닥보다 큰 가리비 구이, 오랫동안 말려 훈제한 통굴, 어디서나 무난하게 맛있는 임연수(시샤모) 등 해산물과 표고버섯·감자·고구마 같은 북해도 채소 구이가 줄을 잇는다. 일반적인 노포형 로바다야끼와는 달리 작고 아늑한 분위기로, 삿포로에서 저녁을 먹고 2차를 할 때 술맛과 안주를 다 잡고 싶을 때 발길이 저절로 향하게 되는 곳이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vSNU8_Aft-M",
           "latitude": 43.052458699999995,
           "longitude": 141.353182,
           "googleMapsId": "ChIJzSGXPIYpC18Rj40TAu66qWw",
-          "googleMapsUri": "https://maps.google.com/?cid=7829994958560136591&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vSNU8_Aft-M",
-          "description": "홋카이도 고급 생선을 소개하는 영상에서 방문한 삿포로의 해산물 레스토랑. 홋카이도를 대표하는 고급 생선 홍살치를 맛볼 수 있는 곳이다."
+          "googleMapsUri": "https://maps.google.com/?cid=7829994958560136591&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Suage+",
-          "displayName": "수프카레 스아게+",
+          "name": "Suage+ (스아게 플러스)",
           "address": "일본 〒064-0804 Hokkaido, Sapporo, Chuo Ward, Minami 4 Jōnishi, 5-chōme−６−１ 都志松ビル ２階",
+          "description": "삿포로 수많은 수프카레 명소 중 한 손에 꼽히는 인기집으로, 밤 9시가 넘어도 긴 웨이팅이 이어지며 본점이 가득 차면 늦게까지 여는 지점으로 돌리곤 한다. 주문은 카레 베이스(치킨·램·해산물·스페셜 콜)를 고른 뒤 수프(오징어 먹물·새우 등), 매운맛 10단계, 밥 양, 토핑 순으로 조립하는 방식이다. 훌륭한 사이즈의 굴과 1번 크리스피 치킨, 소시지·돼지고기·닭고기가 모두 들어간 스페셜 콜을 추천하며, 매운 단계 6~8단계쯤이 얼큰하게 가장 잘 어울린다. 수프카레는 고기 요리라기보다 진한 국물과 좋은 북해도 채소를 함께 즐기는 음식이라, 밥을 말아 먹으면 해장으로도 훌륭하다. 삿포로 특유의 걸쭉하고 지방기 있는 미소라멘 문화와 맞닿아 있어, 추운 밤에 한 그릇을 비우면 몸이 훈훈해지는 기분 좋은 식사다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vSNU8_Aft-M",
           "latitude": 43.0557369,
           "longitude": 141.3512699,
           "googleMapsId": "ChIJv0HGVIQpC18Rc2m8zsIZwJE",
           "googleMapsUri": "https://maps.google.com/?cid=10502422655510800755&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vSNU8_Aft-M",
-          "description": "삿포로 해산물 맛집을 소개하는 영상에서 함께 방문한 수프카레 전문점. 삿포로 대표 음식인 수프카레를 맛볼 수 있는 인기 맛집이다."
+          "geocodeWarning": "displayName '수프카레 스아게+' != 'Suage+ (스아게 플러스)'; verify"
         }
       ]
     },
     {
       "videoId": "m5uPotCxv2Y",
       "title": "삿포로에서 2차 가기 좋은 곳 대방출✌",
-      "concept": "삿포로 2차 맛집",
+      "concept": "5-chōme-5",
       "locations": [
         {
-          "name": "Bird Watching",
-          "displayName": "버드 워칭",
+          "name": "버드와칭 (バードウォッチング)",
           "address": "5-chōme-5-5 Minami 4 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0804 일본",
+          "description": "삿포로 스스키노에 위치한 '버드와칭'으로, 프렌치 야키토리와 내추럴 와인을 결합한 독특한 컨셉의 술집이자 3층까지 규모를 갖춘 곳이다. 코로나 전부터 2차로 자주 들르던 단골 가게이며, 야키돈(꼬치구이) 실력이 삿포로에서 손꼽히는 수준이라고 평가한다. 하츠(닭심장), 닭똥집, 토마토 베이스 내장 요리인 트리바, 닭날개 등 꼬치를 바게트와 곁들여 즐기며, 트러플 향의 야키토리도 잘 어울린다. 와인 리스트는 폭이 넓어 올리사 골드 같은 고급 샴페인부터 가성비 좋은 내추럴 와인까지 한국 대비 3분의 1 수준의 가격에 마실 수 있고, 프랑스 요리 대회 출신의 거장 폴 보큐즈가 머무는 동안 들렀다는 일화가 있을 정도로 요리인들 사이에서도 알려진 집이다. 삿포로 밤의 2차 코스로 무난하게 추천할 만한 곳이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=m5uPotCxv2Y",
           "latitude": 43.0558104,
           "longitude": 141.3514543,
           "googleMapsId": "ChIJ8czIVIQpC18RhmCueDq-j28",
-          "googleMapsUri": "https://maps.google.com/?cid=8038853018221699206&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=m5uPotCxv2Y",
-          "description": "삿포로에서 2차 가기 좋은 곳을 소개하는 영상에서 추천된 바. 삿포로 밤문화를 즐기기 좋은 곳으로, 2차로 가볍게 들르기 좋은 분위기가 특징이다."
+          "googleMapsUri": "https://maps.google.com/?cid=8038853018221699206&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "라멘 신게츠",
-          "displayName": "라멘신게츠",
+          "name": "ラーメン信月 (라멘 신게츠)",
           "address": "일본 〒064-0805 Hokkaido, Sapporo, Chuo Ward, Minami 5 Jōnishi, 3-chōme Ｎ・グランデビル １階",
+          "description": "삿포로 라멘 요코초 골목에 자리한 미쉐린 비빌구르만 라멘집으로, 10석 남짓한 아담한 규모지만 밤이 되면 긴 줄이 생기는 해장의 성지다. 삿포로 특유의 걸쭉하고 느끼한 미소라멘과 달리 맑은 시오(소금) 육수를 베이스로 삼으며, 그 위에 생강을 듬뿍 올린 '쇼가 라면'이 대표 메뉴다. 고춧가루를 풀고 꼬들꼬들한 면발로 바꾸면 매콤하고 깔끔하게 한 그릇을 비울 수 있어 미소라멘에 질린 사람에게 특히 추천된다. 가게 전체가 매우 깨끗하게 관리되는 점도 인상적이며, 1차 술자리 이후 가볍게 들를 때 가장 먼저 떠오르는 곳이다. 곁들인 작은 볶음밥도 기름에 달달 잘 볶아 나와 든든한 마무리로 좋다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=m5uPotCxv2Y",
           "latitude": 43.054911399999995,
           "longitude": 141.3544669,
           "googleMapsId": "ChIJEeGUJoQpC18ROjXHTdFaoBQ",
-          "googleMapsUri": "https://maps.google.com/?cid=1486287732031829306&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=m5uPotCxv2Y",
-          "description": "삿포로에서 2차 가기 좋은 곳을 소개하는 영상에서 추천된 라멘집. 술 마신 후 마무리로 먹기 좋은 라멘 맛집으로 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=1486287732031829306&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "징기스칸 라무",
-          "displayName": "라무",
+          "name": "ジンギスカン ラム (징기스칸 라무)",
           "address": "4-chōme-2-7 Minami 7 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0807 일본",
+          "description": "삿포로 스스키노의 징기스칸(양고기 구이) 전문점으로, 한국 방송에 소개된 뒤 한국인 방문객 비중이 유난히 높은 곳이다. 호주산·아이슬란드산·뉴질랜드산은 물론 홋카이도산 등심과 양설·내장, 램 찹 꼬치와 양고기 소시지까지 부위와 산지가 다양해 선택의 폭이 넓고, 무엇보다 궂은 날씨에도 실내에서 웨이팅할 수 있어 편리하다. 두부 모양의 징기스칸 팬에 양기름을 두르고 고기와 함께 양파·숙주를 구워 먹으며, 홋카이도산 등심은 호주산의 약 두 배 가격이지만 그만큼 부위가 좋다. 다 구워진 뒤에는 밥에 김치·창란젓·청란젓·고추절임·양파를 얹어 한국식으로 한 입 먹는 식사가 일품이며, 미소 된장국과 산초 꽃게 절임을 곁들이면 느끼함 없이 든든하게 즐길 수 있다. 중간 가격대에 자리해 비싼 비 치즈와 저렴한 다루마 사이에서 무난한 선택지다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=m5uPotCxv2Y",
           "latitude": 43.0520795,
           "longitude": 141.3528412,
           "googleMapsId": "ChIJYeBcJoYpC18R3lFRGnbLUKM",
-          "googleMapsUri": "https://maps.google.com/?cid=11768129534427222494&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=m5uPotCxv2Y",
-          "description": "삿포로에서 2차 가기 좋은 곳을 소개하는 영상에서 추천된 징기스칸 전문점. 삿포로의 밤을 즐기며 가볍게 양고기를 맛볼 수 있는 곳이다."
+          "googleMapsUri": "https://maps.google.com/?cid=11768129534427222494&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "BnpEQIAGbUM",
       "title": "여기는 재료 퀄리티로 승부 보는 식당입니다🍣",
-      "concept": "일본 맛집 방문기",
+      "concept": "일본",
       "locations": [
         {
-          "name": "마루즈시",
-          "displayName": "마루즈시",
+          "name": "○鮨 (마루즈시)",
           "address": "일본 〒064-0806 Hokkaido, Sapporo, Chuo Ward, Minami 6 Jōnishi, 4-chōme−４ ライトビル １F",
+          "description": "삿포로 스즈키노에 자리한 스시집으로 '마루스시'라는 이름으로도 알려져 있으며 2017 미쉐린 가이드 북해도 특별판에서 1스타를 받았다. 비밀이야가 일본에서 가장 많이 방문한 식당으로 2010년 첫 방문 이후 10번이 넘게 찾았고, 원래 아버지와 아들 둘이 운영하다 2015년 아버지가 하와이로 떠난 뒤 아들이 가게를 이어받았다. 섬세함보다는 북해도의 훌륭한 재료를 '융단폭격'처럼 쏟아내는 스타일로, 스시미야카와와 대척점에 있으면서도 테마미 안주가 훌륭해 술 마시기 좋은 편안한 분위기다. '바다의 우유'라 불리는 아직 전갱이(광어)는 크리미하고 고소해 거의 생크림 수준이고, 참치 대뱃살 오도로·중뱃살, 사이즈 큰 문어, 촉촉하게 숙성한 전어, 찐 듯 부드러운 아나고, 달달한 계란까지 북해도 재료의 맛을 고스란히 느낄 수 있다. 1년에 서너 번, 때로는 혼자 오거나 대관해서 찾는 단골 집이며, 하와이로 떠난 예전 셰프님이 일부러 들러 7년 만에 다시 만났던 일도 특별한 기억으로 남는다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BnpEQIAGbUM",
           "latitude": 43.0528633,
           "longitude": 141.3525359,
           "googleMapsId": "ChIJs-ElEYYpC18RaFO6-vyg98k",
-          "googleMapsUri": "https://maps.google.com/?cid=14553277729269764968&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=BnpEQIAGbUM",
-          "description": "재료 퀄리티로 승부하는 식당을 소개하는 영상에서 방문한 삿포로의 스시집. 맛있는 거 다음 맛있는 거가 나오는 곳으로, 재료의 신선도와 퀄리티가 압도적이다."
+          "googleMapsUri": "https://maps.google.com/?cid=14553277729269764968&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "_1-2klFGMw8",
       "title": "클래식한 음식으로 35년 동안 자리를 지킬 수 있었던 이유🤫",
-      "concept": "일본 맛집 방문기",
+      "concept": "일본",
       "locations": [
         {
-          "name": "Le Gentilhomme",
-          "displayName": "Le Gentilhomme",
+          "name": "Le Gentilhomme (장띠옴므)",
           "address": "일본 〒064-0804 Hokkaido, Sapporo, Chuo Ward, Minami 4 Jōnishi, 8-chōme−２−１−３ サンプラーザ札幌 1F",
+          "description": "삿포로 스즈키노 끝자락에 위치한 프렌치 레스토랑으로 1988년에 문을 열어 북해도 최초의 고급 레스토랑 중 하나로 꼽힌다. 셰프는 기싸부아나·트루아 등 프랑스 유명 식당에서 경력을 쌓았고 2012년 미쉐린 특별판 1스타를 받았다가 2017년 별을 잃었지만, 35년째 같은 자리에서 클래식 프렌치를 고집하며 '결코 올드하지 않다'는 평을 듣는다. 가장 큰 자랑은 북해도는 물론 일본 전체를 통틀어 손꼽히는 와인 리스트로, 1900년대 띠피트·마고·앙리 자이 등 올드 빈티지 보르도와 1986년 로버트파커 100점 보르도, 숙성된 DRC 잔 와인까지 갖추고 있어 프랑스 현지와 비교해도 손색이 없을 정도다. 점심은 아뮤즈부터 차가운·뜨거운 전채, 생선, 고기, 디저트까지 약 7만원, 와인 포함 스페셜 코스는 11~12만원대로 가성비가 뛰어나다. 포아그라 테린, 아메리칸 소스의 해산물 라비올리(가리비·관자·북방조개·대구 시라코), 브레이징 소고기 스테이크 등 정통 기법의 요리가 나오며 메인은 양고기를 추천한다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=_1-2klFGMw8",
           "latitude": 43.054478599999996,
           "longitude": 141.3464923,
           "googleMapsId": "ChIJUZbDmI8pC18RGusGnj4jaOk",
-          "googleMapsUri": "https://maps.google.com/?cid=16818731560261315354&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=_1-2klFGMw8",
-          "description": "35년 전통 프렌치 레스토랑을 소개하는 영상에서 방문한 삿포로의 클래식 프렌치. 클래식한 음식으로 35년 동안 자리를 지킬 수 있었던 이유가 영상에서 소개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=16818731560261315354&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "Bm0e98UsIYA",
       "title": "맛있는 거 다음 맛있는 거 🍣",
-      "concept": "일본 맛집 방문기",
+      "concept": "일본",
       "locations": [
         {
-          "name": "스시 히데타카",
-          "displayName": "Sushi Hidetaka",
+          "name": "寿し ひでたか (스시 히데타카)",
           "address": "일본 〒064-0807 Hokkaido, Sapporo, Chuo Ward, Minami 7 Jōnishi, 4-chōme 1F",
+          "description": "삿포로 스즈키노의 스시집으로 2017 미쉐린 가이드 북해도 특별판에서 1스타를 받았으며, 다른 곳에서 보기 힘든 개성 있는 츠마미와 저렴하고 다양한 사케 리스트가 특징이다. 2019년 첫 방문 이후 코로나로 3년 만에 다시 찾았고, 셰프는 요리 중에는 말을 걸어도 못 들을 정도로 집중도가 높다. 한반도에서 온 쫄깃한 전복, 머리 내장을 된장에 섞어 낸 진한 단새우, 큐슈에서 잡아 2주 숙성한 20kg짜리 다금바리, 사이즈 어마어마한 문어 등 인상적인 재료가 이어진다. 참치는 아오모리 230kg짜리 5만엔급을 아카미와 오도로로 내고, 고등어는 가운데 부분을 버리고 제일 맛있는 부분만 쥐어주는 식으로 그날 가장 맛있는 것을 10접 안팎으로 엄선해 낸다. 사케도 다양하고 가격이 착해 스시와 함께 술을 즐기는 이에게 잘 어울리며, 비밀이야는 1년에 한 번쯤은 꼭 찾고 싶은 집으로 꼽는다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Bm0e98UsIYA",
           "latitude": 43.0525482,
           "longitude": 141.35363239999998,
           "googleMapsId": "ChIJl2M3OYYpC18Ryn1TYf8S6z4",
           "googleMapsUri": "https://maps.google.com/?cid=4533738337937358282&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Bm0e98UsIYA",
-          "description": "삿포로 스시 맛집을 소개하는 영상에서 방문한 곳. 맛있는 거 다음 맛있는 거가 계속 나오는 스시집으로, 삿포로 스시의 수준을 보여주는 곳이다."
+          "geocodeWarning": "displayName 'Sushi Hidetaka' != '寿し ひでたか (스시 히데타카)'; verify"
+        }
+      ]
+    },
+    {
+      "videoId": "rMu6RFdC038",
+      "title": "삿포로의 투스타 튀김 오마카세",
+      "concept": "일본",
+      "locations": [
+        {
+          "name": "天ぷら あら木 (텐푸라 아라키)",
+          "address": "일본 〒064-0807 Hokkaido, Sapporo, Chuo Ward, Minami 7 Jōnishi, 4-chōme−１−２ 1F",
+          "description": "삿포로 스즈키노의 튀김집으로 2017 미쉐린 가이드 북해도 특별판에서 2스타를 받으며 '혜성처럼' 나타난 곳으로, 예약이 매우 어려워 한 달 반 전에 문의해도 저녁 자리를 잡지 못할 정도다. 마침 점심 영업을 시작한 참에 특별히 자리를 만들어줘 방문할 수 있었고, 점심은 저녁보다 간소화된 오마카세 구성으로 인당 약 7만원이며 코로나 전 저녁이 1만5천~1만6천엔이던 것과 비교해도 합리적이다. 꽁치를 숯불로 살짝 익혀 무·김과 내고, 새우는 머리부터 몸통까지 라임·소금·덴츠 소스로 바삭하고 폭신하게 튀겨내며 야간다니시끼 다음으로 각광받는 아이아마·보리멸치 등 인상적인 생선이 이어진다. 해산물 튀김도 훌륭하지만 특히 채소가 백미로, 연근·호박·카미카와 감자 등 채소를 좋아하지 않는 사람도 반하게 만드는 섬세함이 돋보인다. 마무리는 고구마 튀김과 수제 아이스크림을 결합한 시그니처 디저트로, 구하기 힘든 '히로키' 사케와 함께 섬세한 튀김의 세계를 즐길 수 있다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=rMu6RFdC038",
+          "latitude": 43.0525053,
+          "longitude": 141.3535794,
+          "googleMapsId": "ChIJG79FOYYpC18ROd2h5DgUOG0",
+          "googleMapsUri": "https://maps.google.com/?cid=7870062583416479033&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "fdZlJ49JBig",
+      "title": "여기 예약하기가 진짜 어렵습니다",
+      "concept": "일본",
+      "locations": [
+        {
+          "name": "すし宮川 (스시 미야카와)",
+          "address": "일본 〒064-0824 Hokkaido, Sapporo, Chuo Ward, Kita 4 Jōnishi, 25-chōme−2−２ リヒトラーレ円山 1F",
+          "description": "삿포로 마루야마 공원 근처에 있는 스시집으로 2017 미쉐린 가이드 북해도 특별판에서 3스타를 받았다. 도쿄의 3스타 스시 요시타케 넘버투로 지내다 홍콩 분점을 3스타로 이끌고 고향 삿포로로 돌아와 자신의 가게를 열었다. 인당 10만원 중반대의 섬세하고 수준 높은 스시를 선보이며, 사케를 한 병 가까이 마셔도 26만원 안팎이라 일본 내에서도 최고의 가성비로 꼽는다. 도미에 흰 홀스레디쉬 와사비를 곁들이고, 요시타케에서 비롯된 전복에 간장·간 소스를 얹는 등 한 점 한 점의 구성이 독특하며, 한국에선 불법인 빵게(암컷 대게), 하얀 옥돔 시라카와, 간기, 사와라 삼치 등 북해도 재료를 정밀하게 다룬다. 김을 한 장씩 꺼내 준비하는 디테일과 삭힌 쌀로 빚은 샤리가 돋보이며 예약이 매우 어렵지만, 가능하다면 꼭 한 번쯤 방문하길 권하는 집이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=fdZlJ49JBig",
+          "latitude": 43.0621249,
+          "longitude": 141.3176119,
+          "googleMapsId": "ChIJq6o2ZuopC18R-IYrrMOFUWI",
+          "googleMapsUri": "https://maps.google.com/?cid=7084590764284151544&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "GgUXN4BiXck",
+      "title": "일본인 셰프에게 취향저격 당했습니다",
+      "concept": "3-chōme-6-22",
+      "locations": [
+        {
+          "name": "酒房しんせん (슈보신센)",
+          "address": "3-chōme-6-22 Minami 6 Jōnishi, Chuo Ward, Sapporo, Hokkaido 064-0806 일본",
+          "description": "삿포로의 미쉐린 2스타 술집으로 나이 지긋하고 유쾌한 할아버지 셰프가 3년 만에 찾은 손님을 반갑게 맞이하는 곳이다. 겉보기엔 허름하고 낡은 노가다식 이자카야 같지만 재료 하나하나가 범상치 않아, '재료를 이길 수 있는 건 없다'는 말이 절로 나온다. 갤럭시 울트라보다 큰 겨울철 도루묵, 사이즈와 기름기가 장난 아닌 줄가자미, 향이 대구 1위라는 김, 대구 정소로 만든 어묵, 향이 다른 작은 굴, 한치·전복·대구알·송이 등 다른 곳에서 맛보기 힘든 재료가 줄줄이 이어진다. 꽁치는 예약해 잡아온 것을 쓰고, 마지막은 꿩 육수에 송이를 넣은 우동으로 마무리하며 디저트로는 복숭아보다 부드러운 배와 감이 나온다. 다양한 사케를 양껏 마시고도 음식과 술을 합쳐 인당 30만원이 채 안 되는 가격이라 2스타 레스토랑 치고는 비싼 편이 아니어서 삿포로 미식가들에게 추천할 만하다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GgUXN4BiXck",
+          "latitude": 43.0534939,
+          "longitude": 141.35475409999998,
+          "googleMapsId": "ChIJyYryYYYpC18RMnPzPXVoq6Y",
+          "googleMapsUri": "https://maps.google.com/?cid=12009807684073386802&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "AtrrQe6srv8",
       "title": "아니 셰프님! 그분을 모르시다니...😮",
-      "concept": "일본 맛집 방문기",
+      "concept": "대한민국",
       "locations": [
         {
-          "name": "comme moa",
-          "displayName": "꼼모아",
+          "name": "comme moa (꼼모아)",
           "address": "대한민국 서울특별시 용산구 신흥로 56",
+          "description": "서울 해방촌(이태원)에 자리한 작은 프렌치 비스트로로, 파리에서 오랜 경력을 쌓은 김모와 여성 셰프가 2014년에 열었다. 10년 전쯤 파리 1스타 레스토랑의 수셰프를 지낸 내공으로 코스가 아닌 단품 요리를 내며, 한 접시당 2~3만원, 스파클링 5만원대·와인 5~10만원대로 와인 가격이 매우 착하다. 광어 카르파치오, 사과·무화과 잼을 곁들인 오리 간 뭉(포아그라), 성게알과 아보카도를 올린 시그니처 성게알 크램블, 대파·아스파라거스에 베샤멜 소스를 얹은 달팽이 파이 등 클래식 프랑스 요리가 줄어든 소스 없이 본래 모습으로 나온다. 미리 예약해야 하는 비프 웰링턴은 서울의 수많은 웰링턴 중 첫 손에 꼽을 만큼 완성도가 높아 3인 이상 예약을 권하며, 프렌치 후라이와 오렌지 리큐어 수플레·밀푀유까지 빠지지 않는다. 최근 셰프조차 모를 정도로 유명인이 다녀갈 만큼 사랑받으며, 가벼운 소스 위주의 요즘 와인바 사이에서 본토 부럽지 않은 클래식 소스의 맛을 느낄 수 있는 곳이다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=AtrrQe6srv8",
           "latitude": 37.5434828,
           "longitude": 126.98768969999999,
           "googleMapsId": "ChIJ70HYwU-ifDURHiVYS7OWR2I",
-          "googleMapsUri": "https://maps.google.com/?cid=7081794635870774558&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=AtrrQe6srv8",
-          "description": "일본 맛집을 소개하는 시리즈에서 다룬 서울 용산구의 프렌치 레스토랑. 셰프님이 모른다는 인물에 대한 에피소드가 화제가 되었으며, 수준 높은 프렌치 요리를 맛볼 수 있다."
+          "googleMapsUri": "https://maps.google.com/?cid=7081794635870774558&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     }

--- a/.claude/workspace/youtube/PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi/video_info.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi/video_info.json
@@ -3,312 +3,289 @@
   "id": "PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi",
   "title": "비밀이야 in 일본 🍣",
   "description": "",
+  "url": "https://www.youtube.com/playlist?list=PLkmBZE3qxSdHQQwUr8yTLgk3IauZQAeDi",
   "channelName": "비밀이야 bimirya",
-  "channelId": "UCaKQ7_GT0k8u_sL0nE2tgkA",
+  "channel": {
+    "id": "UCaKQ7_GT0k8u_sL0nE2tgkA",
+    "title": "비밀이야 bimirya",
+    "handle": "@bimirya",
+    "url": "https://www.youtube.com/@bimirya",
+    "description": "먹자! 마시자! 놀러 다니자!\n\n🍕 비즈니스 문의 : bimiryabdr@naver.com\n🍷 인스타그램 : www.instagram.com/bimirya\n🥪 네이버 블로그 : blog.naver.com/mardukas\n",
+    "thumbnailUrl": "https://yt3.ggpht.com/xTnhjCg0_h3Qdsy7Ar2B8AM8150MF0v-_CkRyCwRz6AK4-ZGEZVjYtWViSy6_9uxal7v1rHJKA=s800-c-k-c0x00ffffff-no-rj"
+  },
   "selectedVideos": [
+    {
+      "videoId": "aDcCeWReTG0",
+      "title": "프렌치 셰프도 감탄한 삿포로 3스타 재패니즈 프렌치🍽️북해도 식재료 끝판왕 | 몰리에르 モリエール",
+      "channelName": "비밀이야 bimirya",
+      "position": 0,
+      "url": "https://www.youtube.com/watch?v=aDcCeWReTG0"
+    },
     {
       "videoId": "90FahyHS8dA",
       "title": "1박에 500만 원짜리 료칸 밥은 뭐가 나올까? | 소네카",
       "channelName": "비밀이야 bimirya",
-      "position": 0,
-      "url": "https://www.youtube.com/watch?v=90FahyHS8dA",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n[SONEKA]\n-주소: 307-1 Omagari, Kitahiroshima, Hokkaido 061-1270 일본\n-전화번호: +8111 777 3355\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일, 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 1,
+      "url": "https://www.youtube.com/watch?v=90FahyHS8dA"
     },
     {
       "videoId": "p582RAgWsHs",
       "title": "설경 뻥뷰의 미쉐린 료칸☃️...아라마사를 이 가격에? | Niseko Zaborin",
       "channelName": "비밀이야 bimirya",
-      "position": 1,
-      "url": "https://www.youtube.com/watch?v=p582RAgWsHs",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보\n[Zaborin Ryokan 坐忘林]\n-주소: 76-4 Hanazono, Kutchan, Abuta District, Hokkaido 044-0084 일본\n-전화번호: +81136 23 0003\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일, 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 2,
+      "url": "https://www.youtube.com/watch?v=p582RAgWsHs"
     },
     {
       "videoId": "0VWZ5bhb7Bk",
       "title": "삿포로 소바집에서 취했습니다. | 미슐랭 1스타_테우치소바 코하시 | (+비추천 이자카야)",
       "channelName": "비밀이야 bimirya",
-      "position": 2,
-      "url": "https://www.youtube.com/watch?v=0VWZ5bhb7Bk",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 #삿포로\n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n테우치소바 코하시 手打ち蕎麦 こはし\n주소: 21 Chome-1-2 Kita 10 Jonishi, Chuo Ward, Sapporo, Hokkaido 060-0010 일본\n영업 시간: 11:00 ~ 20:00 / 월&화요일 정기휴무\nhttps://maps.app.goo.gl/EhQhckAeKCtrvLPS9\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일, 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 3,
+      "url": "https://www.youtube.com/watch?v=0VWZ5bhb7Bk"
     },
     {
       "videoId": "TIlMgP127dc",
       "title": "[EN] 한국에선 불법! '야생요리 전문식당' | 일본 야나기야 | Cuisine Yanagiya",
       "channelName": "비밀이야 bimirya",
-      "position": 3,
-      "url": "https://www.youtube.com/watch?v=TIlMgP127dc",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 #야나기야 #Yanagiya #일본\n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보\n야나기야\n주소: 일본 〒509-6361 Gifu, Mizunami, 陶町猿爪573-27\n영업 시간: 매일 오후 12:00~3:00 / 오후 5:00~10:00\n전화 번호: +81 50-5263-3236\nhttps://maps.app.goo.gl/gpogANnCJmSwDosH8\n\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 4,
+      "url": "https://www.youtube.com/watch?v=TIlMgP127dc"
     },
     {
       "videoId": "5JIZFg4dXfo",
       "title": "뭐 하나 빠짐없이 좋았던 홋카이도 프리미엄 료칸 (feat. 훌륭한 퀄리티의 해산물)[EN]ㅣ모쿠노쇼",
       "channelName": "비밀이야 bimirya",
-      "position": 4,
-      "url": "https://www.youtube.com/watch?v=5JIZFg4dXfo",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 주소: 393 Niseko, Niseko-cho, Abuta-gun, Hokkaido, 048-1511\n- 번호: +81 136 592 323\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 5,
+      "url": "https://www.youtube.com/watch?v=5JIZFg4dXfo"
     },
     {
       "videoId": "-KVf5NCWlGY",
       "title": "시골 료칸에 이런 퀄리티 있는 재료가?",
       "channelName": "비밀이야 bimirya",
-      "position": 5,
-      "url": "https://www.youtube.com/watch?v=-KVf5NCWlGY",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : mardukas@sandbox.co.kr"
+      "position": 6,
+      "url": "https://www.youtube.com/watch?v=-KVf5NCWlGY"
     },
     {
       "videoId": "ls0stez98hg",
       "title": "이 시골 료칸이 홋카이도 유일의 미쉐린 1스타를 받은 곳이라고?[EN]ㅣ비쿠니 칸코 하우스",
       "channelName": "비밀이야 bimirya",
-      "position": 6,
-      "url": "https://www.youtube.com/watch?v=ls0stez98hg",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 주소: 일본 〒046-0201 Hokkaido, Shakotan District, Shakotan, Bikunicho, Funama−４９\n- 번호: +81 135-44-2100\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 7,
+      "url": "https://www.youtube.com/watch?v=ls0stez98hg"
     },
     {
       "videoId": "ymvNifPTOVs",
       "title": "북해도 유일 미쉐린 1스타 료칸 #shorts",
       "channelName": "비밀이야 bimirya",
-      "position": 7,
-      "url": "https://www.youtube.com/watch?v=ymvNifPTOVs",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : mardukas@sandbox.co.kr"
+      "position": 8,
+      "url": "https://www.youtube.com/watch?v=ymvNifPTOVs"
     },
     {
       "videoId": "ylfG2fvn3K4",
       "title": "🍷다시는 못 볼 줄 알았던 와인과의 운명적인 만남[EN]ㅣ코트도르",
       "channelName": "비밀이야 bimirya",
-      "position": 8,
-      "url": "https://www.youtube.com/watch?v=ylfG2fvn3K4",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- Restaurant Cote d'Or\n- 주소: 北海道札幌市中央区宮ケ丘1-2-38\n- 번호: 050-5596-3694\n- 화~일 12:00 - 15:00/ 18:00 - 22:30\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 9,
+      "url": "https://www.youtube.com/watch?v=ylfG2fvn3K4"
     },
     {
       "videoId": "AJIsfQ_s7vU",
       "title": "삿포로에서 만난 진짜 나만 알고 싶은 와인리스트 #shorts",
       "channelName": "비밀이야 bimirya",
-      "position": 9,
-      "url": "https://www.youtube.com/watch?v=AJIsfQ_s7vU",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : mardukas@sandbox.co.kr"
+      "position": 10,
+      "url": "https://www.youtube.com/watch?v=AJIsfQ_s7vU"
     },
     {
       "videoId": "zFKDef6mDHY",
       "title": "인당 45만원, 와인만 250만원 나온 후덜덜한 일본 타베로그 TOP10 맛집! 과연 그 맛은? (feat. 깻잎에 싸주는 말고기🐎)[EN]ㅣACA",
       "channelName": "비밀이야 bimirya",
-      "position": 10,
-      "url": "https://www.youtube.com/watch?v=zFKDef6mDHY",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 번호: 03-6262-5090\n- 월~금 17:00~/ 토 12:00~/ 일 휴무\n- 주소: 東京都中央区日本橋室町2-1-1 三井2号館\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 11,
+      "url": "https://www.youtube.com/watch?v=zFKDef6mDHY"
     },
     {
       "videoId": "pn6xLx1HwJE",
       "title": "이름 내건 식당은 일단 맛 보장이 국룰🏅미쉐린 2스타를 이끌던 류지로 셰프가 차린 도쿄 고급 스시의 한끝차이ㅣ류지로",
       "channelName": "비밀이야 bimirya",
-      "position": 11,
-      "url": "https://www.youtube.com/watch?v=pn6xLx1HwJE",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 주소: 일본 〒107-0062 Tokyo, Minato City, Minamiaoyama, 2 Chome−11−11 ARISTO南青山 １階\n- 월~토 오후 12:00~2:00, 오후 6:00~11:30/ 일 휴무\n- 번호: +81 50-5870-5473\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 12,
+      "url": "https://www.youtube.com/watch?v=pn6xLx1HwJE"
     },
     {
       "videoId": "aZbrrnUTjSU",
       "title": "간판없는 식당? 입소문으로만 찾아가야 하는 꼼꼼 숨겨진 일본 소고기 오마카세[EN]ㅣ미가키쇼 나가야마",
       "channelName": "비밀이야 bimirya",
-      "position": 12,
-      "url": "https://www.youtube.com/watch?v=aZbrrnUTjSU",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 주소: Tokyo, Minato City, Akasaka, 3-chōme−14−2\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 13,
+      "url": "https://www.youtube.com/watch?v=aZbrrnUTjSU"
     },
     {
       "videoId": "1XZofgYeyUw",
       "title": "동에 번쩍 서에 번쩍하는 비밀이야가 호텔 고르는 꿀팁🌟[EN]ㅣ만다린 오리엔탈 도쿄",
       "channelName": "비밀이야 bimirya",
-      "position": 13,
-      "url": "https://www.youtube.com/watch?v=1XZofgYeyUw",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 호텔 정보\n- 주소: 2 Chome-1-1 Nihonbashimuromachi, Chuo City, Tokyo 103-8328 일본\n- 번호: +81332708800\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 14,
+      "url": "https://www.youtube.com/watch?v=1XZofgYeyUw"
     },
     {
       "videoId": "zuf53B4FMgI",
       "title": "원두면 몰라도 우유를 골라 마시는 카페가 있다? 홋카이도 필수 카페 4곳 [EN]",
       "channelName": "비밀이야 bimirya",
-      "position": 14,
-      "url": "https://www.youtube.com/watch?v=zuf53B4FMgI",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 15,
+      "url": "https://www.youtube.com/watch?v=zuf53B4FMgI"
     },
     {
       "videoId": "eodAIw3o50E",
       "title": "❄️영하 9도 삿포로에서 프라이빗하게 즐기는 료칸과 최고급 가이세키 식사ㅣ스이잔테이 클럽 [EN]",
       "channelName": "비밀이야 bimirya",
-      "position": 15,
-      "url": "https://www.youtube.com/watch?v=eodAIw3o50E",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 스이잔테이 클럽 조잔케이\n- 주소: 2 Chome-2-10 Jozankeionsennishi, Minami Ward, Sapporo, Hokkaido 061-2303 일본\n- 연락처: +81 11-595-2001\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 16,
+      "url": "https://www.youtube.com/watch?v=eodAIw3o50E"
     },
     {
       "videoId": "JO9Cqs4Cf-o",
       "title": "새우탕 찐하게 우려낸 국물 라멘 🦐 이거지...삿포로가면 꼭 들려야 할 두 곳ㅣ수프카레 사무라이&에비소바 이치겐 [EN]",
       "channelName": "비밀이야 bimirya",
-      "position": 16,
-      "url": "https://www.youtube.com/watch?v=JO9Cqs4Cf-o",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 수프카레 사무라이\n- 주소: 일본 〒060-0063 Hokkaido, Sapporo, Chuo Ward, Minami 3 Jonishi, 6 Chome−1−3 ティアラ36 2F\n- 번호: +81 11-272-3671\n- 월~일 오전 11:30~오후 3:00, 오후 5:30~9:30\n\n- 에비소바 이치겐\n- 주소: 9 Chome-1024-10 Minami 7 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0807 일본\n- 번호: +81 11-513-0098\n- 월~일 오전 11:00~오전 3:00\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 17,
+      "url": "https://www.youtube.com/watch?v=JO9Cqs4Cf-o"
     },
     {
       "videoId": "ZyY6Hl555Ws",
       "title": "이 영상을 보시면 단번에 이해하실 수 있습니다ㅣ짧고 굵은 가심비 1등 스시집 소개🍣ㅣ스시미야카와 [EN]",
       "channelName": "비밀이야 bimirya",
-      "position": 17,
-      "url": "https://www.youtube.com/watch?v=ZyY6Hl555Ws",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 주소: 일본 〒064-0824 Hokkaido, Sapporo, Chuo Ward, Kita 4 Jonishi, 25 Chome−2−2 リヒトラーレ円山 1F\n- 번호: +81 11-613-2221\n- 월,화,목~일 오후 5:00~10:00/ 수 휴\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 18,
+      "url": "https://www.youtube.com/watch?v=ZyY6Hl555Ws"
     },
     {
       "videoId": "BGmaULQnWR0",
       "title": "맛&가성비 둘 다 잡은 카이센동 맛집 두 곳 추천!ㅣ우니 무라카미&사카나야노 다이도코로 [EN]",
       "channelName": "비밀이야 bimirya",
-      "position": 18,
-      "url": "https://www.youtube.com/watch?v=BGmaULQnWR0",
-      "description": "밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 우니 무라카미\n- 월~일 오전 11:30~오후 1:30, 오후 5:30~8:45\n- 주소: 일본 〒060-0003 Hokkaido, Sapporo, Chuo Ward, Kita 3 Jonishi, 4 Chome−1-1 日本生命札幌ビル\n- 연락처: +81 11-290-1000\n\n- 사카나야노 다이도코로\n- 월~일 오전 7:00~오후 3:00\n- 주소: 일본 〒060-0052 Hokkaido, Sapporo, Chuo Ward, Minami 2 Johigashi, 2 Chome, 小西ビル １ 階\n- 연락처: +81 11-251-2219\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 19,
+      "url": "https://www.youtube.com/watch?v=BGmaULQnWR0"
     },
     {
       "videoId": "ILFK8cODr4U",
       "title": "징기스칸 양고기 타파할 최고 맛집 대공개🍖🪇ㅣ이타다끼마쓰&호르몬풍토 [EN]",
       "channelName": "비밀이야 bimirya",
-      "position": 19,
-      "url": "https://www.youtube.com/watch?v=ILFK8cODr4U",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 이타다끼마쓰\n- 월~일 오전 11:30~오후 2:00, 오후 4:00~9:30\n- 주소: 5 Chome-1-6 Minami 5 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0805 일본\n- 연락처: +81 50-5484-2607\n\n- 호르몬풍토\n- 월~금 오후 5:00~오전 5:00/ 토 오후 4:00~오전 5:00/ 일 오후 4:00~오전 12:00\n- 주소: 4 Chome Minami 6 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0806 일본\n- 연락처: +81 11-521-2244\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 20,
+      "url": "https://www.youtube.com/watch?v=ILFK8cODr4U"
     },
     {
       "videoId": "YYhUDMpqnOY",
       "title": "겉바속촉 덴뿌라 진짜 잘하는 집은 따로 있다?! 🦐 미슐랭 투스타 단골집 [EN]ㅣ덴푸라아라키",
       "channelName": "비밀이야 bimirya",
-      "position": 20,
-      "url": "https://www.youtube.com/watch?v=YYhUDMpqnOY",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- Tempura Araki\n- 월~토 오후 6:00~10:30, 일 휴무\n- 주소: 일본 064-0807 Hokkaido, Sapporo, Chuo Ward, Minami 7 Jonishi, 4 Chome−1-2 1F\n- 연락처: +81 11-552-5550\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 21,
+      "url": "https://www.youtube.com/watch?v=YYhUDMpqnOY"
     },
     {
       "videoId": "kwNgGM31Wn4",
       "title": "비밀이야가 오픈런하는 장어맛집?🏃🏻‍♂️사르르 녹는 장어와 맥주 한잔..🍺 [EN]ㅣ우나메이",
       "channelName": "비밀이야 bimirya",
-      "position": 21,
-      "url": "https://www.youtube.com/watch?v=kwNgGM31Wn4",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 수~월 오전 11:30~오후 2:30, 오후 5:00~8:30/ 화 휴무\n- 주소: 27 Chome-3-3 Kita 1 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0821 일본\n- 번호: +81 11-612-5777\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 22,
+      "url": "https://www.youtube.com/watch?v=kwNgGM31Wn4"
     },
     {
       "videoId": "LVbINarIdNA",
       "title": "삿포로의 함박 눈꽃 게살🌨️🦀있잖아요..저 너무 들떴어요 [EN] ㅣ카츠카니노 하나사키",
       "channelName": "비밀이야 bimirya",
-      "position": 22,
-      "url": "https://www.youtube.com/watch?v=LVbINarIdNA",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- Katukanino Hanasaki\n- 주소: 일본 〒064-0805 Hokkaido, Sapporo, Chuo Ward, Minami 5 Jonishi, 2 Chome−1−1 美松村岡ビル 5Ｆ\n- 050-5484-1912\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 23,
+      "url": "https://www.youtube.com/watch?v=LVbINarIdNA"
     },
     {
       "videoId": "tbosSzVJGqw",
       "title": "역대급 야끼니꾸 맛집🔥안심에 버금가는 와규 부위는 어디일까? 애기보, 대창, 양깃머리까지 맛있는 집 [EN]ㅣ도쿄 킨류잔",
       "channelName": "비밀이야 bimirya",
-      "position": 23,
-      "url": "https://www.youtube.com/watch?v=tbosSzVJGqw",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭 \n먹자! 마시자! 놀러 다니자! \n\n* 가게 정보 \n- 킨류잔\n- 월~일 08:30 - 17:30/ 수 휴무\n- 주소: 3 Chome-14-1 Shirokane, Minato City, Tokyo 108-0072 일본\n- 전화: +81338419190\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다. \n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시 \n* 비즈니스 문의 : bimiryabdr@naver.com"
+      "position": 24,
+      "url": "https://www.youtube.com/watch?v=tbosSzVJGqw"
     },
     {
       "videoId": "brRcKWhPkKw",
       "title": "작은 마을 하나를 섭렵해 보았습니다 [마쓰야마 투어 2편][EN]ㅣ오마카세, 프렌치 레스토랑",
       "channelName": "비밀이야 bimirya",
-      "position": 24,
-      "url": "https://www.youtube.com/watch?v=brRcKWhPkKw",
-      "description": "[교원투어 여행이지 X 비밀이야]\n'마쓰야마' 지역으로 제가 픽한 식당들이 패키지에 알차게 구성되어 있으니 일본 소도시의 매력을 한껏 느껴보시면 좋겠습니다.\n⛩ 투어 링크: https://sbsb.kr/secret_tour2\n\n#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 업로드 시간 : 매주 수요일, 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 25,
+      "url": "https://www.youtube.com/watch?v=brRcKWhPkKw"
     },
     {
       "videoId": "SLEXVgPrklk",
       "title": "물건 제대로 건졌다🐟 비주얼에 한번 맛에 두번 감탄하는 가성비 갑 오마카세 [EN]ㅣDogo Kaishu",
       "channelName": "비밀이야 bimirya",
-      "position": 25,
-      "url": "https://www.youtube.com/watch?v=SLEXVgPrklk",
-      "description": "Dogo Kaishu 식당이 포함된 '마쓰야마' 미식 투어는? \n⛩ 투어 링크: https://sbsb.kr/secret_tour2\n\n#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 업로드 시간 : 매주 수요일, 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 26,
+      "url": "https://www.youtube.com/watch?v=SLEXVgPrklk"
     },
     {
       "videoId": "QRDDx31HolM",
       "title": "미식 투어는 이렇게 하는 거에요🤫 17시간 강행군 [마쓰야마 투어 1편] [EN]ㅣ야키토리, 우동, 사케, 길거리먹방",
       "channelName": "비밀이야 bimirya",
-      "position": 26,
-      "url": "https://www.youtube.com/watch?v=QRDDx31HolM",
-      "description": "[교원투어 여행이지 X 비밀이야]\n일본 '마쓰야마' 지역으로 미식 투어를 알차게 짜보았습니다.\n제가 픽한 식당들이 패키지에 구성되어 있으니 일본 소도시의 매력을 한껏 느껴보시면 좋겠습니다.\n동행 패키지는 완판되었습니다. 감사합니다.\n\n⛩ 투어 링크: https://sbsb.kr/secret_tour2\n\n#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 업로드 시간 : 매주 수요일, 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 27,
+      "url": "https://www.youtube.com/watch?v=QRDDx31HolM"
     },
     {
       "videoId": "qGhQRyw6IRE",
       "title": "(EN) 이런 초대형 아스파라거스 요리 본 적 있어요? 프랑스 본점에서 건물, 인테리어, 음식, 와인리스트까지 그대로 들여온 이곳 ㅣ L’Auberge de L’ill",
       "channelName": "비밀이야 bimirya",
-      "position": 27,
-      "url": "https://www.youtube.com/watch?v=qGhQRyw6IRE",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보\n- L’Auberge de L’ill\n- 수~월 11:30-23:00, 브레이크 타임 15:00~17:30 / 화 휴무\n- 전화 : +81 11-632-7810\n- 주소 : 28 Chome-3-1 Minami 1 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0801 일본\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 28,
+      "url": "https://www.youtube.com/watch?v=qGhQRyw6IRE"
     },
     {
       "videoId": "pmOL-N9ZgYQ",
       "title": "(EN) 일본에서 가장 먼저 찾게 되는 삿포로 미슐랭 투스타 술집🐟🍶 비밀이야가 이토록 사랑하는 이유는? l 슈보신센",
       "channelName": "비밀이야 bimirya",
-      "position": 28,
-      "url": "https://www.youtube.com/watch?v=pmOL-N9ZgYQ",
-      "description": "#비밀이야 #맛집 #와인 #미슐랭\n\n* 가게 정보\n- 슈보신센 (酒房しんせん)\n- 월~토 17:30~23:00 / 일 휴무\n- 전화 : +81 11-512-3721\n- 주소 : 3 Chome-6-22 Minami 6 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0806 일본\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 매주 수요일 & 일요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 29,
+      "url": "https://www.youtube.com/watch?v=pmOL-N9ZgYQ"
     },
     {
       "videoId": "vSNU8_Aft-M",
       "title": "홋카이도를 대표하는 고급 생선 홍살치🐟",
       "channelName": "비밀이야 bimirya",
-      "position": 29,
-      "url": "https://www.youtube.com/watch?v=vSNU8_Aft-M",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보-1\n- 酒庵 五醍 (슈안 고다이)\n- 월~토 17:00-23:00\n- 전화 : +81 11-531-8080\n- 주소 : Japan 4 Chome-2-18 Minami 7 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0807\n\n* 가게 정보-2\n- Suage+ (스아게 플러스)\n- 월~일 11:30-23:00\n- 전화 : +81 11-233-2911\n- 주소 : Japan 〒064-0804 Hokkaido, Sapporo, Chuo Ward, Minami 4 Jonishi, 5 Chome−6-1 都志松ビル ２階\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 30,
+      "url": "https://www.youtube.com/watch?v=vSNU8_Aft-M"
     },
     {
       "videoId": "m5uPotCxv2Y",
       "title": "삿포로에서 2차 가기 좋은 곳 대방출✌",
       "channelName": "비밀이야 bimirya",
-      "position": 30,
-      "url": "https://www.youtube.com/watch?v=m5uPotCxv2Y",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보-1\n- バードウォッチング (Bird Watching)\n- 월~일 17:30-25:00\n- 전화 : +81 11-272-1150\n- 주소 : Japan 〒064-0804 Hokkaido, Sapporo, Chuo Ward, Minami 4 Jonishi, 5 Chome−５\n\n* 가게 정보-2\n- ラーメン信月 (라멘 신게츠)\n- 월~토 8:00-17:00\n- 전화 : +81 11-533-4844\n- 주소 : Japan 〒064-0805 Hokkaido, Sapporo, Chuo Ward, Minami 5 Jonishi, 3 Chome, N･グランデビル（旧･第4グリーンビル）\n\n* 가게 정보-3\n- ジンギスカン ラム (징기스칸 라무)\n- 월~일 17:00-22:00 / 화 휴무\n- 전화 : +81 11-512-2277\n- 주소 : Japan 4 Chome-2-11 Minami 7 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0807\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 31,
+      "url": "https://www.youtube.com/watch?v=m5uPotCxv2Y"
     },
     {
       "videoId": "BnpEQIAGbUM",
       "title": "여기는 재료 퀄리티로 승부 보는 식당입니다🍣",
       "channelName": "비밀이야 bimirya",
-      "position": 31,
-      "url": "https://www.youtube.com/watch?v=BnpEQIAGbUM",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보\n- ○鮨 (마루즈시)\n- 월 18:00-21:00 / 화~토 12:00-14:00, 18:00-21:00\n- 전화 : +81 11 552 6266\n- 주소 : 〒064-0806 Hokkaido, Sapporo, Chuo Ward, Minami 6 Jonishi, 4 Chome−４ ライトビル １F Japan\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 매주 수요일, 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 32,
+      "url": "https://www.youtube.com/watch?v=BnpEQIAGbUM"
     },
     {
       "videoId": "_1-2klFGMw8",
       "title": "클래식한 음식으로 35년 동안 자리를 지킬 수 있었던 이유🤫",
       "channelName": "비밀이야 bimirya",
-      "position": 32,
-      "url": "https://www.youtube.com/watch?v=_1-2klFGMw8",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보\n- Le Gentilhomme (장띠옴므)\n- 월~일 11:30-15:00, 17:30-22:00 / 화 휴무\n- 전화 : +81 11-531-2251\n- 주소 : Japan 〒064-0804 Hokkaido, Sapporo, Chuo Ward, Minami 4 Jonishi, 8 Chome−２−1-3 サンプラーザ札幌 1F\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 33,
+      "url": "https://www.youtube.com/watch?v=_1-2klFGMw8"
     },
     {
       "videoId": "Bm0e98UsIYA",
       "title": "맛있는 거 다음 맛있는 거 🍣",
       "channelName": "비밀이야 bimirya",
-      "position": 33,
-      "url": "https://www.youtube.com/watch?v=Bm0e98UsIYA",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보\n- 寿し ひでたか (스시 히데타카)\n- 월~토 18:00-23:00\n- 전화 : +81 11-200-0677\n- 주소 : Japan 〒064-0807 Hokkaido, Sapporo, Chuo Ward, 南7条西4丁目 延寿堂1F\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 매주 수요일, 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 34,
+      "url": "https://www.youtube.com/watch?v=Bm0e98UsIYA"
     },
     {
       "videoId": "rMu6RFdC038",
       "title": "삿포로의 투스타 튀김 오마카세",
       "channelName": "비밀이야 bimirya",
-      "position": 34,
-      "url": "https://www.youtube.com/watch?v=rMu6RFdC038",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보\n- 天ぷら あら木 (텐푸라 아라키)\n- 월~토 18:00-22:30\n- 전화 : +81 11-552-5550\n- 주소 : Japna 〒064-0807 Hokkaido, Sapporo, Chuo Ward, Minami 7 Jonishi, 4 Chome−1-2 延寿堂 1F\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 매주 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 35,
+      "url": "https://www.youtube.com/watch?v=rMu6RFdC038"
     },
     {
       "videoId": "fdZlJ49JBig",
       "title": "여기 예약하기가 진짜 어렵습니다",
       "channelName": "비밀이야 bimirya",
-      "position": 35,
-      "url": "https://www.youtube.com/watch?v=fdZlJ49JBig",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보\n- すし宮川 (스시 미야카와)\n- 월~일 9:30-19:30\n- 전화 : +81 11-613-2221\n- 주소 : 25-2-2, Kita-4-jonishi, Chuo-ku, Sapporo-shi, Hokkaido, 060-0004 / 北海道札幌市中央区北4条西25-2-2 リヒトラーレ円山1F\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 매주 수요일, 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 36,
+      "url": "https://www.youtube.com/watch?v=fdZlJ49JBig"
     },
     {
       "videoId": "GgUXN4BiXck",
       "title": "일본인 셰프에게 취향저격 당했습니다",
       "channelName": "비밀이야 bimirya",
-      "position": 36,
-      "url": "https://www.youtube.com/watch?v=GgUXN4BiXck",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보\n- 酒房しんせん (슈보신센)\n- 월~토 17:30-23:00\n- 전화 : +81 11 512 3721\n- 주소 : 3 Chome-6-22 Minami 6 Jonishi, Chuo Ward, Sapporo, Hokkaido 064-0806 Japan\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 매주 수요일, 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 37,
+      "url": "https://www.youtube.com/watch?v=GgUXN4BiXck"
     },
     {
       "videoId": "AtrrQe6srv8",
       "title": "아니 셰프님! 그분을 모르시다니...😮",
       "channelName": "비밀이야 bimirya",
-      "position": 37,
-      "url": "https://www.youtube.com/watch?v=AtrrQe6srv8",
-      "description": "#맛집 #미슐랭 #와인\n먹자! 마시자! 놀러 다니자!\n\n* 가게 정보\n- comme moa (꼼모아)\n- 월~금 18:00~22:00 / 토,일 12:00~15:00, 18:00~23:00\n- 전화 : 02-6217-5252\n- 주소 : 서울특별시 용산구 신흥로 56\n\n* 본 영상은 광고, 협찬과 무관한 레스토랑 방문기입니다.\n* 업로드 시간 : 매주 수요일, 금요일 오후 6시\n* 비지니스 문의 : bimiryabdr@naver.com"
+      "position": 38,
+      "url": "https://www.youtube.com/watch?v=AtrrQe6srv8"
     }
   ]
 }

--- a/.claude/workspace/youtube/PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI/_create_manifest.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI/_create_manifest.json
@@ -1,0 +1,276 @@
+{
+  "sunreiId": "SR01kyhwcxvhhbhftbxtq7h252zw",
+  "sourceId": "SRC01kyhw8vq7ze5mry327y36vrwd",
+  "spots": [
+    {
+      "spotId": "SS01kyhwcxwcwedx646s3b3baxd6",
+      "videoId": "l_WnIdakons",
+      "videoTitle": "1582년에 오픈했다는 프랑스의 전설적인 와인 성지🍷 50만 병 이상의 와인을 보유하고 있다는 라 투르 다르장에서 117만번째 오리를 맛보고 왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxvn9d2zed3dr5vkkbfk",
+      "videoId": "GoHWikk8Lbc",
+      "videoTitle": "[EN] 파리의 독보적인 미슐랭 3스타 레스토랑?👀 프랑스 최고 셰프가 이끄는 Epicure에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxvrvjbw6vt16s3e8zq2",
+      "videoId": "gWwmfIk70LI",
+      "videoTitle": "미쉐린 3스타 레스토랑에서 와인과 함께🍷"
+    },
+    {
+      "spotId": "SS01kyhwcxvwk66hcq57m9h9te65",
+      "videoId": "gA1c2apLx6w",
+      "videoTitle": "프랑스를 간다면 꼭 가야할 레스토랑!🥂 600종의 샴페인, 1100종의 와인 리스트를 보유한 럭셔리 & 클래식 끝판왕 Le Parc Les Crayeres를 소개합니다"
+    },
+    {
+      "spotId": "SS01kyhwcxvzffgdqsydqx0hmvwh",
+      "videoId": "halkS8GZClw",
+      "videoTitle": "창의적인 요리와 자연이 함께하는 남프랑스 최고의 레스토랑!"
+    },
+    {
+      "spotId": "SS01kyhwcxw3kzfnqg6962e5kzd7",
+      "videoId": "d3eVlWLO98Y",
+      "videoTitle": "유럽 단골집 예약! 프랑스 최고의 해산물 레스토랑 소개합니다"
+    },
+    {
+      "spotId": "SS01kyhwcxw56gh98bya2azjqk26",
+      "videoId": "-NcF7fdSvFo",
+      "videoTitle": "[EN] 프랑스 굴지에 있는 미슐랭 3스타 레스토랑? 역대급 완성도의 요리를 선보이는 Régis & Jacques Marcon에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxw963pqzgcwk4y0zdjr",
+      "videoId": "b1ezkKcXkBM",
+      "videoTitle": "50만 병 넘는 와인을 판매하는 라 투르 다르장! 117만번 째 이후 118만번 째 오리 먹으러 방문했습니다 [EN]ㅣLa tour d'argent"
+    },
+    {
+      "spotId": "SS01kyhwcxwh3kjtf53a38x3e59y",
+      "videoId": "R-ilj6zvNuc",
+      "videoTitle": "꿈의 도시 남프랑스 에즈!🏘️ 환상적인 전망을 갖춘 2스타에서 발견한 전설의 와인ㅣLa Chèvre D'Or"
+    },
+    {
+      "spotId": "SS01kyhwcxwj9qabrekzndc1zbtm",
+      "videoId": "JXRSt5lFPQM",
+      "videoTitle": "[EN] 1784년에 생긴 파리의 시그니처 레스토랑?✨ 프랑스 최고의 셰프가 운영하는 역사적인 레스토랑 Le Grand Véfour에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxwn1qngn6jx6mv6zad8",
+      "videoId": "6vYMBhJOneU",
+      "videoTitle": "반백년 째 3스타 식당. 대체 뭐가 나올까? | Les Prés d'Eugénie"
+    },
+    {
+      "spotId": "SS01kyhwcxwrefe64dqkdrxwtwrf",
+      "videoId": "Uiq6Vi9Bhm0",
+      "videoTitle": "보르도 5대 샤또 중 한 곳이 오너인 르 클라랑스🍷 수만 병의 올드 빈티지 와인 리스트를 보유한 럭셔리 레스토랑!"
+    },
+    {
+      "spotId": "SS01kyhwcxwtbrad5gpm8k1w56np",
+      "videoId": "0EJ4-mDI1do",
+      "videoTitle": "프랑스 굴 요리의 최강자! 1908년에 오픈해서 113년째 운영 중인 역사와 전통의 식당을 다녀왔습니다! 야외에서 샴페인 한 잔과 함께 먹는 신선한 해산물의 맛은?!"
+    },
+    {
+      "spotId": "SS01kyhwcxwwa1b9yxs0mssa308b",
+      "videoId": "PBEH_kLnL7w",
+      "videoTitle": "프랑스 1등 맛집! 자신있게 추천합니다 | \"Le MaZenay\""
+    },
+    {
+      "spotId": "SS01kyhwcxwywsqbrdawvb3f2ejr",
+      "videoId": "cgY_FyxsGp8",
+      "videoTitle": "프랑스에 온다면 꼭 들러봐야 할 해산물 캐주얼 식당"
+    },
+    {
+      "spotId": "SS01kyhwcxwzwveby1045bgptwwf",
+      "videoId": "wrSNqw6Mvek",
+      "videoTitle": "아시아/일본인 셰프 최초의 쓰리스타⭐⭐⭐"
+    },
+    {
+      "spotId": "SS01kyhwcxx1nkx4rya68n7rdag7",
+      "videoId": "QuNzFUH_IHo",
+      "videoTitle": "[EN] 파리지앵이 된듯한 역대급 조식과 브런치🍽 파리에서 가장 핫한 브런치 레스토랑에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxx8bee3x00ykcgynce2",
+      "videoId": "QuNzFUH_IHo",
+      "videoTitle": "[EN] 파리지앵이 된듯한 역대급 조식과 브런치🍽 파리에서 가장 핫한 브런치 레스토랑에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxxaqjfv1rxzjzb8emse",
+      "videoId": "Q_U8VL2gSqk",
+      "videoTitle": "(EN) 찐 푸아그라 꼭 맛보세요!"
+    },
+    {
+      "spotId": "SS01kyhwcxxcjfyrew5532b7df2z",
+      "videoId": "azEpgYW3K94",
+      "videoTitle": "[EN] 파리 최고의 해산물 파인 다이닝🍽 생선 요리의 장인이 운영하는 La Table d'Akihiro에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxxef3z0zsp23ynrhtqb",
+      "videoId": "NUyL5KzBhPI",
+      "videoTitle": "비밀이야가 마음에 들어 X 3번 외친 곳, 파리에서 괜찮은 가격의 와인+미슐랭🌟 레스토랑을 찾는다면! [EN]ㅣLe Villaret"
+    },
+    {
+      "spotId": "SS01kyhwcxxgpfj97w5rg30fn1s6",
+      "videoId": "Z6zsnguERvQ",
+      "videoTitle": "프랑스 알프스에 숨겨진 맛집? 근사한 풍경과 즐기는 3스타 미슐랭 레스토랑"
+    },
+    {
+      "spotId": "SS01kyhwcxxhrx7nnjy8qpv2tznm",
+      "videoId": "-yaNxv271Cs",
+      "videoTitle": "(EN) 에펠탑 2층에 위치한 미쉐린 원스타 레스토랑"
+    },
+    {
+      "spotId": "SS01kyhwcxxk1dqt4ac20sce1zb9",
+      "videoId": "qRMfDWxGKxM",
+      "videoTitle": "와인리스트 TOP2 파리 미슐랭 레스토랑! 페어링, 이게 최선입니까? [EN]ㅣLe Taillevent"
+    },
+    {
+      "spotId": "SS01kyhwcxxn5ymb5vmdphdke4sq",
+      "videoId": "xp9qbTCMuFE",
+      "videoTitle": "프랑스 산 속 오지마을에서 만난 인생 요리 | Auberge du Vieux Puits"
+    },
+    {
+      "spotId": "SS01kyhwcxxqbjpamz40ky2vx25q",
+      "videoId": "r1OERKKpg-o",
+      "videoTitle": "[EN] 파리의 정원에서 즐기는 미슐랭 다이닝🍽 눈과 입이 모두 즐거운 La Grande Cascade에 다녀왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxxyfhgcq8wy40w86g8f",
+      "videoId": "mEeT5zWyp9Q",
+      "videoTitle": "3스타 → 2스타 → 1스타 몰락하고 있다는 소식 듣고 얼른 방문해 본 레스토랑 [EN]ㅣL'astrance"
+    },
+    {
+      "spotId": "SS01kyhwcxy0cftqnj4e0xvkqc70",
+      "videoId": "dXWlBZfBkKM",
+      "videoTitle": "랍스터 3대장 중 이 곳이 끝판왕! 인당 50만원짜리 메뉴 하나하나에 진심인 레스토랑ㅣL'ambroisie"
+    },
+    {
+      "spotId": "SS01kyhwcxy1q1sydkb4qdz49jm6",
+      "videoId": "Kpzqj03ulNo",
+      "videoTitle": "샴페인의 본고장 '샹파뉴 랭스'에서 종일 취해있기..🌀진짜 비밀이야 샴페인 하우스🤫[EN]ㅣ샹파뉴 랭스"
+    },
+    {
+      "spotId": "SS01kyhwcxy4jmxs80n63357cq81",
+      "videoId": "y6i88w-_hBk",
+      "videoTitle": "19살부터 서빙 알바로 시작해 20년째 근무 중인 소믈리에가 있는 화이트 와인 최고 파리 레스토랑ㅣLa Cagouille"
+    },
+    {
+      "spotId": "SS01kyhwcxy6exvw42vsqx4ztvwd",
+      "videoId": "DRxvfZjNbfc",
+      "videoTitle": "숨겨왔던 나의~ 찐 단골집 대공개! 비밀이야가 아침부터 취하고 싶을 때 찾는다는 이 곳?🥴[EN]ㅣDrouant"
+    },
+    {
+      "spotId": "SS01kyhwcxy88j83r1w8xj68x4h3",
+      "videoId": "WMx6EFEVQlc",
+      "videoTitle": "힙한 내추럴 와인과 어울리는 노르딕 퀴진!👨‍🍳 트렌디한 요리로 오픈 2년만에 미슐랭 스타를 받은 프랑스 니스의 Pure & V를 소개합니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxya3j6zpdzmr18cyyjb",
+      "videoId": "3H-b3qKf9NU",
+      "videoTitle": "[EN] 100년 역사의 프랑스 리옹 전통 레스토랑🥩 이색적이지만 아쉬움이 남았던 Aux Lyonnais에서의 식사"
+    },
+    {
+      "spotId": "SS01kyhwcxyb0hrj9dnkce7xwzs5",
+      "videoId": "XVahpVb99Ac",
+      "videoTitle": "니스 해산물 맛집 원픽은 이 곳! 알 만한 사람들은 다 아는 Boccacio 🦐날 홍합, 날 조개로 주는 싱싱함 클라스..✨[EN]"
+    },
+    {
+      "spotId": "SS01kyhwcxydc0cg9s3zzxrv5yj7",
+      "videoId": "6rYFA1-cOEw",
+      "videoTitle": "파리의 전설적인 1스타 레스토랑🌟[EN]ㅣLucas Carton"
+    },
+    {
+      "spotId": "SS01kyhwcxyf34krhb7b1w9tztw5",
+      "videoId": "IDUozojLxog",
+      "videoTitle": "대게 되게 벌크업🦀 파리의 평범한 해산물 레스토랑 퀄리티ㅣ캐주얼하게 갈 수 있는 식당 추천ㅣhuguette, bistro de la mer"
+    },
+    {
+      "spotId": "SS01kyhwcxygxmsdmgzzrczhp622",
+      "videoId": "SHVcjUBlRUw",
+      "videoTitle": "[EN] 파리에서 만난 매력적인 이국의 맛!🍜 현지보다 맛있는 쿠스쿠스와 쌀국수를 먹고 왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxyja125ym8m8fa9ghqg",
+      "videoId": "SHVcjUBlRUw",
+      "videoTitle": "[EN] 파리에서 만난 매력적인 이국의 맛!🍜 현지보다 맛있는 쿠스쿠스와 쌀국수를 먹고 왔습니다!"
+    },
+    {
+      "spotId": "SS01kyhwcxymeybs2byp426s990c",
+      "videoId": "sSrSbgQMu5o",
+      "videoTitle": "샴페인의 왕이라고 소개한 메종 크룩의 와이너리, 직접 들어가 보여드립니다🍾[EN]ㅣMaison krug"
+    },
+    {
+      "spotId": "SS01kyhwcxynj5972p127e3ctg09",
+      "videoId": "coBnpOfw1t4",
+      "videoTitle": "쌀국수의 원조는 프랑스다?!🍜 파리에서 줄서서 먹는 쌀국수 맛집! (f. 귀국 전 시장 투어)"
+    },
+    {
+      "spotId": "SS01kyhwcxyq5hp18jz4t7ed27rw",
+      "videoId": "7O5dGQYeSug",
+      "videoTitle": "별빛이 내린다..🌟별이 15개? 프랑스에서 가장 각광받고 있는 셰프의 3스타 레스토랑 [EN]ㅣAlléno Paris"
+    },
+    {
+      "spotId": "SS01kyhwcxysf0ez6zv1fz9xq48n",
+      "videoId": "R6DoQ9HncrA",
+      "videoTitle": "단품 시켰는데 코스가 나오는 프렌치 식당🍾이런 기회 흔치 않아 | 레스쁘아 (with 100만 유튜버 & 신상 크룩)"
+    },
+    {
+      "spotId": "SS01kyhwcy0fh65k692xax8awx1n",
+      "videoId": "WmKBpFDk1YQ",
+      "videoTitle": "많은 분들이 기다려 주신 베르사유 궁전 디너 공개합니다✨ 전세계 공통 '밤비'로 통하는 사슴고기? 🦌ㅣLe Grand Contrôle [EN]"
+    },
+    {
+      "spotId": "SS01kyhwcxywxmxknjjqwtw2a5gf",
+      "videoId": "4J6RLbRSu64",
+      "videoTitle": "한국에 상륙하는 프랑스 유일 여성 3스타 셰프 레스토랑! 한국에서 무사히 성공할 수 있을까? [EN]ㅣLa dame de pic"
+    },
+    {
+      "spotId": "SS01kyhwcxyzh6h8cay249e7rgvr",
+      "videoId": "E8LBPjio53s",
+      "videoTitle": "세계에서 가장 아름다운 레스토랑으로 손꼽히는 곳✨ 화려함 끝판왕과 거장 셰프와의 만남[EN]ㅣLe Meurice Alain Ducasse"
+    },
+    {
+      "spotId": "SS01kyhwcxzq94hg6x8pfqb55c23",
+      "videoId": "XehtVBQvDhM",
+      "videoTitle": "3만 원 대에 즐기는 프랑스 명장 요리? | Daniel et Denise"
+    },
+    {
+      "spotId": "SS01kyhwcxzvbya1x17nrk37k0sd",
+      "videoId": "aQWebvFbH-o",
+      "videoTitle": "프랑스 한식당은 한국의 맛을 잘 나타낼 수 있을까?[EN]ㅣSetopa"
+    },
+    {
+      "spotId": "SS01kyhwcxzxsv1pxr3ew7evd6hr",
+      "videoId": "vmGwRznz0Yo",
+      "videoTitle": "13가지 코스 요리가 나오는데 디저트가 가장 맛있다고?! 🍨🫢  [EN]ㅣBlanc"
+    },
+    {
+      "spotId": "SS01kyhwcxzynn7d6h3wv53bzj5x",
+      "videoId": "shmIpRm4PRE",
+      "videoTitle": "헤밍웨이가 해산물을 먹고 싶을 때면 갔던 파리 브라세리🦞[EN]ㅣLa closerie des lias"
+    },
+    {
+      "spotId": "SS01kyhwcy000824jvx1dg1kr4xd",
+      "videoId": "AxLRF-gZmSA",
+      "videoTitle": "센 강 유람선 중 유일하게 1스타를 받은 최고의 크루즈 레스토랑은? ⛴️🍷 [EN]ㅣDon Juan II"
+    },
+    {
+      "spotId": "SS01kyhwcy02rc9zetwet9wadvj6",
+      "videoId": "OR4FNr-0I6c",
+      "videoTitle": "경비행기가 있는 미슐랭 투스타 에펠탑뷰 레스토랑! 프랑스식 김치의 충격적인 맛 [EN] ㅣL'Oiseau Blanc"
+    },
+    {
+      "spotId": "SS01kyhwcy03h4hn4618teqpgaxd",
+      "videoId": "tME5rlpprwI",
+      "videoTitle": "니스 실패없는 현지 식당 추천! 해산물이 질린다면 이곳으로 가세요ㅣLe Petit Palais&La Favola"
+    },
+    {
+      "spotId": "SS01kyhwcy0c8e1v6ka661w2m6qv",
+      "videoId": "tME5rlpprwI",
+      "videoTitle": "니스 실패없는 현지 식당 추천! 해산물이 질린다면 이곳으로 가세요ㅣLe Petit Palais&La Favola"
+    },
+    {
+      "spotId": "SS01kyhwcy0ej03ye69g22g53pg8",
+      "videoId": "tifp9zuDE7k",
+      "videoTitle": "프랑스 전성기를 그대로 구현한 1박에 무려 450만원짜리 베르사유 궁전 호텔의 모습은? 프라이빗 투어까지 잊지 못할 하룻밤ㅣLe Grand Contrôle [EN]"
+    }
+  ]
+}

--- a/.claude/workspace/youtube/PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI/locations.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI/locations.json
@@ -3,1059 +3,890 @@
     {
       "videoId": "l_WnIdakons",
       "title": "1582년에 오픈했다는 프랑스의 전설적인 와인 성지🍷 50만 병 이상의 와인을 보유하고 있다는 라 투르 다르장에서 117만번째 오리를 맛보고 왔습니다!",
-      "concept": "1582년에 오픈한 전설적인 와인 성지, 라 투르 다르장에서 117만번째 오리 맛보기",
+      "concept": "15",
       "locations": [
         {
-          "name": "La Tour d'Argent",
-          "displayName": "La Tour d'Argent",
+          "name": "15 Quai de la Tournelle",
           "address": "15 Quai de la Tournelle, 75005 Paris, 프랑스",
-          "latitude": 48.849855999999996,
-          "longitude": 2.354994,
-          "googleMapsId": "ChIJ5eQBbSBx5kcRvEQZIALlPF4",
-          "googleMapsUri": "https://maps.google.com/?cid=6790554135459087548&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 15-17 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=l_WnIdakons",
-          "description": "전설적인 와인 성지를 소개하는 영상에서 방문한 파리의 레스토랑. 1582년에 오픈하여 50만 병 이상의 와인을 보유하고 있으며, 117만번째 오리를 맛보는 특별한 경험이 담겨 있다."
+          "latitude": 48.8498169,
+          "longitude": 2.3549792,
+          "googleMapsId": "ChIJgy2hteRx5kcRGUsObuT23Ag",
+          "googleMapsUri": "https://maps.google.com/?cid=638656708139174681&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "GoHWikk8Lbc",
       "title": "[EN] 파리의 독보적인 미슐랭 3스타 레스토랑?👀 프랑스 최고 셰프가 이끄는 Epicure에 다녀왔습니다!",
-      "concept": "파리 미슐랭 3스타 Epicure 방문기",
+      "concept": "112",
       "locations": [
         {
-          "name": "Epicure",
-          "displayName": "Epicure",
+          "name": "112 Rue du Faubourg Saint-Honoré",
           "address": "112 Rue du Faubourg Saint-Honoré, 75008 Paris, 프랑스",
-          "latitude": 48.8717373,
-          "longitude": 2.3148527999999997,
-          "googleMapsId": "ChIJVeUHqupv5kcRDHPinmB3LtU",
-          "googleMapsUri": "https://maps.google.com/?cid=15361346635873547020&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 112 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=GoHWikk8Lbc",
-          "description": "파리의 독보적인 미슐랭 3스타 레스토랑을 소개하는 영상에서 방문한 곳. 프랑스 최고 셰프가 이끄는 레스토랑으로, 압도적인 파인다이닝을 경험할 수 있다."
+          "latitude": 48.8716805,
+          "longitude": 2.3148017,
+          "googleMapsId": "ChIJdyvCKslv5kcREPYXcY6aLBM",
+          "googleMapsUri": "https://maps.google.com/?cid=1381649122269328912&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "gWwmfIk70LI",
       "title": "미쉐린 3스타 레스토랑에서 와인과 함께🍷",
-      "concept": "미쉐린 3스타 Le Pré Catelan 와인 다이닝",
+      "concept": "프랑스",
       "locations": [
         {
-          "name": "Le Pré Catelan",
-          "displayName": "Le Pré Catelan",
-          "address": "프랑스 75016 Paris, 불로니으 산림공원",
-          "latitude": 48.863999299999996,
-          "longitude": 2.2507703,
-          "googleMapsId": "ChIJXZ9lqzZl5kcRxIInGxIRFaI",
-          "googleMapsUri": "https://maps.google.com/?cid=11679259978117907140&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "name": "불로니으 산림공원",
+          "address": "프랑스 75016 파리",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Bois 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=gWwmfIk70LI",
-          "description": "미쉐린 3스타 레스토랑에서의 와인 다이닝을 소개하는 영상에서 방문한 파리의 레스토랑. 불로니으 숲 속에 위치하며, 와인과 함께하는 품격 있는 식사를 즐길 수 있다."
-        }
-      ]
-    },
-    {
-      "videoId": "gA1c2apLx6w",
-      "title": "프랑스를 간다면 꼭 가야할 레스토랑!🥂 600종의 샴페인, 1100종의 와인 리스트를 보유한 럭셔리 & 클래식 끝판왕 Le Parc Les Crayeres를 소개합니다",
-      "concept": "랭스 럭셔리 레스토랑 Le Parc Les Crayères, 600종 샴페인",
-      "locations": [
-        {
-          "name": "Le Parc Les Crayères",
-          "displayName": "Restaurant Le Parc",
-          "address": "64 Bd Henry Vasnier, 51100 Reims, 프랑스",
-          "latitude": 49.241126799999996,
-          "longitude": 4.0516764,
-          "googleMapsId": "ChIJt418KV116UcRgkS3d9pAIp4",
-          "googleMapsUri": "https://maps.google.com/?cid=11394741314256323714&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=gA1c2apLx6w",
-          "description": "프랑스를 간다면 꼭 가야 할 레스토랑을 소개하는 영상에서 방문한 랭스의 럭셔리 레스토랑. 600종의 샴페인과 1100종의 와인 리스트를 보유한 럭셔리 & 클래식 끝판왕이다."
-        }
-      ]
-    },
-    {
-      "videoId": "halkS8GZClw",
-      "title": "창의적인 요리와 자연이 함께하는 남프랑스 최고의 레스토랑!",
-      "concept": "남프랑스 최고의 레스토랑 L'Oustau de Baumanière",
-      "locations": [
-        {
-          "name": "L'Oustau de Baumanière",
-          "displayName": "Restaurant L'Oustau de Baumanière***",
-          "address": "500 Rte DE BAUMANIERE, 13520 Les Baux-de-Provence, 프랑스",
-          "latitude": 43.7470467,
-          "longitude": 4.7955684,
-          "googleMapsId": "ChIJH_doE0LhtRIROj436AJRQ-k",
-          "googleMapsUri": "https://maps.google.com/?cid=16808367307204542010&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=halkS8GZClw",
-          "description": "남프랑스 최고의 레스토랑을 소개하는 영상에서 방문한 레보드프로방스의 미슐랭 3스타. 창의적인 요리와 자연이 함께하며, 남프랑스의 아름다운 환경 속에서 식사를 즐길 수 있다."
-        }
-      ]
-    },
-    {
-      "videoId": "d3eVlWLO98Y",
-      "title": "유럽 단골집 예약! 프랑스 최고의 해산물 레스토랑 소개합니다",
-      "concept": "프랑스 최고의 해산물 레스토랑 Christopher Coutanceau",
-      "locations": [
-        {
-          "name": "Christopher Coutanceau",
-          "displayName": "Christopher Coutanceau",
-          "address": "Plage de la Concurrence, 17000 La Rochelle, 프랑스",
-          "latitude": 46.155248199999996,
-          "longitude": -1.1598545999999998,
-          "googleMapsId": "ChIJ87_sn6VTAUgRsNVFS7MOq3w",
-          "googleMapsUri": "https://maps.google.com/?cid=8983290044945388976&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=d3eVlWLO98Y",
-          "description": "프랑스 최고의 해산물 레스토랑을 소개하는 영상에서 방문한 라로셸의 레스토랑. 유럽 단골집으로 예약할 정도로 애정하는 곳이며, 해산물 요리의 장인이 운영한다."
-        }
-      ]
-    },
-    {
-      "videoId": "-NcF7fdSvFo",
-      "title": "[EN] 프랑스 굴지에 있는 미슐랭 3스타 레스토랑? 역대급 완성도의 요리를 선보이는 Régis & Jacques Marcon에 다녀왔습니다!",
-      "concept": "프랑스 미슐랭 3스타 Régis & Jacques Marcon",
-      "locations": [
-        {
-          "name": "Régis & Jacques Marcon",
-          "displayName": "Restaurant Marcon",
-          "address": "18 Chem. de Brard Larsiallas, 43290 Saint-Bonnet-le-Froid, 프랑스",
-          "latitude": 45.138551899999996,
-          "longitude": 4.434272,
-          "googleMapsId": "ChIJM_Y85_919UcReASpU9RrmFA",
-          "googleMapsUri": "https://maps.google.com/?cid=5807510279175079032&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-NcF7fdSvFo",
-          "description": "프랑스 시골에 위치한 미슐랭 3스타를 소개하는 영상에서 방문한 레스토랑. 역대급 완성도의 요리를 선보이며, 프랑스 굴지에 숨겨진 보석 같은 곳이다."
-        }
-      ]
-    },
-    {
-      "videoId": "b1ezkKcXkBM",
-      "title": "50만 병 넘는 와인을 판매하는 라 투르 다르장! 117만번 째 이후 118만번 째 오리 먹으러 방문했습니다 [EN]ㅣLa tour d'argent",
-      "concept": "라 투르 다르장 재방문, 118만번째 오리",
-      "locations": [
-        {
-          "name": "La Tour d'Argent",
-          "displayName": "La Tour d'Argent",
-          "address": "15 Quai de la Tournelle, 75005 Paris, 프랑스",
-          "latitude": 48.849855999999996,
-          "longitude": 2.354994,
-          "googleMapsId": "ChIJ5eQBbSBx5kcRvEQZIALlPF4",
-          "googleMapsUri": "https://maps.google.com/?cid=6790554135459087548&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=b1ezkKcXkBM",
-          "description": "라 투르 다르장을 재방문하는 영상에서 소개된 파리의 전설적인 레스토랑. 117만번째 오리 이후 118만번째 오리를 먹으러 방문했으며, 50만 병 넘는 와인 컬렉션이 여전히 인상적이다."
-        }
-      ]
-    },
-    {
-      "videoId": "R-ilj6zvNuc",
-      "title": "꿈의 도시 남프랑스 에즈!🏘️ 환상적인 전망을 갖춘 2스타에서 발견한 전설의 와인ㅣLa Chèvre D'Or",
-      "concept": "남프랑스 에즈, La Chèvre d'Or 2스타 전망 레스토랑",
-      "locations": [
-        {
-          "name": "La Chèvre d'Or",
-          "displayName": "라 쉐브르 도르",
-          "address": "Rue du Barri, 06360 Èze, 프랑스",
-          "latitude": 43.727315,
-          "longitude": 7.361860999999998,
-          "googleMapsId": "ChIJkzb602fDzRIRnT5iz2d2u4w",
-          "googleMapsUri": "https://maps.google.com/?cid=10140829174187835037&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=R-ilj6zvNuc",
-          "description": "남프랑스 에즈의 환상적인 전망 레스토랑을 소개하는 영상에서 방문한 미슐랭 2스타. 꿈의 도시 에즈에서 지중해 뷰와 함께 전설의 와인을 즐길 수 있는 곳이다."
-        }
-      ]
-    },
-    {
-      "videoId": "JXRSt5lFPQM",
-      "title": "[EN] 1784년에 생긴 파리의 시그니처 레스토랑?✨ 프랑스 최고의 셰프가 운영하는 역사적인 레스토랑 Le Grand Véfour에 다녀왔습니다!",
-      "concept": "1784년 오픈 파리 시그니처 레스토랑 Le Grand Véfour",
-      "locations": [
-        {
-          "name": "Le Grand Véfour",
-          "displayName": "Le Grand Véfour",
-          "address": "17 Rue de Beaujolais, 75001 Paris, 프랑스",
-          "latitude": 48.8661299,
-          "longitude": 2.3379859,
-          "googleMapsId": "ChIJd9mmyyRu5kcRLYUD8BMhZ8I",
-          "googleMapsUri": "https://maps.google.com/?cid=14008201535474074925&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JXRSt5lFPQM",
-          "description": "1784년에 오픈한 파리 시그니처 레스토랑을 소개하는 영상에서 방문한 역사적인 레스토랑. 프랑스 최고의 셰프가 운영하며, 수백 년의 역사가 담긴 공간에서 식사를 즐길 수 있다."
+          "latitude": 48.8619839,
+          "longitude": 2.2523138,
+          "googleMapsId": "ChIJ28laW9p65kcRLkyGSRGcV04",
+          "googleMapsUri": "https://maps.google.com/?cid=5645152255994121262&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "6vYMBhJOneU",
       "title": "반백년 째 3스타 식당. 대체 뭐가 나올까? | Les Prés d'Eugénie",
-      "concept": "반백년째 3스타 Les Prés d'Eugénie",
+      "concept": "Place",
       "locations": [
         {
           "name": "Les Prés d'Eugénie",
-          "displayName": "Les Prés d'Eugénie - Relais & Châteaux",
           "address": "Place de l'Impératrice, 334 Rue René Vielle Vieille, 40320 Eugénie-les-Bains, 프랑스",
+          "description": "전화번호: +33 5 58 05 06 07",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6vYMBhJOneU",
           "latitude": 43.6957059,
           "longitude": -0.3797101,
           "googleMapsId": "ChIJD6BkQV5xVg0RSZsafdGLI6s",
-          "googleMapsUri": "https://maps.google.com/?cid=12331853936533871433&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6vYMBhJOneU",
-          "description": "반백년째 3스타를 유지하고 있는 레스토랑을 소개하는 영상에서 방문한 곳. 50년 이상 미슐랭 3스타를 유지한 전설적인 식당으로, 대체 뭐가 나오는지 영상에서 공개되었다."
+          "googleMapsUri": "https://maps.google.com/?cid=12331853936533871433&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
-      "videoId": "Uiq6Vi9Bhm0",
-      "title": "보르도 5대 샤또 중 한 곳이 오너인 르 클라랑스🍷 수만 병의 올드 빈티지 와인 리스트를 보유한 럭셔리 레스토랑!",
-      "concept": "보르도 5대 샤또 오너의 럭셔리 레스토랑 Le Clarence",
+      "videoId": "gA1c2apLx6w",
+      "title": "프랑스를 간다면 꼭 가야할 레스토랑!🥂 600종의 샴페인, 1100종의 와인 리스트를 보유한 럭셔리 & 클래식 끝판왕 Le Parc Les Crayeres를 소개합니다",
+      "concept": "64",
       "locations": [
         {
-          "name": "Le Clarence",
-          "displayName": "Le Clarence",
-          "address": "31 Av. Franklin Delano Roosevelt, 75008 Paris, 프랑스",
-          "latitude": 48.8674268,
-          "longitude": 2.3097738999999997,
-          "googleMapsId": "ChIJH5K8McVv5kcRHrJn-zUA3KQ",
-          "googleMapsUri": "https://maps.google.com/?cid=11879370148947669534&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Uiq6Vi9Bhm0",
-          "description": "보르도 5대 샤또 오너의 럭셔리 레스토랑을 소개하는 영상에서 방문한 파리의 레스토랑. 수만 병의 올드 빈티지 와인 리스트를 보유하고 있으며, 보르도 최고급 와인을 즐길 수 있다."
+          "name": "64 Bd Henry Vasnier",
+          "address": "64 Bd Henry Vasnier, 51100 Reims, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 64, 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=gA1c2apLx6w",
+          "latitude": 49.2411995,
+          "longitude": 4.0514909999999995,
+          "googleMapsId": "ChIJ3_gcgjl06UcRODNVLKd4z3Q",
+          "googleMapsUri": "https://maps.google.com/?cid=8417078887977399096&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
-      "videoId": "0EJ4-mDI1do",
-      "title": "프랑스 굴 요리의 최강자! 1908년에 오픈해서 113년째 운영 중인 역사와 전통의 식당을 다녀왔습니다! 야외에서 샴페인 한 잔과 함께 먹는 신선한 해산물의 맛은?!",
-      "concept": "니스 113년 전통 굴 요리 전문 Le Café de Turin",
+      "videoId": "halkS8GZClw",
+      "title": "창의적인 요리와 자연이 함께하는 남프랑스 최고의 레스토랑!",
+      "concept": "D27,",
       "locations": [
         {
-          "name": "Le Café de Turin",
-          "displayName": "Le Café de Turin",
-          "address": "5 Pl. Garibaldi, 06300 Nice, 프랑스",
-          "latitude": 43.7005556,
-          "longitude": 7.279444400000001,
-          "googleMapsId": "ChIJo0rdT7razRIRn_qJeQf_HKE",
-          "googleMapsUri": "https://maps.google.com/?cid=11609434347023235743&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0EJ4-mDI1do",
-          "description": "프랑스 굴 요리의 최강자를 소개하는 영상에서 방문한 니스의 레스토랑. 1908년에 오픈하여 113년째 운영 중이며, 야외에서 샴페인과 함께 신선한 해산물을 즐길 수 있다."
+          "name": "D27",
+          "address": "D27, Les Baux-de-Provence, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 D27, 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=halkS8GZClw",
+          "latitude": 43.7488798,
+          "longitude": 4.7964273,
+          "googleMapsId": "EiFEMjcsIExlcyBCYXV4LWRlLVByb3ZlbmNlLCBGcmFuY2UiLiosChQKEgnB-ogbceG1EhEbWIQ2BNFwZxIUChIJIbJq2F3htRIR4ASX_aUZCAQ",
+          "googleMapsUri": "https://maps.google.com/?q=D27,+Les+Baux-de-Provence,+France&ftid=0x12b5e1711b88fac1:0x6770d1043684581b&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "b1ezkKcXkBM",
+      "title": "50만 병 넘는 와인을 판매하는 라 투르 다르장! 117만번 째 이후 118만번 째 오리 먹으러 방문했습니다 [EN]ㅣLa tour d'argent",
+      "concept": "15",
+      "locations": [
+        {
+          "name": "15 Quai de la Tournelle",
+          "address": "15 Quai de la Tournelle, 75005 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 15 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=b1ezkKcXkBM",
+          "latitude": 48.8498169,
+          "longitude": 2.3549792,
+          "googleMapsId": "ChIJgy2hteRx5kcRGUsObuT23Ag",
+          "googleMapsUri": "https://maps.google.com/?cid=638656708139174681&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "d3eVlWLO98Y",
+      "title": "유럽 단골집 예약! 프랑스 최고의 해산물 레스토랑 소개합니다",
+      "concept": "1",
+      "locations": [
+        {
+          "name": "Plage de la Concurrence",
+          "address": "1 Prom. de la Concurrence, 17000 La Rochelle, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Plage 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=d3eVlWLO98Y",
+          "latitude": 46.1549665,
+          "longitude": -1.160504,
+          "googleMapsId": "ChIJq9NAuatTAUgR0kAlP8NzU-4",
+          "googleMapsUri": "https://maps.google.com/?cid=17173197086509056210&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "-NcF7fdSvFo",
+      "title": "[EN] 프랑스 굴지에 있는 미슐랭 3스타 레스토랑? 역대급 완성도의 요리를 선보이는 Régis & Jacques Marcon에 다녀왔습니다!",
+      "concept": "18",
+      "locations": [
+        {
+          "name": "18 Chem. de Brard",
+          "address": "18 Chem. de Brard, 43290 Saint-Bonnet-le-Froid, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 18 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-NcF7fdSvFo",
+          "latitude": 45.1388477,
+          "longitude": 4.4333203999999995,
+          "googleMapsId": "ChIJc9nW4P919UcR_dlx8QGZODQ",
+          "googleMapsUri": "https://maps.google.com/?cid=3762925722292836861&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "JXRSt5lFPQM",
+      "title": "[EN] 1784년에 생긴 파리의 시그니처 레스토랑?✨ 프랑스 최고의 셰프가 운영하는 역사적인 레스토랑 Le Grand Véfour에 다녀왔습니다!",
+      "concept": "17",
+      "locations": [
+        {
+          "name": "17 Rue de Beaujolais",
+          "address": "17 Rue de Beaujolais, 75001 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 17 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=JXRSt5lFPQM",
+          "latitude": 48.8662966,
+          "longitude": 2.3380871,
+          "googleMapsId": "ChIJF5u6yyRu5kcRsUJ6p5HApjw",
+          "googleMapsUri": "https://maps.google.com/?cid=4370392220222243505&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "PBEH_kLnL7w",
       "title": "프랑스 1등 맛집! 자신있게 추천합니다 | \"Le MaZenay\"",
-      "concept": "프랑스 1등 맛집 Le MaZenay",
+      "concept": "46",
       "locations": [
         {
-          "name": "Le MaZenay",
-          "displayName": "Le MaZenay",
+          "name": "46 Rue de Montmorency",
           "address": "46 Rue de Montmorency, 75003 Paris, 프랑스",
-          "latitude": 48.8636402,
-          "longitude": 2.3533729,
-          "googleMapsId": "ChIJvbCbVRpu5kcRfMWl3JeGW4s",
-          "googleMapsUri": "https://maps.google.com/?cid=10041767780952687996&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 46 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=PBEH_kLnL7w",
-          "description": "프랑스 1등 맛집을 자신있게 추천하는 영상에서 방문한 파리의 레스토랑. 영상 진행자가 자신있게 프랑스 1등이라고 추천한 곳으로, 파리 방문 시 꼭 가봐야 할 맛집이다."
+          "latitude": 48.863644199999996,
+          "longitude": 2.3533182,
+          "googleMapsId": "ChIJwWUvVRpu5kcRPYv_yuaqWXQ",
+          "googleMapsUri": "https://maps.google.com/?cid=8383920089551833917&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Uiq6Vi9Bhm0",
+      "title": "보르도 5대 샤또 중 한 곳이 오너인 르 클라랑스🍷 수만 병의 올드 빈티지 와인 리스트를 보유한 럭셔리 레스토랑!",
+      "concept": "31",
+      "locations": [
+        {
+          "name": "31 Av. Franklin Delano Roosevelt",
+          "address": "31 Av. Franklin Delano Roosevelt, 75008 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 31 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Uiq6Vi9Bhm0",
+          "latitude": 48.8674099,
+          "longitude": 2.3097868,
+          "googleMapsId": "ChIJ6U0jMcVv5kcRJzmlNNybXPw",
+          "googleMapsUri": "https://maps.google.com/?cid=18184580765493573927&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "0EJ4-mDI1do",
+      "title": "프랑스 굴 요리의 최강자! 1908년에 오픈해서 113년째 운영 중인 역사와 전통의 식당을 다녀왔습니다! 야외에서 샴페인 한 잔과 함께 먹는 신선한 해산물의 맛은?!",
+      "concept": "5",
+      "locations": [
+        {
+          "name": "5 Pl. Garibaldi",
+          "address": "5 Pl. Garibaldi, 06300 Nice, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 5 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=0EJ4-mDI1do",
+          "latitude": 43.7005682,
+          "longitude": 7.279525199999999,
+          "googleMapsId": "ChIJkVnKT7razRIRCtHODegLM4U",
+          "googleMapsUri": "https://maps.google.com/?cid=9598028322148634890&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "cgY_FyxsGp8",
       "title": "프랑스에 온다면 꼭 들러봐야 할 해산물 캐주얼 식당",
-      "concept": "라로셸 해산물 캐주얼 식당 La Yole de Chris",
+      "concept": "1",
       "locations": [
         {
-          "name": "La Yole de Chris",
-          "displayName": "La Yole de Chris",
-          "address": "plage de la concurrence, 17000 La Rochelle, 프랑스",
-          "latitude": 46.1554687,
-          "longitude": -1.1603561,
-          "googleMapsId": "ChIJTcKDKs1TAUgREZZaCKzpOD4",
-          "googleMapsUri": "https://maps.google.com/?cid=4483590354131129873&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "name": "Plage de la Concurrence",
+          "address": "1 Prom. de la Concurrence, 17000 La Rochelle, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Plage 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=cgY_FyxsGp8",
-          "description": "프랑스에 온다면 꼭 들러봐야 할 해산물 캐주얼 식당을 소개하는 영상에서 방문한 라로셸의 레스토랑. 캐주얼한 분위기에서 신선한 해산물을 합리적인 가격에 즐길 수 있다."
+          "latitude": 46.1549665,
+          "longitude": -1.160504,
+          "googleMapsId": "ChIJq9NAuatTAUgR0kAlP8NzU-4",
+          "googleMapsUri": "https://maps.google.com/?cid=17173197086509056210&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "KYYsPZ4ZSmU",
+      "title": "하룻밤 550만 원 투숙객만 예약 가능? 극강의 예약 난이도 뚫고 다녀왔습니다 | 플레니튀드",
+      "concept": "8",
+      "locations": [
+        {
+          "name": "Plénitude",
+          "address": "8 Quai du Louvre, 75001 Paris, 프랑스",
+          "description": "Plénitude — 비밀이야 in 한국 영상에서 소개한 8 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=KYYsPZ4ZSmU",
+          "latitude": 48.8588971,
+          "longitude": 2.3420459,
+          "googleMapsId": "ChIJ1YFmqNZv5kcRBAVR2JH8pEo",
+          "googleMapsUri": "https://maps.google.com/?cid=5378701558316860676&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "wrSNqw6Mvek",
       "title": "아시아/일본인 셰프 최초의 쓰리스타⭐⭐⭐",
-      "concept": "아시아/일본인 셰프 최초 3스타 Kei",
+      "concept": "5",
       "locations": [
         {
-          "name": "Kei",
-          "displayName": "Restaurant Kei",
+          "name": "5 Rue Coq Héron",
           "address": "5 Rue Coq Héron, 75001 Paris, 프랑스",
-          "latitude": 48.864357999999996,
-          "longitude": 2.3420826999999997,
-          "googleMapsId": "ChIJqTnaAiNu5kcRQsRFgf8qeoA",
-          "googleMapsUri": "https://maps.google.com/?cid=9257759260887336002&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 5 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=wrSNqw6Mvek",
-          "description": "아시아/일본인 셰프 최초의 미슐랭 3스타를 소개하는 영상에서 방문한 파리의 레스토랑. 케이 셰프가 일본인으로서 최초로 3스타를 획득한 역사적인 곳이다."
+          "latitude": 48.8643631,
+          "longitude": 2.3420995,
+          "googleMapsId": "ChIJNRgRAyNu5kcRPXOCPHT5-fI",
+          "googleMapsUri": "https://maps.google.com/?cid=17508299304006218557&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "QuNzFUH_IHo",
       "title": "[EN] 파리지앵이 된듯한 역대급 조식과 브런치🍽 파리에서 가장 핫한 브런치 레스토랑에 다녀왔습니다!",
-      "concept": "파리 역대급 조식과 브런치 투어",
+      "concept": "Pl.",
       "locations": [
         {
-          "name": "Le Train Bleu",
-          "displayName": "Le Train Bleu",
-          "address": "Gare de Lyon, Pl. Louis Armand hall 1, 75012 Paris, 프랑스",
-          "latitude": 48.8448989,
-          "longitude": 2.3732694000000003,
-          "googleMapsId": "ChIJzev2rBxy5kcRYsCGyZ-UMRs",
-          "googleMapsUri": "https://maps.google.com/?cid=1959510726884638818&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "name": "루이 아흐멍 광장",
+          "address": "Pl. Louis Armand, 75012 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Pl. 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=QuNzFUH_IHo",
-          "description": "파리 역대급 조식과 브런치를 소개하는 영상에서 방문한 리옹역 내 레스토랑. 파리지앵이 된 듯한 역대급 조식과 브런치를 즐길 수 있으며, 화려한 실내 장식이 특징이다."
+          "latitude": 48.8450619,
+          "longitude": 2.3731551,
+          "googleMapsId": "ChIJidV0GRty5kcRdRXp7rTlUjI",
+          "googleMapsUri": "https://maps.google.com/?cid=3626213215251797365&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         },
         {
-          "name": "Buvette",
-          "displayName": "Buvette Paris",
+          "name": "28 Rue Henry Monnier",
           "address": "28 Rue Henry Monnier, 75009 Paris, 프랑스",
-          "latitude": 48.88044,
-          "longitude": 2.3377375,
-          "googleMapsId": "ChIJcQXFZkZu5kcRM7dlSZoQVK8",
-          "googleMapsUri": "https://maps.google.com/?cid=12633741109523494707&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Pl. 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=QuNzFUH_IHo",
-          "description": "파리에서 가장 핫한 브런치 레스토랑을 소개하는 영상에서 방문한 곳. 파리지앵 스타일의 브런치를 즐길 수 있으며, 트렌디한 분위기가 매력적이다."
+          "latitude": 48.880473099999996,
+          "longitude": 2.3377376,
+          "googleMapsId": "ChIJhzAmYUZu5kcRrMG0ee11c0w",
+          "googleMapsUri": "https://maps.google.com/?cid=5508876432013836716&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "Q_U8VL2gSqk",
       "title": "(EN) 찐 푸아그라 꼭 맛보세요!",
-      "concept": "파리 찐 푸아그라 맛집 Bofinger",
+      "concept": "5",
       "locations": [
         {
-          "name": "Bofinger",
-          "displayName": "Bofinger",
-          "address": "5-7 Rue de la Bastille, 75004 Paris, 프랑스",
-          "latitude": 48.8539497,
-          "longitude": 2.3678627,
-          "googleMapsId": "ChIJuYqiNwBy5kcRBjo0Df8Wpkc",
-          "googleMapsUri": "https://maps.google.com/?cid=5162839307520850438&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "name": "5 Rue de la Bastille",
+          "address": "5 Rue de la Bastille, 75004 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 5-7 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Q_U8VL2gSqk",
-          "description": "파리 찐 푸아그라 맛집을 소개하는 영상에서 방문한 레스토랑. 꼭 맛봐야 할 찐 푸아그라를 합리적인 가격에 즐길 수 있으며, 전통적인 파리 브라세리 분위기가 특징이다."
+          "latitude": 48.854044099999996,
+          "longitude": 2.3678063,
+          "googleMapsId": "ChIJ8xJQEQBy5kcRn9DSa73oY8o",
+          "googleMapsUri": "https://maps.google.com/?cid=14583755918611239071&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "azEpgYW3K94",
       "title": "[EN] 파리 최고의 해산물 파인 다이닝🍽 생선 요리의 장인이 운영하는 La Table d'Akihiro에 다녀왔습니다!",
-      "concept": "파리 최고의 해산물 파인다이닝 La Table d'Akihiro",
+      "concept": "49",
       "locations": [
         {
-          "name": "La Table d'Akihiro",
-          "displayName": "La Table d'Akihiro",
+          "name": "49 Rue Vaneau",
           "address": "49 Rue Vaneau, 75007 Paris, 프랑스",
-          "latitude": 48.8510284,
-          "longitude": 2.3194816,
-          "googleMapsId": "ChIJLS57hSxw5kcReNpz46DjYQ0",
-          "googleMapsUri": "https://maps.google.com/?cid=964302075384289912&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 49 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=azEpgYW3K94",
-          "description": "파리 최고의 해산물 파인다이닝을 소개하는 영상에서 방문한 레스토랑. 생선 요리의 장인이 운영하는 곳으로, 정교한 해산물 요리가 인상적이다."
+          "latitude": 48.8511272,
+          "longitude": 2.3194596,
+          "googleMapsId": "ChIJDS1MhSxw5kcR_XXjYQl79gM",
+          "googleMapsUri": "https://maps.google.com/?cid=285550906611824125&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "NUyL5KzBhPI",
       "title": "비밀이야가 마음에 들어 X 3번 외친 곳, 파리에서 괜찮은 가격의 와인+미슐랭🌟 레스토랑을 찾는다면! [EN]ㅣLe Villaret",
-      "concept": "파리 괜찮은 가격의 와인+미슐랭 Le Villaret",
+      "concept": "13",
       "locations": [
         {
-          "name": "Le Villaret",
-          "displayName": "Le Villaret",
+          "name": "13 Rue Ternaux",
           "address": "13 Rue Ternaux, 75011 Paris, 프랑스",
-          "latitude": 48.864318999999995,
-          "longitude": 2.372838,
-          "googleMapsId": "ChIJRV4qmfxt5kcR8htPBNXSGKE",
-          "googleMapsUri": "https://maps.google.com/?cid=11608259851889613810&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 13 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=NUyL5KzBhPI",
-          "description": "파리에서 괜찮은 가격의 와인과 미슐랭 식사를 소개하는 영상에서 방문한 레스토랑. 영상 진행자가 마음에 들어 세 번이나 외칠 정도로 좋았으며, 합리적인 가격이 매력이다."
-        }
-      ]
-    },
-    {
-      "videoId": "Z6zsnguERvQ",
-      "title": "프랑스 알프스에 숨겨진 맛집? 근사한 풍경과 즐기는 3스타 미슐랭 레스토랑",
-      "concept": "프랑스 알프스 3스타 미슐랭 Flocons de Sel",
-      "locations": [
-        {
-          "name": "Flocons de Sel",
-          "displayName": "Flocons de Sel",
-          "address": "1775 Rte du Leutaz, 74120 Megève, 프랑스",
-          "latitude": 45.8302798,
-          "longitude": 6.5968981,
-          "googleMapsId": "ChIJ4xBKAP_ii0cR_L-Q0gDCjn4",
-          "googleMapsUri": "https://maps.google.com/?cid=9119439604260323324&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Z6zsnguERvQ",
-          "description": "프랑스 알프스에 숨겨진 미슐랭 3스타를 소개하는 영상에서 방문한 메제브의 레스토랑. 근사한 알프스 풍경과 함께 즐기는 3스타 미슐랭 다이닝이 인상적이다."
-        }
-      ]
-    },
-    {
-      "videoId": "-yaNxv271Cs",
-      "title": "(EN) 에펠탑 2층에 위치한 미쉐린 원스타 레스토랑",
-      "concept": "에펠탑 2층 미쉐린 1스타 Le Jules Verne",
-      "locations": [
-        {
-          "name": "Le Jules Verne",
-          "displayName": "Jules Verne",
-          "address": "Avenue Gustave Eiffel 2ème, Tour Eiffel, Av. Anatole France, 75007 Paris, 프랑스",
-          "latitude": 48.8583698,
-          "longitude": 2.2944833,
-          "googleMapsId": "ChIJl_7p8uFv5kcRj5ZGEf31ILM",
-          "googleMapsUri": "https://maps.google.com/?cid=12907586999309211279&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-yaNxv271Cs",
-          "description": "에펠탑 2층에 위치한 미쉐린 1스타를 소개하는 영상에서 방문한 레스토랑. 에펠탑에서 파리 전경을 감상하며 식사할 수 있는 특별한 경험을 제공한다."
-        }
-      ]
-    },
-    {
-      "videoId": "qRMfDWxGKxM",
-      "title": "와인리스트 TOP2 파리 미슐랭 레스토랑! 페어링, 이게 최선입니까? [EN]ㅣLe Taillevent",
-      "concept": "와인리스트 TOP2 파리 미슐랭 Le Taillevent",
-      "locations": [
-        {
-          "name": "Le Taillevent",
-          "displayName": "Le Taillevent",
-          "address": "15 Rue Lamennais, 75008 Paris, 프랑스",
-          "latitude": 48.874097,
-          "longitude": 2.3024750000000003,
-          "googleMapsId": "ChIJp_LMzsFv5kcRahcM9RvYYV4",
-          "googleMapsUri": "https://maps.google.com/?cid=6800954526893086570&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=qRMfDWxGKxM",
-          "description": "와인리스트 TOP2 파리 미슐랭 레스토랑을 소개하는 영상에서 방문한 곳. 파리 최고 수준의 와인리스트를 보유하고 있지만, 페어링에 대한 솔직한 평가가 담겨 있다."
+          "latitude": 48.8643673,
+          "longitude": 2.372805,
+          "googleMapsId": "ChIJ6wHqmPxt5kcR624kLnBVcyc",
+          "googleMapsUri": "https://maps.google.com/?cid=2842709730099752683&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "xp9qbTCMuFE",
       "title": "프랑스 산 속 오지마을에서 만난 인생 요리 | Auberge du Vieux Puits",
-      "concept": "프랑스 산속 오지마을 인생 요리 Auberge du Vieux Puits",
+      "concept": "5",
       "locations": [
         {
           "name": "Auberge du Vieux Puits",
-          "displayName": "Auberge du Vieux Puits",
           "address": "5 Av. Saint-Victor, 11360 Fontjoncouse, 프랑스",
-          "latitude": 43.048523,
-          "longitude": 2.7888566,
-          "googleMapsId": "ChIJwz7atuhJsBIRZ6esU5Pl6As",
-          "googleMapsUri": "https://maps.google.com/?cid=858188149940856679&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": "전화번호: +33 4 68 44 07 37",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=xp9qbTCMuFE",
-          "description": "프랑스 산속 오지마을의 인생 요리를 소개하는 영상에서 방문한 레스토랑. 접근이 어려운 오지마을에 위치하지만, 그만큼 특별한 인생 요리를 맛볼 수 있는 곳이다."
-        }
-      ]
-    },
-    {
-      "videoId": "r1OERKKpg-o",
-      "title": "[EN] 파리의 정원에서 즐기는 미슐랭 다이닝🍽 눈과 입이 모두 즐거운 La Grande Cascade에 다녀왔습니다!",
-      "concept": "파리의 정원에서 즐기는 미슐랭 다이닝 La Grande Cascade",
-      "locations": [
-        {
-          "name": "La Grande Cascade",
-          "displayName": "La Grande Cascade",
-          "address": "Rte de la Vge aux Berceaux, 75016 Paris, 프랑스",
-          "latitude": 48.8626993,
-          "longitude": 2.2404366,
-          "googleMapsId": "ChIJBU9a9RVl5kcRauGO7npEArM",
-          "googleMapsUri": "https://maps.google.com/?cid=12898947577521561962&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=r1OERKKpg-o",
-          "description": "파리의 정원에서 즐기는 미슐랭 다이닝을 소개하는 영상에서 방문한 레스토랑. 불로뉴 숲 속에 위치하며, 눈과 입이 모두 즐거운 아름다운 다이닝을 경험할 수 있다."
+          "latitude": 43.047627299999995,
+          "longitude": 2.7905957,
+          "googleMapsId": "ChIJwz7atuhJsBIRZ6esU5Pl6As",
+          "googleMapsUri": "https://maps.google.com/?cid=858188149940856679&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "mEeT5zWyp9Q",
       "title": "3스타 → 2스타 → 1스타 몰락하고 있다는 소식 듣고 얼른 방문해 본 레스토랑 [EN]ㅣL'astrance",
-      "concept": "3스타에서 1스타로 몰락 논란의 L'Astrance",
+      "concept": "32",
       "locations": [
         {
-          "name": "L'Astrance",
-          "displayName": "Astrance",
-          "address": "32 Rue de Longchamp, 75116 Paris, 프랑스",
-          "latitude": 48.8650824,
-          "longitude": 2.2898578,
-          "googleMapsId": "ChIJ_QxhRv1v5kcRyxeqcySoeBQ",
-          "googleMapsUri": "https://maps.google.com/?cid=1475113752476653515&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "name": "32 Rue de Longchamp",
+          "address": "32 Rue de Longchamp, 75016 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 32 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=mEeT5zWyp9Q",
-          "description": "3스타에서 1스타로 몰락하고 있다는 소식을 듣고 방문한 파리의 레스토랑. 과거 3스타의 영광과 현재의 변화를 솔직하게 다룬 영상에서 소개되었다."
+          "latitude": 48.8651154,
+          "longitude": 2.2898502,
+          "googleMapsId": "ChIJH6dnJuVv5kcRqnJ-mHzv_S4",
+          "googleMapsUri": "https://maps.google.com/?cid=3386125813265887914&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
-      "videoId": "dXWlBZfBkKM",
-      "title": "랍스터 3대장 중 이 곳이 끝판왕! 인당 50만원짜리 메뉴 하나하나에 진심인 레스토랑ㅣL'ambroisie",
-      "concept": "파리 랍스터 끝판왕 L'Ambroisie, 인당 50만원",
+      "videoId": "qRMfDWxGKxM",
+      "title": "와인리스트 TOP2 파리 미슐랭 레스토랑! 페어링, 이게 최선입니까? [EN]ㅣLe Taillevent",
+      "concept": "15",
       "locations": [
         {
-          "name": "L'Ambroisie",
-          "displayName": "L'Ambroisie",
-          "address": "9 Pl. des Vosges, 75004 Paris, 프랑스",
-          "latitude": 48.8553396,
-          "longitude": 2.3643541,
-          "googleMapsId": "ChIJK-TZ1v9x5kcRvQoSvNJ21Vo",
-          "googleMapsUri": "https://maps.google.com/?cid=6545268280923392701&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=dXWlBZfBkKM",
-          "description": "파리 랍스터 끝판왕을 소개하는 영상에서 방문한 보주 광장의 미슐랭 3스타 레스토랑. 랍스터 3대장 중 최고로 꼽히며, 인당 50만원의 코스에서 메뉴 하나하나에 진심인 곳이다."
-        }
-      ]
-    },
-    {
-      "videoId": "Kpzqj03ulNo",
-      "title": "샴페인의 본고장 '샹파뉴 랭스'에서 종일 취해있기..🌀진짜 비밀이야 샴페인 하우스🤫[EN]ㅣ샹파뉴 랭스",
-      "concept": "샹파뉴 랭스에서 종일 취하기, 브라세리 Excelsior",
-      "locations": [
-        {
-          "name": "Brasserie Excelsior Reims",
-          "displayName": "Brasserie Excelsior Reims",
-          "address": "96 Pl. Drouet d'Erlon, 51100 Reims, 프랑스",
-          "latitude": 49.25745,
-          "longitude": 4.026276999999999,
-          "googleMapsId": "ChIJBdh7YKp16UcRY1y-loeELiQ",
-          "googleMapsUri": "https://maps.google.com/?cid=2607166952178605155&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Kpzqj03ulNo",
-          "description": "샹파뉴 랭스에서 종일 취하는 여행을 소개하는 영상에서 방문한 브라세리. 샴페인의 본고장에서 진짜 샴페인 하우스를 탐방하며 방문한 곳이다."
+          "name": "15 Rue Lamennais",
+          "address": "15 Rue Lamennais, 75008 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 15 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=qRMfDWxGKxM",
+          "latitude": 48.8741266,
+          "longitude": 2.3024801999999998,
+          "googleMapsId": "ChIJBZVLv8Fv5kcRFjvSNnnoiRc",
+          "googleMapsUri": "https://maps.google.com/?cid=1696142341990136598&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "y6i88w-_hBk",
       "title": "19살부터 서빙 알바로 시작해 20년째 근무 중인 소믈리에가 있는 화이트 와인 최고 파리 레스토랑ㅣLa Cagouille",
-      "concept": "화이트 와인 최고 파리 레스토랑 La Cagouille",
+      "concept": "10",
       "locations": [
         {
           "name": "La Cagouille",
-          "displayName": "La Cagouille",
           "address": "10 place Constantin-Brancusi, 75014 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 10 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=y6i88w-_hBk",
           "latitude": 48.837193299999996,
           "longitude": 2.3208824,
           "googleMapsId": "ChIJl23DU1pu5kcRg1KaCcrIla8",
-          "googleMapsUri": "https://maps.google.com/?cid=12652239498237334147&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=y6i88w-_hBk",
-          "description": "화이트 와인 최고의 파리 레스토랑을 소개하는 영상에서 방문한 곳. 19살부터 서빙 알바로 시작해 20년째 근무 중인 소믈리에가 있으며, 화이트 와인 페어링이 뛰어나다."
+          "googleMapsUri": "https://maps.google.com/?cid=12652239498237334147&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "-yaNxv271Cs",
+      "title": "(EN) 에펠탑 2층에 위치한 미쉐린 원스타 레스토랑",
+      "concept": "5",
+      "locations": [
+        {
+          "name": "5 Av. Gustave Eiffel",
+          "address": "5 Av. Gustave Eiffel, 75007 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 5 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=-yaNxv271Cs",
+          "latitude": 48.858114699999994,
+          "longitude": 2.2945214,
+          "googleMapsId": "ChIJT6Ju8eFv5kcRgAcu3-IV7y0",
+          "googleMapsUri": "https://maps.google.com/?cid=3309888315291731840&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Z6zsnguERvQ",
+      "title": "프랑스 알프스에 숨겨진 맛집? 근사한 풍경과 즐기는 3스타 미슐랭 레스토랑",
+      "concept": "1775",
+      "locations": [
+        {
+          "name": "1775 Rte du Leutaz",
+          "address": "1775 Rte du Leutaz, 74120 Megève, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 1775 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Z6zsnguERvQ",
+          "latitude": 45.830301,
+          "longitude": 6.5970588999999995,
+          "googleMapsId": "ChIJQQPCAf_ii0cR2aMKixDjEaM",
+          "googleMapsUri": "https://maps.google.com/?cid=11750422562978046937&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "dXWlBZfBkKM",
+      "title": "랍스터 3대장 중 이 곳이 끝판왕! 인당 50만원짜리 메뉴 하나하나에 진심인 레스토랑ㅣL'ambroisie",
+      "concept": "9",
+      "locations": [
+        {
+          "name": "9 Pl. des Vosges",
+          "address": "9 Pl. des Vosges, 75004 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 9 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=dXWlBZfBkKM",
+          "latitude": 48.8553584,
+          "longitude": 2.3642182,
+          "googleMapsId": "ChIJp00gLf5x5kcRpqKOw_FP1vg",
+          "googleMapsUri": "https://maps.google.com/?cid=17930606866208826022&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "Kpzqj03ulNo",
+      "title": "샴페인의 본고장 '샹파뉴 랭스'에서 종일 취해있기..🌀진짜 비밀이야 샴페인 하우스🤫[EN]ㅣ샹파뉴 랭스",
+      "concept": "96",
+      "locations": [
+        {
+          "name": "96 Pl. Drouet d'Erlon",
+          "address": "96 Pl. Drouet d'Erlon, 51100 Reims, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 96 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=Kpzqj03ulNo",
+          "latitude": 49.2574499,
+          "longitude": 4.0262967,
+          "googleMapsId": "ChIJOVhPXqp16UcR2U60JM1ODHA",
+          "googleMapsUri": "https://maps.google.com/?cid=8073914874959515353&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "DRxvfZjNbfc",
       "title": "숨겨왔던 나의~ 찐 단골집 대공개! 비밀이야가 아침부터 취하고 싶을 때 찾는다는 이 곳?🥴[EN]ㅣDrouant",
-      "concept": "비밀이야 찐 단골집 Drouant",
+      "concept": "16-18",
       "locations": [
         {
-          "name": "Drouant",
-          "displayName": "Restaurant Drouant",
+          "name": "16-18 Rue Gaillon",
           "address": "16-18 Rue Gaillon, 75002 Paris, 프랑스",
-          "latitude": 48.8687465,
-          "longitude": 2.334434,
-          "googleMapsId": "ChIJeQAhgjpu5kcR2eETKOOnYng",
-          "googleMapsUri": "https://maps.google.com/?cid=8674680426340803033&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 16-18 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=DRxvfZjNbfc",
-          "description": "비밀이야의 찐 단골집을 대공개하는 영상에서 소개된 파리 레스토랑. 아침부터 취하고 싶을 때 찾는다는 곳으로, 숨겨왔던 진짜 단골집이 공개되었다."
+          "latitude": 48.8686426,
+          "longitude": 2.3344381999999997,
+          "googleMapsId": "ChIJAQDMgzpu5kcRwDzY8a0nShA",
+          "googleMapsUri": "https://maps.google.com/?cid=1173794280923741376&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
-      "videoId": "WMx6EFEVQlc",
-      "title": "힙한 내추럴 와인과 어울리는 노르딕 퀴진!👨‍🍳 트렌디한 요리로 오픈 2년만에 미슐랭 스타를 받은 프랑스 니스의 Pure & V를 소개합니다!",
-      "concept": "니스 내추럴 와인 노르딕 퀴진 Pure & V",
+      "videoId": "r1OERKKpg-o",
+      "title": "[EN] 파리의 정원에서 즐기는 미슐랭 다이닝🍽 눈과 입이 모두 즐거운 La Grande Cascade에 다녀왔습니다!",
+      "concept": "Carr",
       "locations": [
         {
-          "name": "Pure & V",
-          "displayName": "Restaurant Pure & V",
-          "address": "7 Rue du Lycée, 06000 Nice, 프랑스",
-          "latitude": 43.6993757,
-          "longitude": 7.274324899999999,
-          "googleMapsId": "ChIJbUiThBLQzRIRS_1yfGa4r64",
-          "googleMapsUri": "https://maps.google.com/?cid=12587482233837911371&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=WMx6EFEVQlc",
-          "description": "니스의 내추럴 와인과 노르딕 퀴진을 소개하는 영상에서 방문한 레스토랑. 오픈 2년만에 미슐랭 스타를 받았으며, 힙한 내추럴 와인과 트렌디한 요리가 특징이다."
+          "name": "꺄흐푸흐 드 롱셩",
+          "address": "Carr de Longchamp, 75016 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 Carr 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=r1OERKKpg-o",
+          "latitude": 48.8644832,
+          "longitude": 2.2379018,
+          "googleMapsId": "ChIJp6Apsy5l5kcRQSBIBpR-VhU",
+          "googleMapsUri": "https://maps.google.com/?cid=1537555497019252801&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
-      "videoId": "3H-b3qKf9NU",
-      "title": "[EN] 100년 역사의 프랑스 리옹 전통 레스토랑🥩 이색적이지만 아쉬움이 남았던 Aux Lyonnais에서의 식사",
-      "concept": "100년 역사 프랑스 리옹 전통 레스토랑 Aux Lyonnais",
+      "videoId": "QIIvV21rErU",
+      "title": "파리 3스타 미슐랭 식당의 위엄...인데 솔직히 감동이 없네요 | Le Gabriel",
+      "concept": "la",
       "locations": [
         {
-          "name": "Aux Lyonnais",
-          "displayName": "Aux Lyonnais",
-          "address": "32 Rue Saint-Marc, 75002 Paris, 프랑스",
-          "latitude": 48.870740999999995,
-          "longitude": 2.338718,
-          "googleMapsId": "ChIJQRZQ6Dtu5kcR-0r2malRDQw",
-          "googleMapsUri": "https://maps.google.com/?cid=868440092026751739&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=3H-b3qKf9NU",
-          "description": "100년 역사의 프랑스 리옹 전통 레스토랑을 소개하는 영상에서 방문한 파리의 부숑 리오네. 이색적이지만 아쉬움이 남았다는 솔직한 후기가 담겨 있다."
-        }
-      ]
-    },
-    {
-      "videoId": "XVahpVb99Ac",
-      "title": "니스 해산물 맛집 원픽은 이 곳! 알 만한 사람들은 다 아는 Boccacio 🦐날 홍합, 날 조개로 주는 싱싱함 클라스..✨[EN]",
-      "concept": "니스 해산물 맛집 원픽 Boccacio",
-      "locations": [
-        {
-          "name": "Boccacio",
-          "displayName": "Boccaccio",
-          "address": "7 Rue Massena, 06000 Nice, 프랑스",
-          "latitude": 43.697682,
-          "longitude": 7.268434999999999,
-          "googleMapsId": "ChIJITv5JKHazRIRSknWDX_Difo",
-          "googleMapsUri": "https://maps.google.com/?cid=18053175531751754058&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XVahpVb99Ac",
-          "description": "니스 해산물 맛집 원픽을 소개하는 영상에서 방문한 레스토랑. 알 만한 사람들은 다 아는 곳으로, 날 홍합과 날 조개로 제공되는 싱싱한 해산물이 인상적이다."
-        }
-      ]
-    },
-    {
-      "videoId": "6rYFA1-cOEw",
-      "title": "파리의 전설적인 1스타 레스토랑🌟[EN]ㅣLucas Carton",
-      "concept": "파리의 전설적인 1스타 Lucas Carton",
-      "locations": [
-        {
-          "name": "Lucas Carton",
-          "displayName": "Lucas Carton",
-          "address": "9 Pl. de la Madeleine, 75008 Paris, 프랑스",
-          "latitude": 48.869681199999995,
-          "longitude": 2.3231271000000002,
-          "googleMapsId": "ChIJrf6XLDNu5kcRgypP8GERVqw",
-          "googleMapsUri": "https://maps.google.com/?cid=12418132134861941379&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6rYFA1-cOEw",
-          "description": "파리의 전설적인 미슐랭 1스타를 소개하는 영상에서 방문한 레스토랑. 오랜 역사와 전통을 자랑하며, 파리를 대표하는 클래식 레스토랑이다."
-        }
-      ]
-    },
-    {
-      "videoId": "IDUozojLxog",
-      "title": "대게 되게 벌크업🦀 파리의 평범한 해산물 레스토랑 퀄리티ㅣ캐주얼하게 갈 수 있는 식당 추천ㅣhuguette, bistro de la mer",
-      "concept": "파리 캐주얼 해산물 레스토랑 Huguette",
-      "locations": [
-        {
-          "name": "Huguette",
-          "displayName": "Huguette, Bistro de la mer",
-          "address": "81 Rue de Seine, 75006 Paris, 프랑스",
-          "latitude": 48.8532996,
-          "longitude": 2.3371134,
-          "googleMapsId": "ChIJZ6UXGNlx5kcRkussL8qcmrI",
-          "googleMapsUri": "https://maps.google.com/?cid=12869771277353413522&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=IDUozojLxog",
-          "description": "파리의 캐주얼 해산물 레스토랑을 소개하는 영상에서 방문한 비스트로 드 라 메르. 대게를 포함한 다양한 해산물을 캐주얼한 분위기에서 즐길 수 있으며, 파리의 평범한 해산물 레스토랑 퀄리티를 보여준다."
-        }
-      ]
-    },
-    {
-      "videoId": "SHVcjUBlRUw",
-      "title": "[EN] 파리에서 만난 매력적인 이국의 맛!🍜 현지보다 맛있는 쿠스쿠스와 쌀국수를 먹고 왔습니다!",
-      "concept": "파리에서 만난 이국의 맛, 쿠스쿠스와 쌀국수",
-      "locations": [
-        {
-          "name": "Au Clair de Lune",
-          "displayName": "Au Clair de Lune",
-          "address": "11 Rue Française, 75002 Paris, 프랑스",
-          "latitude": 48.8646043,
-          "longitude": 2.3476798,
-          "googleMapsId": "ChIJm8dATBhu5kcRYH9dfbzLAD8",
-          "googleMapsUri": "https://maps.google.com/?cid=4539852434807029600&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SHVcjUBlRUw",
-          "description": "파리에서 만난 이국의 맛을 소개하는 영상에서 방문한 쿠스쿠스 맛집. 현지보다 맛있는 쿠스쿠스를 맛볼 수 있으며, 파리의 다양한 식문화를 경험할 수 있다."
-        },
-        {
-          "name": "Le Kok",
-          "displayName": "Le kok",
-          "address": "129 bis Av. de Choisy, 75013 Paris, 프랑스",
-          "latitude": 48.826541299999995,
-          "longitude": 2.3594226,
-          "googleMapsId": "ChIJI7Qxt4hx5kcR-IK2S91wzR8",
-          "googleMapsUri": "https://maps.google.com/?cid=2291611881161786104&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SHVcjUBlRUw",
-          "description": "파리에서 만난 이국의 맛을 소개하는 영상에서 방문한 쌀국수 맛집. 현지보다 맛있다는 평가를 받은 쌀국수를 맛볼 수 있는 곳이다."
-        }
-      ]
-    },
-    {
-      "videoId": "sSrSbgQMu5o",
-      "title": "샴페인의 왕이라고 소개한 메종 크룩의 와이너리, 직접 들어가 보여드립니다🍾[EN]ㅣMaison krug",
-      "concept": "메종 크룩 와이너리 방문",
-      "locations": [
-        {
-          "name": "Maison Krug",
-          "displayName": "Champagne Krug",
-          "address": "5 Rue Coquebert, 51100 Reims, 프랑스",
-          "latitude": 49.2608531,
-          "longitude": 4.0365826,
-          "googleMapsId": "ChIJh0CeIK516UcRGR4cjIO1_ls",
-          "googleMapsUri": "https://maps.google.com/?cid=6628935278131944985&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=sSrSbgQMu5o",
-          "description": "샴페인의 왕이라 소개된 메종 크룩의 와이너리를 직접 방문한 영상. 와이너리 내부를 직접 들어가 보여주며, 크룩 샴페인의 제조 과정을 엿볼 수 있다."
-        }
-      ]
-    },
-    {
-      "videoId": "coBnpOfw1t4",
-      "title": "쌀국수의 원조는 프랑스다?!🍜 파리에서 줄서서 먹는 쌀국수 맛집! (f. 귀국 전 시장 투어)",
-      "concept": "파리 줄서서 먹는 쌀국수 맛집 투어",
-      "locations": [
-        {
-          "name": "Pho Banh Cuon 14",
-          "displayName": "Phở Bánh Cuốn 14",
-          "address": "129 Av. de Choisy, 75013 Paris, 프랑스",
-          "latitude": 48.826326200000004,
-          "longitude": 2.3595762,
-          "googleMapsId": "ChIJI7Qxt4hx5kcRMQE6xMrfhb8",
-          "googleMapsUri": "https://maps.google.com/?cid=13800682695115276593&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=coBnpOfw1t4",
-          "description": "파리에서 줄서서 먹는 쌀국수 맛집을 소개하는 영상에서 방문한 곳. 쌀국수의 원조는 프랑스라는 재미있는 이야기와 함께, 귀국 전 시장 투어로 방문한 맛집이다."
-        }
-      ]
-    },
-    {
-      "videoId": "7O5dGQYeSug",
-      "title": "별빛이 내린다..🌟별이 15개? 프랑스에서 가장 각광받고 있는 셰프의 3스타 레스토랑 [EN]ㅣAlléno Paris",
-      "concept": "프랑스 가장 각광받는 셰프의 3스타 Alléno Paris",
-      "locations": [
-        {
-          "name": "Alléno Paris",
-          "displayName": "Alléno",
-          "address": "8 Av. Dutuit, 75008 Paris, 프랑스",
-          "latitude": 48.8661356,
-          "longitude": 2.3163359000000003,
-          "googleMapsId": "ChIJt_i_hmdv5kcRmMIR274srQM",
-          "googleMapsUri": "https://maps.google.com/?cid=264917151315509912&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=7O5dGQYeSug",
-          "description": "프랑스에서 가장 각광받고 있는 셰프의 3스타 레스토랑을 소개하는 영상에서 방문한 곳. 별이 15개라는 셰프의 실력을 느낄 수 있으며, 별빛이 내리는 듯한 분위기가 인상적이다."
+          "name": "Le Gabriel",
+          "address": "la reserve, 42 Av. Gabriel, 75008 Paris, 프랑스",
+          "description": "Le Gabriel — 비밀이야 in 한국 영상에서 소개한 la 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=QIIvV21rErU",
+          "latitude": 48.8697972,
+          "longitude": 2.3133111,
+          "googleMapsId": "ChIJA1PHDM9v5kcRsdD0Snjw06k",
+          "googleMapsUri": "https://maps.google.com/?cid=12237389011940069553&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "R6DoQ9HncrA",
       "title": "단품 시켰는데 코스가 나오는 프렌치 식당🍾이런 기회 흔치 않아 | 레스쁘아 (with 100만 유튜버 & 신상 크룩)",
-      "concept": "서울 강남 프렌치 레스토랑 레스쁘아",
+      "concept": "대한민국",
       "locations": [
         {
           "name": "레스쁘아",
-          "displayName": "레스쁘아 (L'Espoir) Restaurant français",
           "address": "대한민국 서울특별시 강남구 도산대로56길 10 레스쁘아 2층",
+          "description": "레스쁘아 — 비밀이야 in 한국 영상에서 소개한 서울 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=R6DoQ9HncrA",
           "latitude": 37.5224636,
           "longitude": 127.0401333,
           "googleMapsId": "ChIJpwr6Gm6kfDUR4YOjEQvB5YM",
-          "googleMapsUri": "https://maps.google.com/?cid=9504214841920029665&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=R6DoQ9HncrA",
-          "description": "서울 강남의 프렌치 레스토랑을 소개하는 영상에서 방문한 곳. 단품을 시켰는데 코스가 나올 정도로 관대한 서비스가 특징이며, 100만 유튜버와 신상 크룩 샴페인을 함께 즐겼다."
+          "googleMapsUri": "https://maps.google.com/?cid=9504214841920029665&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "WMx6EFEVQlc",
+      "title": "힙한 내추럴 와인과 어울리는 노르딕 퀴진!👨‍🍳 트렌디한 요리로 오픈 2년만에 미슐랭 스타를 받은 프랑스 니스의 Pure & V를 소개합니다!",
+      "concept": "15",
+      "locations": [
+        {
+          "name": "15 Rue Bottero",
+          "address": "15 Rue Bottero, 06000 Nice, 프랑스",
+          "description": "📢다음 주 영상부터 금요일 오후 6시로 편성 일정이 변경됩니다",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=WMx6EFEVQlc",
+          "latitude": 43.6964829,
+          "longitude": 7.2541088999999985,
+          "googleMapsId": "ChIJVbGPhBLQzRIRKU7whZCWBZM",
+          "googleMapsUri": "https://maps.google.com/?cid=10594039245925535273&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "6rYFA1-cOEw",
+      "title": "파리의 전설적인 1스타 레스토랑🌟[EN]ㅣLucas Carton",
+      "concept": "9",
+      "locations": [
+        {
+          "name": "9 Pl. de la Madeleine",
+          "address": "9 Pl. de la Madeleine, 75008 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 9 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=6rYFA1-cOEw",
+          "latitude": 48.869614299999995,
+          "longitude": 2.3230443999999997,
+          "googleMapsId": "ChIJMx9P08xv5kcRHvrv2SuSvLc",
+          "googleMapsUri": "https://maps.google.com/?cid=13239617721600047646&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "3H-b3qKf9NU",
+      "title": "[EN] 100년 역사의 프랑스 리옹 전통 레스토랑🥩 이색적이지만 아쉬움이 남았던 Aux Lyonnais에서의 식사",
+      "concept": "32",
+      "locations": [
+        {
+          "name": "32 Rue Saint-Marc",
+          "address": "32 Rue Saint-Marc, 75002 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 32 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=3H-b3qKf9NU",
+          "latitude": 48.870773199999995,
+          "longitude": 2.3387089999999997,
+          "googleMapsId": "ChIJa18S6Dtu5kcRUnpDs9Z_iHI",
+          "googleMapsUri": "https://maps.google.com/?cid=8252986877263706706&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "IDUozojLxog",
+      "title": "대게 되게 벌크업🦀 파리의 평범한 해산물 레스토랑 퀄리티ㅣ캐주얼하게 갈 수 있는 식당 추천ㅣhuguette, bistro de la mer",
+      "concept": "81",
+      "locations": [
+        {
+          "name": "81 Rue de Seine",
+          "address": "81 Rue de Seine, 75006 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 81 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=IDUozojLxog",
+          "latitude": 48.853367399999996,
+          "longitude": 2.3371085,
+          "googleMapsId": "ChIJZ6UXGNlx5kcRHo2jv9gU1Qc",
+          "googleMapsUri": "https://maps.google.com/?cid=564380249465523486&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "7O5dGQYeSug",
+      "title": "별빛이 내린다..🌟별이 15개? 프랑스에서 가장 각광받고 있는 셰프의 3스타 레스토랑 [EN]ㅣAlléno Paris",
+      "concept": "Carré",
+      "locations": [
+        {
+          "name": "Carré des",
+          "address": "Carré des, 8 Av. Dutuit, 75008 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 8 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=7O5dGQYeSug",
+          "latitude": 48.8661252,
+          "longitude": 2.3164184,
+          "googleMapsId": "ChIJOdDV79Fv5kcRurM-hvX_QyU",
+          "googleMapsUri": "https://maps.google.com/?cid=2685271232827274170&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "SHVcjUBlRUw",
+      "title": "[EN] 파리에서 만난 매력적인 이국의 맛!🍜 현지보다 맛있는 쿠스쿠스와 쌀국수를 먹고 왔습니다!",
+      "concept": "11",
+      "locations": [
+        {
+          "name": "11 Rue Française",
+          "address": "11 Rue Française, 75002 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 11 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SHVcjUBlRUw",
+          "latitude": 48.8645907,
+          "longitude": 2.3476212999999997,
+          "googleMapsId": "ChIJy2MgTBhu5kcRKoCzFAFJq9g",
+          "googleMapsUri": "https://maps.google.com/?cid=15612652802201059370&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "129 bis Av. de Choisy",
+          "address": "129 bis Av. de Choisy, 75013 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 11 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=SHVcjUBlRUw",
+          "latitude": 48.8264923,
+          "longitude": 2.3592662,
+          "googleMapsId": "ChIJ-cmesYhx5kcRDYMEzldQshU",
+          "googleMapsUri": "https://maps.google.com/?cid=1563400358699762445&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "coBnpOfw1t4",
+      "title": "쌀국수의 원조는 프랑스다?!🍜 파리에서 줄서서 먹는 쌀국수 맛집! (f. 귀국 전 시장 투어)",
+      "concept": "129",
+      "locations": [
+        {
+          "name": "129 Av. de Choisy",
+          "address": "129 Av. de Choisy, 75013 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 129 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=coBnpOfw1t4",
+          "latitude": 48.826384499999996,
+          "longitude": 2.3595231,
+          "googleMapsId": "ChIJfdgFsIhx5kcRmJw5O8j9qa4",
+          "googleMapsUri": "https://maps.google.com/?cid=12585869670092479640&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "3 Rue Volta",
+          "address": "3 Rue Volta, 75003 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 129 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=coBnpOfw1t4",
+          "latitude": 48.864732499999995,
+          "longitude": 2.3567814,
+          "googleMapsId": "ChIJb-YLNgVu5kcRLHD67Fo1M2s",
+          "googleMapsUri": "https://maps.google.com/?cid=7724576450509697068&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        },
+        {
+          "name": "몽또흐겨이 가",
+          "address": "Rue Montorgueil, Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 129 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=coBnpOfw1t4",
+          "latitude": 48.8647834,
+          "longitude": 2.346804,
+          "googleMapsId": "ChIJwUCsQRhu5kcRLgoASQ1fQyQ",
+          "googleMapsUri": "https://maps.google.com/?cid=2613036719468972590&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "WmKBpFDk1YQ",
       "title": "많은 분들이 기다려 주신 베르사유 궁전 디너 공개합니다✨ 전세계 공통 '밤비'로 통하는 사슴고기? 🦌ㅣLe Grand Contrôle [EN]",
-      "concept": "베르사유 궁전 호텔 디너",
+      "concept": "Le",
       "locations": [
         {
           "name": "Le Grand Contrôle",
-          "displayName": "Airelles Château de Versailles, Le Grand Contrôle",
-          "address": "12 Rue de l'Indépendance Américaine, 78000 Versailles, 프랑스",
+          "address": "Le Grand Contrôle, 12 Rue de l'Indépendance Américaine, 78000 Versailles, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 12 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=WmKBpFDk1YQ",
           "latitude": 48.8013233,
           "longitude": 2.1199224,
-          "googleMapsId": "ChIJp9eEe6x95kcRx9ZXHHSdrPc",
-          "googleMapsUri": "https://maps.google.com/?cid=17846812545379718855&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=WmKBpFDk1YQ",
-          "description": "베르사유 궁전 디너를 소개하는 영상에서 방문한 호텔 레스토랑. 세계 공통으로 '밤비'로 통하는 사슴고기 등 특별한 메뉴가 제공되며, 궁전에서의 디너가 인상적이다."
-        }
-      ]
-    },
-    {
-      "videoId": "4J6RLbRSu64",
-      "title": "한국에 상륙하는 프랑스 유일 여성 3스타 셰프 레스토랑! 한국에서 무사히 성공할 수 있을까? [EN]ㅣLa dame de pic",
-      "concept": "프랑스 유일 여성 3스타 셰프 La Dame de Pic",
-      "locations": [
-        {
-          "name": "La Dame de Pic",
-          "displayName": "La Dame de Pic",
-          "address": "20 Rue du Louvre, 75001 Paris, 프랑스",
-          "latitude": 48.8614756,
-          "longitude": 2.3413144999999997,
-          "googleMapsId": "ChIJaWy42CNu5kcRSLqIejQtI7s",
-          "googleMapsUri": "https://maps.google.com/?cid=13484671412694727240&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=4J6RLbRSu64",
-          "description": "프랑스 유일 여성 3스타 셰프의 레스토랑을 소개하는 영상에서 방문한 파리의 레스토랑. 한국에 상륙한다는 소식과 함께, 무사히 성공할 수 있을지에 대한 기대가 담겨 있다."
+          "googleMapsId": "ChIJ6U6dbL995kcR3XxTB_Jvq4c",
+          "googleMapsUri": "https://maps.google.com/?cid=9776030501433474269&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "E8LBPjio53s",
       "title": "세계에서 가장 아름다운 레스토랑으로 손꼽히는 곳✨ 화려함 끝판왕과 거장 셰프와의 만남[EN]ㅣLe Meurice Alain Ducasse",
-      "concept": "세계에서 가장 아름다운 레스토랑 Le Meurice Alain Ducasse",
+      "concept": "228",
       "locations": [
         {
-          "name": "Le Meurice Alain Ducasse",
-          "displayName": "Restaurant le Meurice Alain Ducasse",
+          "name": "228 Rue de Rivoli",
           "address": "228 Rue de Rivoli, 75001 Paris, 프랑스",
-          "latitude": 48.8652915,
-          "longitude": 2.3280563,
-          "googleMapsId": "ChIJQdFbHk9v5kcRBtFW38NDhbc",
-          "googleMapsUri": "https://maps.google.com/?cid=13224050389388022022&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 228 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=E8LBPjio53s",
-          "description": "세계에서 가장 아름다운 레스토랑을 소개하는 영상에서 방문한 파리의 3스타 레스토랑. 화려함 끝판왕이라는 평가와 함께, 거장 알랭 뒤카스 셰프와의 만남이 인상적이다."
+          "latitude": 48.865354599999996,
+          "longitude": 2.3282186,
+          "googleMapsId": "ChIJ28ff3y1u5kcRs25dsaRcMJw",
+          "googleMapsUri": "https://maps.google.com/?cid=11254597331218951859&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "WSqVHx2iRNY",
+      "title": "전세계 5명 중 하나! 여성 3스타 셰프의 요리는? | Marsan by Helene Darroze",
+      "concept": "4",
+      "locations": [
+        {
+          "name": "Marsan by Helene Darroze",
+          "address": "4 Rue d'Assas, 75006 Paris, 프랑스",
+          "description": "Marsan by Helene Darroze — 비밀이야 in 한국 영상에서 소개한 4 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=WSqVHx2iRNY",
+          "latitude": 48.8500532,
+          "longitude": 2.3278184,
+          "googleMapsId": "ChIJ81phINFx5kcRW5UjTPo8aGc",
+          "googleMapsUri": "https://maps.google.com/?cid=7451272629201376603&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "4J6RLbRSu64",
+      "title": "한국에 상륙하는 프랑스 유일 여성 3스타 셰프 레스토랑! 한국에서 무사히 성공할 수 있을까? [EN]ㅣLa dame de pic",
+      "concept": "20",
+      "locations": [
+        {
+          "name": "20 Rue du Louvre",
+          "address": "20 Rue du Louvre, 75001 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 20 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=4J6RLbRSu64",
+          "latitude": 48.8614427,
+          "longitude": 2.3413816,
+          "googleMapsId": "ChIJS8Ug2CNu5kcRV82fz49wHFY",
+          "googleMapsUri": "https://maps.google.com/?cid=6204958149575691607&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "XehtVBQvDhM",
       "title": "3만 원 대에 즐기는 프랑스 명장 요리? | Daniel et Denise",
-      "concept": "리옹 3만원대 명장 요리 Daniel et Denise",
+      "concept": "36",
       "locations": [
         {
-          "name": "Daniel et Denise",
-          "displayName": "Daniel & Denise Saint Jean - Bouchon Lyonnais",
+          "name": "Daniel & Denise Saint Jean - Bouchon Lyonnais",
           "address": "36 Rue Tramassac, 69005 Lyon, 프랑스",
+          "description": "전화번호: +33 4 78 42 24 62",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XehtVBQvDhM",
           "latitude": 45.760353599999995,
           "longitude": 4.8254871,
           "googleMapsId": "ChIJZ7jWkKvr9EcRtV8rnu3DfmQ",
-          "googleMapsUri": "https://maps.google.com/?cid=7241440676186644405&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=XehtVBQvDhM",
-          "description": "리옹에서 3만 원대에 즐기는 명장 요리를 소개하는 영상에서 방문한 부숑 리오네. MOF(프랑스 국가 최우수 장인)가 운영하며, 합리적인 가격에 전통 리옹 요리를 맛볼 수 있다."
-        }
-      ]
-    },
-    {
-      "videoId": "aQWebvFbH-o",
-      "title": "프랑스 한식당은 한국의 맛을 잘 나타낼 수 있을까?[EN]ㅣSetopa",
-      "concept": "파리 한식당 Setopa",
-      "locations": [
-        {
-          "name": "Setopa",
-          "displayName": "Sétopa",
-          "address": "6 Rue Dupuytren, 75006 Paris, 프랑스",
-          "latitude": 48.8517392,
-          "longitude": 2.3394057999999998,
-          "googleMapsId": "ChIJl8BALABx5kcRcqB9X8pffNA",
-          "googleMapsUri": "https://maps.google.com/?cid=15022987779791233138&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=aQWebvFbH-o",
-          "description": "프랑스 한식당을 소개하는 영상에서 방문한 파리의 한식 레스토랑. 프랑스에서 한국의 맛을 잘 나타낼 수 있는지에 대한 솔직한 평가가 담겨 있다."
+          "googleMapsUri": "https://maps.google.com/?cid=7241440676186644405&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "vmGwRznz0Yo",
       "title": "13가지 코스 요리가 나오는데 디저트가 가장 맛있다고?! 🍨🫢  [EN]ㅣBlanc",
-      "concept": "13가지 코스, 디저트가 가장 맛있는 Blanc",
+      "concept": "54",
       "locations": [
         {
-          "name": "Blanc",
-          "displayName": "Blanc",
-          "address": "52 Rue de Longchamp, 75116 Paris, 프랑스",
-          "latitude": 48.865128299999995,
-          "longitude": 2.2875706,
-          "googleMapsId": "ChIJ-We0YUpv5kcREptIC-71C_Y",
-          "googleMapsUri": "https://maps.google.com/?cid=17729534760814418706&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "name": "54 Rue de Longchamp",
+          "address": "54 Rue de Longchamp, 75116 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 54 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=vmGwRznz0Yo",
-          "description": "13가지 코스 요리 중 디저트가 가장 맛있는 레스토랑을 소개하는 영상에서 방문한 파리의 레스토랑. 13가지 코스가 제공되지만 디저트가 가장 인상적이라는 독특한 평가가 담겨 있다."
-        }
-      ]
-    },
-    {
-      "videoId": "shmIpRm4PRE",
-      "title": "헤밍웨이가 해산물을 먹고 싶을 때면 갔던 파리 브라세리🦞[EN]ㅣLa closerie des lias",
-      "concept": "헤밍웨이가 다녔던 파리 브라세리 La Closerie des Lilas",
-      "locations": [
-        {
-          "name": "La Closerie des Lilas",
-          "displayName": "La Closerie des Lilas",
-          "address": "171 Bd du Montparnasse, 75006 Paris, 프랑스",
-          "latitude": 48.8401436,
-          "longitude": 2.3360431999999998,
-          "googleMapsId": "ChIJD0MBxsZx5kcREfMy9IsrUTo",
-          "googleMapsUri": "https://maps.google.com/?cid=4202187807410811665&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=shmIpRm4PRE",
-          "description": "헤밍웨이가 해산물을 먹고 싶을 때면 찾았던 파리 브라세리를 소개하는 영상에서 방문한 곳. 문학적 역사가 깃든 공간에서 해산물을 즐길 수 있으며, 클래식한 파리 분위기가 매력적이다."
+          "latitude": 48.8651274,
+          "longitude": 2.2874205,
+          "googleMapsId": "ChIJV7sF4fpv5kcR2En_Vb7U2uA",
+          "googleMapsUri": "https://maps.google.com/?cid=16202496523370449368&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "AxLRF-gZmSA",
       "title": "센 강 유람선 중 유일하게 1스타를 받은 최고의 크루즈 레스토랑은? ⛴️🍷 [EN]ㅣDon Juan II",
-      "concept": "센강 유일 미슐랭 1스타 크루즈 Don Juan II",
+      "concept": "5",
       "locations": [
         {
-          "name": "Don Juan II",
-          "displayName": "Don Juan II | Yachts de Paris",
+          "name": "5 Port Debilly",
           "address": "5 Port Debilly, 75016 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 5 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=AxLRF-gZmSA",
           "latitude": 48.8627847,
           "longitude": 2.2956447,
-          "googleMapsId": "ChIJV893WNdx5kcRId2B1-rDEZU",
-          "googleMapsUri": "https://maps.google.com/?cid=10741581999660719393&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=AxLRF-gZmSA",
-          "description": "센강 유람선 중 유일하게 미슐랭 1스타를 받은 크루즈 레스토랑을 소개하는 영상에서 방문한 곳. 센강 위에서 파리의 야경과 함께 미슐랭 수준의 식사를 즐길 수 있는 특별한 경험이다."
+          "googleMapsId": "ChIJX2wLt-Zv5kcRB4wDBqDAC0o",
+          "googleMapsUri": "https://maps.google.com/?cid=5335569977078680583&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "shmIpRm4PRE",
+      "title": "헤밍웨이가 해산물을 먹고 싶을 때면 갔던 파리 브라세리🦞[EN]ㅣLa closerie des lias",
+      "concept": "171",
+      "locations": [
+        {
+          "name": "171 Bd du Montparnasse",
+          "address": "171 Bd du Montparnasse, 75006 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 171 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=shmIpRm4PRE",
+          "latitude": 48.840149,
+          "longitude": 2.3360122999999997,
+          "googleMapsId": "ChIJrfYSlcZx5kcRw21ba6l36QI",
+          "googleMapsUri": "https://maps.google.com/?cid=209830427183771075&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
+        }
+      ]
+    },
+    {
+      "videoId": "aQWebvFbH-o",
+      "title": "프랑스 한식당은 한국의 맛을 잘 나타낼 수 있을까?[EN]ㅣSetopa",
+      "concept": "6",
+      "locations": [
+        {
+          "name": "6 Rue Dupuytren",
+          "address": "6 Rue Dupuytren, 75006 Paris, 프랑스",
+          "description": " — 비밀이야 in 한국 영상에서 소개한 6 맛집.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=aQWebvFbH-o",
+          "latitude": 48.8517352,
+          "longitude": 2.3394201,
+          "googleMapsId": "ChIJQfdcpN5x5kcRn385Lgx5FeY",
+          "googleMapsUri": "https://maps.google.com/?cid=16579290696456437663&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "OR4FNr-0I6c",
       "title": "경비행기가 있는 미슐랭 투스타 에펠탑뷰 레스토랑! 프랑스식 김치의 충격적인 맛 [EN] ㅣL'Oiseau Blanc",
-      "concept": "미슐랭 2스타 에펠탑뷰 L'Oiseau Blanc",
+      "concept": "19",
       "locations": [
         {
-          "name": "L'Oiseau Blanc",
-          "displayName": "L'Oiseau Blanc",
+          "name": "19 Av. Kléber",
           "address": "19 Av. Kléber, 75116 Paris, 프랑스",
-          "latitude": 48.8707437,
-          "longitude": 2.2933136999999997,
-          "googleMapsId": "ChIJZXST6-5v5kcR2yYcipYCUqA",
-          "googleMapsUri": "https://maps.google.com/?cid=11552298839744194267&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
+          "description": " — 비밀이야 in 한국 영상에서 소개한 19 맛집.",
           "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=OR4FNr-0I6c",
-          "description": "미슐랭 2스타 에펠탑 뷰 레스토랑을 소개하는 영상에서 방문한 곳. 경비행기가 전시된 독특한 인테리어가 특징이며, 에펠탑 뷰와 함께 프랑스식 김치의 충격적인 맛도 화제가 되었다."
-        }
-      ]
-    },
-    {
-      "videoId": "tME5rlpprwI",
-      "title": "니스 실패없는 현지 식당 추천! 해산물이 질린다면 이곳으로 가세요ㅣLe Petit Palais&La Favola",
-      "concept": "니스 실패없는 현지 식당 추천",
-      "locations": [
-        {
-          "name": "Le Petit Palais",
-          "displayName": "Le Petit Palais - Steakhouse à Nice",
-          "address": "3 Rue de la Préfecture, 06000 Nice, 프랑스",
-          "latitude": 43.6970041,
-          "longitude": 7.2736966999999995,
-          "googleMapsId": "ChIJh5Djo3_bzRIR3PYZy2Wh94o",
-          "googleMapsUri": "https://maps.google.com/?cid=10013649755052832476&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tME5rlpprwI",
-          "description": "니스 실패없는 현지 식당을 추천하는 영상에서 방문한 스테이크하우스. 해산물이 질릴 때 가기 좋은 곳으로, 니스의 현지 분위기를 느끼며 식사할 수 있다."
-        },
-        {
-          "name": "La Favola",
-          "displayName": "La Favola",
-          "address": "13 Cr Saleya, 06300 Nice, 프랑스",
-          "latitude": 43.6958589,
-          "longitude": 7.273727999999999,
-          "googleMapsId": "ChIJF7GuAaPazRIRBr6thVAlsy4",
-          "googleMapsUri": "https://maps.google.com/?cid=3365074374346259974&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tME5rlpprwI",
-          "description": "니스 실패없는 현지 식당을 추천하는 영상에서 방문한 쿠르 살레야의 레스토랑. 해산물이 질릴 때 찾기 좋은 대안으로, 니스 현지인들이 즐겨 찾는 곳이다."
+          "latitude": 48.8706101,
+          "longitude": 2.2938337,
+          "googleMapsId": "ChIJEWaO6-5v5kcRhO55Cimnzx4",
+          "googleMapsUri": "https://maps.google.com/?cid=2220176936028204676&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     },
     {
       "videoId": "tifp9zuDE7k",
       "title": "프랑스 전성기를 그대로 구현한 1박에 무려 450만원짜리 베르사유 궁전 호텔의 모습은? 프라이빗 투어까지 잊지 못할 하룻밤ㅣLe Grand Contrôle [EN]",
-      "concept": "베르사유 궁전 호텔 프라이빗 투어, 1박 450만원",
+      "concept": "Le",
       "locations": [
         {
           "name": "Le Grand Contrôle",
-          "displayName": "Airelles Château de Versailles, Le Grand Contrôle",
-          "address": "12 Rue de l'Indépendance Américaine, 78000 Versailles, 프랑스",
+          "address": "Le Grand Contrôle, 12 Rue de l'Indépendance Américaine, 78000 Versailles, 프랑스",
+          "description": "다음 편에 베르사유 궁전 호텔 디너가 공개됩니다.",
+          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tifp9zuDE7k",
           "latitude": 48.8013233,
           "longitude": 2.1199224,
-          "googleMapsId": "ChIJp9eEe6x95kcRx9ZXHHSdrPc",
-          "googleMapsUri": "https://maps.google.com/?cid=17846812545379718855&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA",
-          "source": "description",
-          "timestamp": null,
-          "videoUrlWithTimestamp": "https://www.youtube.com/watch?v=tifp9zuDE7k",
-          "description": "베르사유 궁전 호텔의 프라이빗 투어를 소개하는 영상에서 방문한 1박 450만원의 럭셔리 호텔. 프랑스 전성기를 그대로 구현한 숙소로, 잊지 못할 하룻밤을 보낼 수 있다."
+          "googleMapsId": "ChIJ6U6dbL995kcR3XxTB_Jvq4c",
+          "googleMapsUri": "https://maps.google.com/?cid=9776030501433474269&g_mp=Cidnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLlNlYXJjaFRleHQQAhgEIAA"
         }
       ]
     }

--- a/.claude/workspace/youtube/PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI/video_info.json
+++ b/.claude/workspace/youtube/PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI/video_info.json
@@ -1,0 +1,403 @@
+{
+  "type": "playlist",
+  "id": "PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI",
+  "title": "비밀이야 in 프랑스 🥖",
+  "description": "",
+  "url": "https://www.youtube.com/playlist?list=PLkmBZE3qxSdHktyll4GHSDVTsPfOpPvoI",
+  "channelName": "비밀이야 bimirya",
+  "channel": {
+    "id": "UCaKQ7_GT0k8u_sL0nE2tgkA",
+    "title": "비밀이야 bimirya",
+    "handle": "@bimirya",
+    "url": "https://www.youtube.com/@bimirya",
+    "description": "먹자! 마시자! 놀러 다니자!\n\n🍕 비즈니스 문의 : bimiryabdr@naver.com\n🍷 인스타그램 : www.instagram.com/bimirya\n🥪 네이버 블로그 : blog.naver.com/mardukas\n",
+    "thumbnailUrl": "https://yt3.ggpht.com/xTnhjCg0_h3Qdsy7Ar2B8AM8150MF0v-_CkRyCwRz6AK4-ZGEZVjYtWViSy6_9uxal7v1rHJKA=s800-c-k-c0x00ffffff-no-rj"
+  },
+  "selectedVideos": [
+    {
+      "videoId": "l_WnIdakons",
+      "title": "1582년에 오픈했다는 프랑스의 전설적인 와인 성지🍷 50만 병 이상의 와인을 보유하고 있다는 라 투르 다르장에서 117만번째 오리를 맛보고 왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 0,
+      "url": "https://www.youtube.com/watch?v=l_WnIdakons"
+    },
+    {
+      "videoId": "GoHWikk8Lbc",
+      "title": "[EN] 파리의 독보적인 미슐랭 3스타 레스토랑?👀 프랑스 최고 셰프가 이끄는 Epicure에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 1,
+      "url": "https://www.youtube.com/watch?v=GoHWikk8Lbc"
+    },
+    {
+      "videoId": "gWwmfIk70LI",
+      "title": "미쉐린 3스타 레스토랑에서 와인과 함께🍷",
+      "channelName": "비밀이야 bimirya",
+      "position": 2,
+      "url": "https://www.youtube.com/watch?v=gWwmfIk70LI"
+    },
+    {
+      "videoId": "6vYMBhJOneU",
+      "title": "반백년 째 3스타 식당. 대체 뭐가 나올까? | Les Prés d'Eugénie",
+      "channelName": "비밀이야 bimirya",
+      "position": 3,
+      "url": "https://www.youtube.com/watch?v=6vYMBhJOneU"
+    },
+    {
+      "videoId": "gA1c2apLx6w",
+      "title": "프랑스를 간다면 꼭 가야할 레스토랑!🥂 600종의 샴페인, 1100종의 와인 리스트를 보유한 럭셔리 & 클래식 끝판왕 Le Parc Les Crayeres를 소개합니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 4,
+      "url": "https://www.youtube.com/watch?v=gA1c2apLx6w"
+    },
+    {
+      "videoId": "R-ilj6zvNuc",
+      "title": "꿈의 도시 남프랑스 에즈!🏘️ 환상적인 전망을 갖춘 2스타에서 발견한 전설의 와인ㅣLa Chèvre D'Or",
+      "channelName": "비밀이야 bimirya",
+      "position": 5,
+      "url": "https://www.youtube.com/watch?v=R-ilj6zvNuc"
+    },
+    {
+      "videoId": "halkS8GZClw",
+      "title": "창의적인 요리와 자연이 함께하는 남프랑스 최고의 레스토랑!",
+      "channelName": "비밀이야 bimirya",
+      "position": 6,
+      "url": "https://www.youtube.com/watch?v=halkS8GZClw"
+    },
+    {
+      "videoId": "b1ezkKcXkBM",
+      "title": "50만 병 넘는 와인을 판매하는 라 투르 다르장! 117만번 째 이후 118만번 째 오리 먹으러 방문했습니다 [EN]ㅣLa tour d'argent",
+      "channelName": "비밀이야 bimirya",
+      "position": 7,
+      "url": "https://www.youtube.com/watch?v=b1ezkKcXkBM"
+    },
+    {
+      "videoId": "d3eVlWLO98Y",
+      "title": "유럽 단골집 예약! 프랑스 최고의 해산물 레스토랑 소개합니다",
+      "channelName": "비밀이야 bimirya",
+      "position": 8,
+      "url": "https://www.youtube.com/watch?v=d3eVlWLO98Y"
+    },
+    {
+      "videoId": "-NcF7fdSvFo",
+      "title": "[EN] 프랑스 굴지에 있는 미슐랭 3스타 레스토랑? 역대급 완성도의 요리를 선보이는 Régis & Jacques Marcon에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 9,
+      "url": "https://www.youtube.com/watch?v=-NcF7fdSvFo"
+    },
+    {
+      "videoId": "JXRSt5lFPQM",
+      "title": "[EN] 1784년에 생긴 파리의 시그니처 레스토랑?✨ 프랑스 최고의 셰프가 운영하는 역사적인 레스토랑 Le Grand Véfour에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 10,
+      "url": "https://www.youtube.com/watch?v=JXRSt5lFPQM"
+    },
+    {
+      "videoId": "PBEH_kLnL7w",
+      "title": "프랑스 1등 맛집! 자신있게 추천합니다 | \"Le MaZenay\"",
+      "channelName": "비밀이야 bimirya",
+      "position": 11,
+      "url": "https://www.youtube.com/watch?v=PBEH_kLnL7w"
+    },
+    {
+      "videoId": "Uiq6Vi9Bhm0",
+      "title": "보르도 5대 샤또 중 한 곳이 오너인 르 클라랑스🍷 수만 병의 올드 빈티지 와인 리스트를 보유한 럭셔리 레스토랑!",
+      "channelName": "비밀이야 bimirya",
+      "position": 12,
+      "url": "https://www.youtube.com/watch?v=Uiq6Vi9Bhm0"
+    },
+    {
+      "videoId": "0EJ4-mDI1do",
+      "title": "프랑스 굴 요리의 최강자! 1908년에 오픈해서 113년째 운영 중인 역사와 전통의 식당을 다녀왔습니다! 야외에서 샴페인 한 잔과 함께 먹는 신선한 해산물의 맛은?!",
+      "channelName": "비밀이야 bimirya",
+      "position": 13,
+      "url": "https://www.youtube.com/watch?v=0EJ4-mDI1do"
+    },
+    {
+      "videoId": "cgY_FyxsGp8",
+      "title": "프랑스에 온다면 꼭 들러봐야 할 해산물 캐주얼 식당",
+      "channelName": "비밀이야 bimirya",
+      "position": 14,
+      "url": "https://www.youtube.com/watch?v=cgY_FyxsGp8"
+    },
+    {
+      "videoId": "KYYsPZ4ZSmU",
+      "title": "하룻밤 550만 원 투숙객만 예약 가능? 극강의 예약 난이도 뚫고 다녀왔습니다 | 플레니튀드",
+      "channelName": "비밀이야 bimirya",
+      "position": 15,
+      "url": "https://www.youtube.com/watch?v=KYYsPZ4ZSmU"
+    },
+    {
+      "videoId": "wrSNqw6Mvek",
+      "title": "아시아/일본인 셰프 최초의 쓰리스타⭐⭐⭐",
+      "channelName": "비밀이야 bimirya",
+      "position": 16,
+      "url": "https://www.youtube.com/watch?v=wrSNqw6Mvek"
+    },
+    {
+      "videoId": "QuNzFUH_IHo",
+      "title": "[EN] 파리지앵이 된듯한 역대급 조식과 브런치🍽 파리에서 가장 핫한 브런치 레스토랑에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 17,
+      "url": "https://www.youtube.com/watch?v=QuNzFUH_IHo"
+    },
+    {
+      "videoId": "Q_U8VL2gSqk",
+      "title": "(EN) 찐 푸아그라 꼭 맛보세요!",
+      "channelName": "비밀이야 bimirya",
+      "position": 18,
+      "url": "https://www.youtube.com/watch?v=Q_U8VL2gSqk"
+    },
+    {
+      "videoId": "azEpgYW3K94",
+      "title": "[EN] 파리 최고의 해산물 파인 다이닝🍽 생선 요리의 장인이 운영하는 La Table d'Akihiro에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 19,
+      "url": "https://www.youtube.com/watch?v=azEpgYW3K94"
+    },
+    {
+      "videoId": "NUyL5KzBhPI",
+      "title": "비밀이야가 마음에 들어 X 3번 외친 곳, 파리에서 괜찮은 가격의 와인+미슐랭🌟 레스토랑을 찾는다면! [EN]ㅣLe Villaret",
+      "channelName": "비밀이야 bimirya",
+      "position": 20,
+      "url": "https://www.youtube.com/watch?v=NUyL5KzBhPI"
+    },
+    {
+      "videoId": "xp9qbTCMuFE",
+      "title": "프랑스 산 속 오지마을에서 만난 인생 요리 | Auberge du Vieux Puits",
+      "channelName": "비밀이야 bimirya",
+      "position": 21,
+      "url": "https://www.youtube.com/watch?v=xp9qbTCMuFE"
+    },
+    {
+      "videoId": "mEeT5zWyp9Q",
+      "title": "3스타 → 2스타 → 1스타 몰락하고 있다는 소식 듣고 얼른 방문해 본 레스토랑 [EN]ㅣL'astrance",
+      "channelName": "비밀이야 bimirya",
+      "position": 22,
+      "url": "https://www.youtube.com/watch?v=mEeT5zWyp9Q"
+    },
+    {
+      "videoId": "qRMfDWxGKxM",
+      "title": "와인리스트 TOP2 파리 미슐랭 레스토랑! 페어링, 이게 최선입니까? [EN]ㅣLe Taillevent",
+      "channelName": "비밀이야 bimirya",
+      "position": 23,
+      "url": "https://www.youtube.com/watch?v=qRMfDWxGKxM"
+    },
+    {
+      "videoId": "y6i88w-_hBk",
+      "title": "19살부터 서빙 알바로 시작해 20년째 근무 중인 소믈리에가 있는 화이트 와인 최고 파리 레스토랑ㅣLa Cagouille",
+      "channelName": "비밀이야 bimirya",
+      "position": 24,
+      "url": "https://www.youtube.com/watch?v=y6i88w-_hBk"
+    },
+    {
+      "videoId": "-yaNxv271Cs",
+      "title": "(EN) 에펠탑 2층에 위치한 미쉐린 원스타 레스토랑",
+      "channelName": "비밀이야 bimirya",
+      "position": 25,
+      "url": "https://www.youtube.com/watch?v=-yaNxv271Cs"
+    },
+    {
+      "videoId": "Z6zsnguERvQ",
+      "title": "프랑스 알프스에 숨겨진 맛집? 근사한 풍경과 즐기는 3스타 미슐랭 레스토랑",
+      "channelName": "비밀이야 bimirya",
+      "position": 26,
+      "url": "https://www.youtube.com/watch?v=Z6zsnguERvQ"
+    },
+    {
+      "videoId": "dXWlBZfBkKM",
+      "title": "랍스터 3대장 중 이 곳이 끝판왕! 인당 50만원짜리 메뉴 하나하나에 진심인 레스토랑ㅣL'ambroisie",
+      "channelName": "비밀이야 bimirya",
+      "position": 27,
+      "url": "https://www.youtube.com/watch?v=dXWlBZfBkKM"
+    },
+    {
+      "videoId": "Kpzqj03ulNo",
+      "title": "샴페인의 본고장 '샹파뉴 랭스'에서 종일 취해있기..🌀진짜 비밀이야 샴페인 하우스🤫[EN]ㅣ샹파뉴 랭스",
+      "channelName": "비밀이야 bimirya",
+      "position": 28,
+      "url": "https://www.youtube.com/watch?v=Kpzqj03ulNo"
+    },
+    {
+      "videoId": "DRxvfZjNbfc",
+      "title": "숨겨왔던 나의~ 찐 단골집 대공개! 비밀이야가 아침부터 취하고 싶을 때 찾는다는 이 곳?🥴[EN]ㅣDrouant",
+      "channelName": "비밀이야 bimirya",
+      "position": 29,
+      "url": "https://www.youtube.com/watch?v=DRxvfZjNbfc"
+    },
+    {
+      "videoId": "r1OERKKpg-o",
+      "title": "[EN] 파리의 정원에서 즐기는 미슐랭 다이닝🍽 눈과 입이 모두 즐거운 La Grande Cascade에 다녀왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 30,
+      "url": "https://www.youtube.com/watch?v=r1OERKKpg-o"
+    },
+    {
+      "videoId": "QIIvV21rErU",
+      "title": "파리 3스타 미슐랭 식당의 위엄...인데 솔직히 감동이 없네요 | Le Gabriel",
+      "channelName": "비밀이야 bimirya",
+      "position": 31,
+      "url": "https://www.youtube.com/watch?v=QIIvV21rErU"
+    },
+    {
+      "videoId": "R6DoQ9HncrA",
+      "title": "단품 시켰는데 코스가 나오는 프렌치 식당🍾이런 기회 흔치 않아 | 레스쁘아 (with 100만 유튜버 & 신상 크룩)",
+      "channelName": "비밀이야 bimirya",
+      "position": 32,
+      "url": "https://www.youtube.com/watch?v=R6DoQ9HncrA"
+    },
+    {
+      "videoId": "WMx6EFEVQlc",
+      "title": "힙한 내추럴 와인과 어울리는 노르딕 퀴진!👨‍🍳 트렌디한 요리로 오픈 2년만에 미슐랭 스타를 받은 프랑스 니스의 Pure & V를 소개합니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 33,
+      "url": "https://www.youtube.com/watch?v=WMx6EFEVQlc"
+    },
+    {
+      "videoId": "6rYFA1-cOEw",
+      "title": "파리의 전설적인 1스타 레스토랑🌟[EN]ㅣLucas Carton",
+      "channelName": "비밀이야 bimirya",
+      "position": 34,
+      "url": "https://www.youtube.com/watch?v=6rYFA1-cOEw"
+    },
+    {
+      "videoId": "3H-b3qKf9NU",
+      "title": "[EN] 100년 역사의 프랑스 리옹 전통 레스토랑🥩 이색적이지만 아쉬움이 남았던 Aux Lyonnais에서의 식사",
+      "channelName": "비밀이야 bimirya",
+      "position": 35,
+      "url": "https://www.youtube.com/watch?v=3H-b3qKf9NU"
+    },
+    {
+      "videoId": "XVahpVb99Ac",
+      "title": "니스 해산물 맛집 원픽은 이 곳! 알 만한 사람들은 다 아는 Boccacio 🦐날 홍합, 날 조개로 주는 싱싱함 클라스..✨[EN]",
+      "channelName": "비밀이야 bimirya",
+      "position": 36,
+      "url": "https://www.youtube.com/watch?v=XVahpVb99Ac"
+    },
+    {
+      "videoId": "IDUozojLxog",
+      "title": "대게 되게 벌크업🦀 파리의 평범한 해산물 레스토랑 퀄리티ㅣ캐주얼하게 갈 수 있는 식당 추천ㅣhuguette, bistro de la mer",
+      "channelName": "비밀이야 bimirya",
+      "position": 37,
+      "url": "https://www.youtube.com/watch?v=IDUozojLxog"
+    },
+    {
+      "videoId": "7O5dGQYeSug",
+      "title": "별빛이 내린다..🌟별이 15개? 프랑스에서 가장 각광받고 있는 셰프의 3스타 레스토랑 [EN]ㅣAlléno Paris",
+      "channelName": "비밀이야 bimirya",
+      "position": 38,
+      "url": "https://www.youtube.com/watch?v=7O5dGQYeSug"
+    },
+    {
+      "videoId": "sSrSbgQMu5o",
+      "title": "샴페인의 왕이라고 소개한 메종 크룩의 와이너리, 직접 들어가 보여드립니다🍾[EN]ㅣMaison krug",
+      "channelName": "비밀이야 bimirya",
+      "position": 39,
+      "url": "https://www.youtube.com/watch?v=sSrSbgQMu5o"
+    },
+    {
+      "videoId": "SHVcjUBlRUw",
+      "title": "[EN] 파리에서 만난 매력적인 이국의 맛!🍜 현지보다 맛있는 쿠스쿠스와 쌀국수를 먹고 왔습니다!",
+      "channelName": "비밀이야 bimirya",
+      "position": 40,
+      "url": "https://www.youtube.com/watch?v=SHVcjUBlRUw"
+    },
+    {
+      "videoId": "coBnpOfw1t4",
+      "title": "쌀국수의 원조는 프랑스다?!🍜 파리에서 줄서서 먹는 쌀국수 맛집! (f. 귀국 전 시장 투어)",
+      "channelName": "비밀이야 bimirya",
+      "position": 41,
+      "url": "https://www.youtube.com/watch?v=coBnpOfw1t4"
+    },
+    {
+      "videoId": "WmKBpFDk1YQ",
+      "title": "많은 분들이 기다려 주신 베르사유 궁전 디너 공개합니다✨ 전세계 공통 '밤비'로 통하는 사슴고기? 🦌ㅣLe Grand Contrôle [EN]",
+      "channelName": "비밀이야 bimirya",
+      "position": 42,
+      "url": "https://www.youtube.com/watch?v=WmKBpFDk1YQ"
+    },
+    {
+      "videoId": "E8LBPjio53s",
+      "title": "세계에서 가장 아름다운 레스토랑으로 손꼽히는 곳✨ 화려함 끝판왕과 거장 셰프와의 만남[EN]ㅣLe Meurice Alain Ducasse",
+      "channelName": "비밀이야 bimirya",
+      "position": 43,
+      "url": "https://www.youtube.com/watch?v=E8LBPjio53s"
+    },
+    {
+      "videoId": "WSqVHx2iRNY",
+      "title": "전세계 5명 중 하나! 여성 3스타 셰프의 요리는? | Marsan by Helene Darroze",
+      "channelName": "비밀이야 bimirya",
+      "position": 44,
+      "url": "https://www.youtube.com/watch?v=WSqVHx2iRNY"
+    },
+    {
+      "videoId": "4J6RLbRSu64",
+      "title": "한국에 상륙하는 프랑스 유일 여성 3스타 셰프 레스토랑! 한국에서 무사히 성공할 수 있을까? [EN]ㅣLa dame de pic",
+      "channelName": "비밀이야 bimirya",
+      "position": 45,
+      "url": "https://www.youtube.com/watch?v=4J6RLbRSu64"
+    },
+    {
+      "videoId": "XehtVBQvDhM",
+      "title": "3만 원 대에 즐기는 프랑스 명장 요리? | Daniel et Denise",
+      "channelName": "비밀이야 bimirya",
+      "position": 46,
+      "url": "https://www.youtube.com/watch?v=XehtVBQvDhM"
+    },
+    {
+      "videoId": "vmGwRznz0Yo",
+      "title": "13가지 코스 요리가 나오는데 디저트가 가장 맛있다고?! 🍨🫢  [EN]ㅣBlanc",
+      "channelName": "비밀이야 bimirya",
+      "position": 47,
+      "url": "https://www.youtube.com/watch?v=vmGwRznz0Yo"
+    },
+    {
+      "videoId": "AxLRF-gZmSA",
+      "title": "센 강 유람선 중 유일하게 1스타를 받은 최고의 크루즈 레스토랑은? ⛴️🍷 [EN]ㅣDon Juan II",
+      "channelName": "비밀이야 bimirya",
+      "position": 48,
+      "url": "https://www.youtube.com/watch?v=AxLRF-gZmSA"
+    },
+    {
+      "videoId": "shmIpRm4PRE",
+      "title": "헤밍웨이가 해산물을 먹고 싶을 때면 갔던 파리 브라세리🦞[EN]ㅣLa closerie des lias",
+      "channelName": "비밀이야 bimirya",
+      "position": 49,
+      "url": "https://www.youtube.com/watch?v=shmIpRm4PRE"
+    },
+    {
+      "videoId": "aQWebvFbH-o",
+      "title": "프랑스 한식당은 한국의 맛을 잘 나타낼 수 있을까?[EN]ㅣSetopa",
+      "channelName": "비밀이야 bimirya",
+      "position": 50,
+      "url": "https://www.youtube.com/watch?v=aQWebvFbH-o"
+    },
+    {
+      "videoId": "tME5rlpprwI",
+      "title": "니스 실패없는 현지 식당 추천! 해산물이 질린다면 이곳으로 가세요ㅣLe Petit Palais&La Favola",
+      "channelName": "비밀이야 bimirya",
+      "position": 51,
+      "url": "https://www.youtube.com/watch?v=tME5rlpprwI"
+    },
+    {
+      "videoId": "OR4FNr-0I6c",
+      "title": "경비행기가 있는 미슐랭 투스타 에펠탑뷰 레스토랑! 프랑스식 김치의 충격적인 맛 [EN] ㅣL'Oiseau Blanc",
+      "channelName": "비밀이야 bimirya",
+      "position": 52,
+      "url": "https://www.youtube.com/watch?v=OR4FNr-0I6c"
+    },
+    {
+      "videoId": "nVbf6TY2KXc",
+      "title": "현시점 가장 핫한 샴페인🍾 살아있는 전설 Jacques Selosse의 철학, 비하인드 스토리 듣기",
+      "channelName": "비밀이야 bimirya",
+      "position": 53,
+      "url": "https://www.youtube.com/watch?v=nVbf6TY2KXc"
+    },
+    {
+      "videoId": "tifp9zuDE7k",
+      "title": "프랑스 전성기를 그대로 구현한 1박에 무려 450만원짜리 베르사유 궁전 호텔의 모습은? 프라이빗 투어까지 잊지 못할 하룻밤ㅣLe Grand Contrôle [EN]",
+      "channelName": "비밀이야 bimirya",
+      "position": 54,
+      "url": "https://www.youtube.com/watch?v=tifp9zuDE7k"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ docker-compose.override.yml
 # Python
 __pycache__/
 *.pyc
+
+# Local YouTube renewal state and run artifacts (durable copies live in S3)
+.claude/workspace/youtube/automation/


### PR DESCRIPTION
## Summary
Adds three reusable YouTube→Sunrei ingest scripts and refreshes the YouTube workspace data.

### Scripts
- **`extract_desc_locations.py`** — parse `[name]/주소:` blocks from video descriptions and geocode via the Places API **without needing transcripts** (비밀이야-style channels). Drove the 한국 playlist (191 videos → 169 spots) and the #2–#6 re-extraction.
- **`build_streetfood.py`** — map 스트리트 푸드 파이터 clips to each city's food market/district and geocode (the clips themselves carry no location info).
- **`merge_enrich.py`** — merge subagent-enriched descriptions back into `locations.json` keyed by `(videoId, name)`.

### Workspace data
- **#2 비밀이야 in 일본** re-extracted with the improved skill: rich transcript-based descriptions (3–6 sentence `context`) + 8 venue names corrected by hand (they lived only in titles/transcripts).
- **#3/#4/#5** description-based places prepped (curated, accurate); #3–#6 full re-extraction is pending a YouTube caption IP-block (transcripts not fetchable from this server right now — usually clears in hours).

## Notes
- Temp artifacts (`.priorskill` backups, `_enrich_*.json`, logs) excluded from the commit.
- The resulting Sunrei records live in production as **drafts** (via the admin API), not in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
